### PR TITLE
Cut the CHANGELOG section for 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-08-31
+
+First full release of 0.1.0. It is `v0.1.0-rc.2` plus the two entries below —
+everything the two release-candidate sections describe is in it, and those sections
+stay as the record of when each part arrived.
+
+Published as `ghcr.io/sageox/agent-base:0.1.0`, and this is the first release to take
+the floating tags a candidate is refused: `:latest` and `:0.1`. `:0` is not published
+at all — before 1.0.0 a minor bump may break you, so a major-only alias would promise
+a stability that does not exist. Pin the digest recorded on the GitHub Release in
+production; the tags are for humans.
+
+Still pre-1.0: configuration format and CLI flags may move between minor versions.
+
+The Helm chart is 0.9.0, unchanged since rc.2. Both entries below are code rather than
+templates — `jobs[].report.probe` is a key an older binary refuses under `.strict()`,
+and `announce: reported` is a value outside that binary's enum — so roll the image
+before setting either, and no chart bump is needed to render an agent that does.
+
 ### Added
 
 - **A job body can post into its report channel, read the answers back, and mint its


### PR DESCRIPTION
## Summary

Step 1 of the release process in [CONTRIBUTING.md](https://github.com/sageox/agent-toolkit/blob/main/CONTRIBUTING.md#releasing): `## [Unreleased]` becomes `## [0.1.0] - 2026-08-31`, with a fresh empty `## [Unreleased]` opened above it. Nothing else changes — the two entries that were unreleased (`jobs[].report.probe` and `announce: reported`) move under the new heading verbatim.

This has to merge before `v0.1.0` can be tagged: `release.yml` fails the release at "Require a CHANGELOG entry for this version" unless `## [0.1.0]` exists, and it quotes everything under that heading as the GitHub Release body.

The section opens with a preamble in the shape the two rc sections use, because a reader of those release notes has only them:

- **What it contains** — `v0.1.0-rc.2` plus the two entries below it. The rc sections stay put as the record of when each part arrived.
- **What it publishes** — `:0.1.0`, and as the first full release rather than a candidate it also takes `:latest` and `:0.1`. Not `:0`; `release.yml` withholds a major-only alias below 1.0.0 on purpose, and the notes say why rather than leaving its absence to be noticed.
- **What it needs** — the image, not just the chart: `probe` is a key an older binary refuses under `.strict()`, and `reported` is a value outside that binary's enum. The chart stays 0.9.0, and `deploy/helm/templates/` has no reference to either.

No code, chart, or version-file change is in this PR. `deploy/helm/Chart.yaml` still reads `appVersion: "0.0.0"` — that predates the rc releases and `imageRef` is what actually selects the image, so fixing it is a separate call, not a release blocker.

## Test Plan

```
pnpm typecheck   # clean
pnpm test        # 63 files, 1055 tests passed
```

`test/naming.test.ts` is the one that reads `CHANGELOG.md`; it passes.

Release-notes extraction simulated with the workflow's own awk, confirming the section ends at the `## [0.1.0-rc.2]` heading:

```
awk -v heading="## [0.1.0]" '
  index($0, heading) == 1 { inside = 1; next }
  inside && /^## / { exit }
  inside { print }
' CHANGELOG.md
```

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added, or N/A documented — N/A, this is the changelog itself
- [x] `pnpm typecheck && pnpm test` green
- [x] Deployment checks run if `deploy/` changed — N/A, `deploy/` untouched
- [x] CHANGELOG entry added if user-facing
- [x] Breaking change documented — none
- [x] Docs updated if behavior or configuration changed — no behavior change

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a05954-b9a6-7a21-95ba-fa77f0e5e57a

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790797368&installation_model_id=433550&pr_number=1&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F1&signature=8b95e0a68c82eda7701f99adb601ed3b68fe6df464cb195a4f5a3768d9c7b988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
