### PR TITLE
Refuse a job-only credential on a job that can be asked for

### DIFF
--- a/.agents/skills/agent-bringup/references/operations.md
+++ b/.agents/skills/agent-bringup/references/operations.md
@@ -57,6 +57,16 @@ Before enabling recurring work, define:
 Run the job once manually before scheduling it. Verify the destination and source-health
 report, then enable the schedule.
 
+**Decide where the job's credentials live, before you arm a trigger.** In `run.secrets` a
+credential is also a file in the gateway's container — unread there, but kept so by policy
+rather than by the kernel. In `run.jobSecrets` it reaches only the process a scheduled or
+webhook run is launched in, and that job **may not arm `trigger.onRequest`**: an on-request
+run executes inside the gateway, so "can be asked for in chat" and "absent from the process
+running the brain" are the same question with opposite answers. The manifest refuses that
+pair at load and names the ref. Choose deliberately — chat-triggerable, or kernel-separated
+and started only by a clock, a webhook, or `job run` at the host. The same work holding the
+same credential cannot be both, and no configuration makes it both.
+
 ## Publish deliberately
 
 Review the local identity bundle and selected artwork before registration. Publication may

--- a/.agents/skills/agent-bringup/references/operations.md
+++ b/.agents/skills/agent-bringup/references/operations.md
@@ -59,13 +59,13 @@ report, then enable the schedule.
 
 **Decide where the job's credentials live, before you arm a trigger.** In `run.secrets` a
 credential is also a file in the gateway's container — unread there, but kept so by policy
-rather than by the kernel. In `run.jobSecrets` it reaches only the process a scheduled or
-webhook run is launched in, and that job **may not arm `trigger.onRequest`**: an on-request
-run executes inside the gateway, so "can be asked for in chat" and "absent from the process
-running the brain" are the same question with opposite answers. The manifest refuses that
-pair at load and names the ref. Choose deliberately — chat-triggerable, or kernel-separated
-and started only by a clock, a webhook, or `job run` at the host. The same work holding the
-same credential cannot be both, and no configuration makes it both.
+rather than by the kernel. In `run.jobSecrets` it reaches only `sageox-agent job run`, the
+separate process every trigger but one enters through — a clock, a webhook, or an operator
+at the host — and that job **may not arm `trigger.onRequest`**: an on-request run executes
+inside the gateway, so "can be asked for in chat" and "absent from the process running the
+brain" are the same question with opposite answers. The manifest refuses that pair at load
+and names the ref. Choose deliberately: chat-triggerable, or kernel-separated. The same work
+holding the same credential cannot be both, and no configuration makes it both.
 
 ## Publish deliberately
 

--- a/.agents/skills/agent-bringup/references/operations.md
+++ b/.agents/skills/agent-bringup/references/operations.md
@@ -57,15 +57,15 @@ Before enabling recurring work, define:
 Run the job once manually before scheduling it. Verify the destination and source-health
 report, then enable the schedule.
 
-**Decide where the job's credentials live, before you arm a trigger.** In `run.secrets` a
-credential is also a file in the gateway's container — unread there, but kept so by policy
-rather than by the kernel. In `run.jobSecrets` it reaches only `sageox-agent job run`, the
-separate process every trigger but one enters through — a clock, a webhook, or an operator
-at the host — and that job **may not arm `trigger.onRequest`**: an on-request run executes
-inside the gateway, so "can be asked for in chat" and "absent from the process running the
-brain" are the same question with opposite answers. The manifest refuses that pair at load
-and names the ref. Choose deliberately: chat-triggerable, or kernel-separated. The same work
-holding the same credential cannot be both, and no configuration makes it both.
+**Decide where the job's credentials live, before you arm a trigger.** A credential in
+`run.secrets` is also within reach of the gateway's own process, the one that runs the
+brain — unread there, but kept so by policy rather than by absence. One in `run.jobSecrets`
+reaches only `sageox-agent job run`, the separate process every trigger but one enters
+through: a clock, a webhook, or an operator at the host. Such a job **may not arm
+`trigger.onRequest`**, and the manifest refuses that pair at load, naming the ref — an
+on-request run executes inside the gateway, so "can be asked for in chat" and "absent from
+the process running the brain" are the same question with opposite answers. Choose
+deliberately. The same work holding the same credential cannot be both.
 
 ## Publish deliberately
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A bundle can say which of a job's credentials the gateway's own process must not hold.**
+  `jobs[].run.jobSecrets` takes the same env-var-to-`secretRef` map `run.secrets` does and
+  resolves from the same directory list, so a one-directory deployment satisfies both. What
+  it adds is a load-time refusal: a job declaring one **may not arm `trigger.onRequest`**,
+  named ref and all. A target could already hand `job run` a second directory it does not
+  give the gateway — `--job-secrets`, which chart 0.9.0 mounts as `agents.<name>.jobSecrets`
+  — but nothing in the manifest recorded which ref lived there, so a job that was both
+  scheduled and on-request resolved it on every tick and was refused by name the first time
+  a person asked for it. `onRequest` is the only trigger the gateway serves; every other one
+  enters through `job run`, a separate process. The gateway still gains no credential to fix
+  it — the message names the three ways out instead: drop `onRequest`, keep the credential
+  in `secrets` and take the weaker guarantee knowingly, or give the credentialed work a job
+  of its own that nothing may ask for. A name declared in both maps is refused too, since
+  the envelope merges them. `run.jobSecrets` is also left out of the inventory `run` checks
+  before it opens a socket, which is what lets such an agent launch at all: a credential
+  that moved but stayed spelled `secrets` refuses the launch, not just the run. Nothing that
+  loads today stops loading — the key is new, and `run` was already `.strict()`.
+
 ## [0.1.0] - 2026-08-31
 
 First full release of 0.1.0. It is `v0.1.0-rc.2` plus the two entries below —

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -371,9 +371,9 @@ opinion about what a job may read.
 ### A credential only the job may hold
 
 `jobSecrets` is a second secret source, mounted by this agent's **CronJob** Pods alongside
-`secrets` and searched ahead of it when a job body resolves its `run.secrets`. It takes the
-same two shapes `secrets` does, and the chart creates a `SecretProviderClass` for each source
-that names a `provider`.
+`secrets` and searched ahead of it when a job body resolves a ref. It takes the same two
+shapes `secrets` does, and the chart creates a `SecretProviderClass` for each source that
+names a `provider`.
 
 ```yaml
 agents:
@@ -410,11 +410,18 @@ Two consequences worth knowing before you split a credential out:
 
 - **It reaches scheduled runs only.** A run started on request — from chat, or by hand —
   executes inside the gateway's own process, in the Deployment Pod, which is passed no second
-  directory. A body needing a `jobSecrets`-only ref fails there with `secretRef … did not
-  resolve`, by name and before it does any work. That is the boundary working, not a gap in
-  it: it is also what stops a prompt-injected turn reaching a write credential through a job
-  it may ask for. Give such a job a schedule and no `onRequest`, or keep the credential in
-  `secrets` and take the weaker guarantee knowingly.
+  directory. That is the boundary working, not a gap in it: it is also what stops a
+  prompt-injected turn reaching a write credential through a job it may ask for. So the
+  bundle has to name which refs moved — `run.jobSecrets` on the job — and a job declaring
+  one may not arm `trigger.onRequest`. Give such a job a schedule and no `onRequest`, keep
+  the credential in `secrets` and take the weaker guarantee knowingly, or give the
+  credentialed work a job of its own that nothing may ask for.
+
+  Naming them there is also what lets the Deployment start. `sageox-agent run` resolves every
+  `run.secrets` ref against its own mount before it opens a socket and refuses the launch on
+  one that does not, so a credential that moved here but stayed spelled `secrets` is a
+  crashlooping agent rather than a quietly weaker one. `run.jobSecrets` is left out of that
+  inventory.
 - **The render refuses `jobSecrets` on an agent with no schedule**, because no Pod would then
   mount it and the field would read as though it had moved a credential it had not.
 

--- a/deploy/helm/templates/validate.yaml
+++ b/deploy/helm/templates/validate.yaml
@@ -59,11 +59,14 @@ agent with no schedule mounts it nowhere. Refused rather than rendered: the whol
 the field is to move a credential off the Pod that runs the brain, and one set on an agent
 whose only Pod is the Deployment has moved nothing while reading as though it had.
 
-A schedule and not a job, because a schedule is what renders the Pod. A job declaring only
-`onRequest` renders no CronJob, and a run started that way executes inside the gateway's own
-process, in the Deployment Pod, with no second directory to search — so a ref that lives only
-here fails to resolve and the run fails by name. That is the boundary holding rather than a
-gap in it, and it is why the count here is of schedules.
+A schedule and not a job, because a schedule is what renders the Pod. A run started on
+request executes inside the gateway's own process, in the Deployment Pod, with no second
+directory to search, so a ref that lives only here cannot resolve there — which is why the
+count is of schedules and not of jobs.
+
+Which refs live only here is settled in the bundle: a job naming one in `run.jobSecrets` may
+not arm `trigger.onRequest`, and `loadManifest` refuses the pair. Not checkable here — an
+agent's values carry a job's slug, schedules and budget, and nothing about its credentials.
 */}}
 {{- if kindIs "map" $agent.jobSecrets -}}
 {{- $scheduled := 0 -}}

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -76,8 +76,8 @@ the fake trigger this declaration
 [deletes](design/2026-08-19-jobs-rfc.md#51-a-scheduleless-job-is-legal-here-and-it-is-not-in-the-fleet-today).
 
 A job body's environment is **declared, not inherited**: it is built from the same six-variable
-allowlist every spawned child gets, plus whatever `run.env`, `run.secrets`, and
-`run.passthrough` name ([the job body contract](job-contract.md#what-the-host-passes-in)).
+allowlist every spawned child gets, plus whatever `run.env`, `run.secrets`, `run.jobSecrets`,
+and `run.passthrough` name ([the job body contract](job-contract.md#what-the-host-passes-in)).
 A target therefore owes a job run the `secretRef` mounts, not a copy of the gateway's
 environment — and a job that needs the pod's cloud identity says so by name in
 `run.passthrough`, which is a grant a reviewer can read rather than an inheritance nobody
@@ -92,10 +92,11 @@ resolves the agent's own credentials as well, for the surface its status post is
 and the switch it is admitted past, and a target that swapped one mount for the other would
 answer a missing credential with a disarmed switch and a lost report rather than a refusal.
 A run started on request gets no such mount: it executes inside the gateway's own process,
-off the agent's own, so a ref that lives only in the scheduled mount fails to resolve there
-and the run fails by name. And a job run is not a second replica: it serves no surface and
-holds no cursor, so `Identity` above is untouched. The rest of the envelope is the
-runtime's rather than the target's — trigger
+off the agent's own, so a ref that lives only in the scheduled mount cannot resolve there.
+Which refs those are is the bundle's to say — `run.jobSecrets` — and a job naming one may not
+arm `trigger.onRequest`, so no target has to make that pairing work. And a job run is not a
+second replica: it serves no surface and holds no cursor, so `Identity` above is untouched.
+The rest of the envelope is the runtime's rather than the target's — trigger
 provenance, admission past a parked switch, the soft kill switch read from the agent's own
 memory, the budget's own bow-out, the run record, and the verdict artifact the job writes. A
 target supplies a clock, a process, a deadline, and durable state.

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -83,7 +83,11 @@ refuses when no job has armed that door — the tool is served for those jobs an
 so allowing it first writes a permission for something that will never exist. The reverse,
 a job that declares `trigger.onRequest` while the policy denies the tool, is a `doctor`
 failure: nothing could ask for it, and the agent reads as one that cannot run its own jobs
-rather than one not allowed to.
+rather than one not allowed to. A job that declares `run.jobSecrets` may not arm this door
+at all — a run started here executes in the gateway's own process, which is not given the
+directory such a ref lives in, so `loadManifest` refuses the pair and names the ref. That is
+the one credential decision that has to be made before the trigger: a job holding a
+credential the gateway must not hold is a job nothing can ask for.
 
 `memory add` and `mcp add` write these for you. Reach for this table only when editing a
 policy by hand — and `doctor` will tell you if you get it wrong.

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -87,7 +87,8 @@ rather than one not allowed to. A job that declares `run.jobSecrets` may not arm
 at all — a run started here executes in the gateway's own process, which is not given the
 directory such a ref lives in, so `loadManifest` refuses the pair and names the ref. That is
 the one credential decision that has to be made before the trigger: a job holding a
-credential the gateway must not hold is a job nothing can ask for.
+credential the gateway must not hold is a job no conversation can start. A clock, a webhook,
+and an operator running `sageox-agent job run` at the host all still can.
 
 `memory add` and `mcp add` write these for you. Reach for this table only when editing a
 policy by hand — and `doctor` will tell you if you get it wrong.

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -35,10 +35,21 @@ jobs:
       # Env var name -> secretRef. Resolved by the host, from /mnt/secrets-store or the
       # environment, and refused at startup if it does not resolve.
       secrets: { GH_TOKEN: GH_TOKEN, ANTHROPIC_API_KEY: ANTHROPIC_API_KEY }
+      # The same, for a credential the gateway's own process must not hold. Resolved
+      # identically; declaring one here refuses `trigger.onRequest` on this job.
+      jobSecrets: { GH_APP_PEM: GH_APP_PEM }
       # Ambient variables this body inherits, by name. For values the platform injects at
       # runtime — EKS IRSA below; GKE and Azure workload identity present the same way.
       passthrough: [AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_REGION]
 ```
+
+`jobSecrets` is a claim about where the value is mounted, not a second resolver — both maps
+resolve from the same directory list, and a deployment with one directory satisfies both.
+A target may hand `job run` a second one it does not give the gateway (`--job-secrets`; the
+Helm chart spells the mount `agents.<name>.jobSecrets`), and a ref living only there cannot
+resolve on the on-request path, which is the one that runs inside the gateway. Saying which
+refs moved is what lets that pairing be refused at load, by name, rather than on the run
+that meets it.
 
 A secret of the same name beats `env`, so a credential can never be silently downgraded to
 a hardcoded value; the `JOB_*` variables above beat everything, because a body that could

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -212,7 +212,13 @@ const call = async (name, args) =>
 
 const { threadRoot } = await call("post_message", { text: rollCall, mentions: roster });
 // … wait, on a schedule this body owns …
-const { replies } = await call("thread_read", { root: threadRoot });
+
+// `null` means the surface named no id, so there is no thread to read. Report that gate
+// `{executed: false}` rather than reading `null` or counting an empty roll call as a pass:
+// "nobody replied" and "this surface cannot tell you" are different findings.
+const replies = threadRoot
+  ? (await call("thread_read", { root: threadRoot })).replies
+  : null;
 ```
 
 **What it is bounded to.** `post_message` reaches the channel `report` names and there is no

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -195,9 +195,8 @@ function secretsDirFrom(argv: string[]): string | undefined {
  * its status post or its switch.
  *
  * A run started on request is served from the gateway, which passes no such directory, so a
- * ref that lives only in the job mount does not resolve there and the run fails by name. A
- * prompt-injected turn therefore cannot reach a job-only credential through a job it is
- * allowed to ask for.
+ * prompt-injected turn cannot reach a job-only credential through a job it is allowed to
+ * ask for. `run.jobSecrets` beside `trigger.onRequest` is refused at load for that reason.
  */
 function jobSecretDirs(argv: string[], secretsDir?: string): string | string[] | undefined {
   const named = flag(argv, "job-secrets");

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -326,6 +326,11 @@ export function declaredSecrets(manifest: AgentManifest, repos: RepoSpec[]): Dec
   // A job resolves its refs per run rather than at startup, so `run` and `doctor` are the
   // only places a missing one can be reported before the job is due. Left out here, the
   // first report is a crashed 3am tick in a channel.
+  //
+  // `run.secrets` and not `run.jobSecrets`: this is checked against the one directory the
+  // calling process was given, and a `jobSecrets` ref is the one a deployment keeps out of
+  // the gateway's. Listing it would refuse the launch of every agent that split a credential
+  // out. `job run` resolves it per run and fails by name.
   manifest.jobs.forEach((job, index) => {
     for (const [envVar, ref] of Object.entries(job.run.secrets)) {
       declared.push({

--- a/packages/cli/test/credentials.test.ts
+++ b/packages/cli/test/credentials.test.ts
@@ -321,6 +321,23 @@ describe("declared secretRefs", () => {
     );
   });
 
+  it("leaves out a ref the deployment keeps off this process's own directory", () => {
+    // Listed, it would refuse the launch of every agent that split a credential out — the
+    // arrangement `run.jobSecrets` exists to describe.
+    const split = loadManifest(`${FLEET}      jobSecrets: { GH_APP_PEM: DEMO_JOB_PEM }\n`);
+    const declared = declaredSecrets(split, parseReposConf(PRIVATE_REPO));
+
+    expect(declared.map((secret) => secret.name)).not.toContain("DEMO_JOB_PEM");
+    writeFileSync(join(secretsDir, "GITHUB_TOKEN"), "ghp_x");
+    for (const name of ["DEMO_NSEC", "DEMO_SLACK_BOT", "DEMO_SLACK_APP", "DEMO_AGE_IDENTITY"]) {
+      writeFileSync(join(secretsDir, name), "value");
+    }
+    writeFileSync(join(secretsDir, "DEMO_TRACKER_KEY"), "value");
+    writeFileSync(join(secretsDir, "DEMO_JOB_TOKEN"), "value");
+    // The PEM is absent from this directory and the launch still goes ahead.
+    expect(requireDeclaredSecrets(declared, { dir: secretsDir })).toEqual([]);
+  });
+
   it("names every missing ref at once, with where it is declared and how to get one", () => {
     const declared = declaredSecrets(loadManifest(FLEET), parseReposConf(PRIVATE_REPO));
     let message = "";

--- a/packages/core/src/job-host.ts
+++ b/packages/core/src/job-host.ts
@@ -993,9 +993,9 @@ export class JobHost {
    * 1. `passthroughEnv` — the six variables a process needs to run, plus the names this job
    *    declared in `passthrough`. Nothing else in `opts.env` reaches the body.
    * 2. `run.env` — plain configuration, from the bundle.
-   * 3. `run.secrets` — resolved refs. A secret wins over config of the same name, so a
-   *    credential can never be silently downgraded to a hardcoded value (`McpBroker` orders
-   *    them the same way, for the same reason).
+   * 3. `run.secrets` and `run.jobSecrets` — resolved refs. A secret wins over config of the
+   *    same name, so a credential can never be silently downgraded to a hardcoded value
+   *    (`McpBroker` orders them the same way, for the same reason).
    * 4. The `JOB_*` envelope, which is the host's and outranks all of it: a body that could
    *    redefine `JOB_VERDICT_PATH` could point this host at a file it wrote in advance. The
    *    `JOB_PARAM_*` values this run was given are part of that block, for the same reason,
@@ -1008,7 +1008,9 @@ export class JobHost {
     channel?: HostedMcp,
   ): NodeJS.ProcessEnv {
     const secrets: NodeJS.ProcessEnv = {};
-    for (const [envVar, ref] of Object.entries(job.run.secrets)) {
+    // Both maps, one loop: `jobSecrets` says which processes are given the directory a ref
+    // lives in, not how it is found. The manifest refuses a name declared in both.
+    for (const [envVar, ref] of Object.entries({ ...job.run.secrets, ...job.run.jobSecrets })) {
       const value = resolveSecret(ref, this.opts.secretOpts ?? {});
       // Refusing here names the missing ref. Handing the body a hole instead produces an
       // auth failure several minutes into unattended work, attributed to whatever it called.

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -800,6 +800,13 @@ const JobSchema = z
          */
         secrets: z.record(EnvVarName, SecretRef).default({}),
         /**
+         * The same map, for a credential the gateway's own process must not hold. Resolved
+         * exactly as `secrets` is — the split is a claim about where the value is mounted,
+         * not a second resolver, and a one-directory deployment satisfies both from it.
+         * Declaring one refuses `trigger.onRequest` on the same job.
+         */
+        jobSecrets: z.record(EnvVarName, SecretRef).default({}),
+        /**
          * Ambient variables this body inherits, by name. See `passthroughEnv`: a value the
          * platform injects at runtime cannot be written into `env`, so its name is written
          * here instead and the grant stays readable.
@@ -1072,6 +1079,43 @@ const ManifestSchema = z
       path: ["jobs"],
     },
   )
+  // A `jobSecrets` ref is one a deployment keeps out of the gateway's own secrets directory,
+  // and `onRequest` is the only trigger the gateway serves: every other one enters through
+  // `sageox-agent job run`, a separate process the target may hand a second directory. So a
+  // job arming both resolves that ref on every tick and cannot on the one path a person
+  // uses. Refused where the pairing is written, because nothing the run can see differs —
+  // only which process the deployment started it in.
+  .superRefine((m, ctx) => {
+    for (const job of m.jobs) {
+      const moved = Object.values(job.run.jobSecrets);
+      if (!moved.length || !job.trigger.onRequest) continue;
+      ctx.addIssue({
+        code: "custom",
+        message:
+          `job "${job.slug}" arms trigger.onRequest and declares ${moved.join(", ")} in ` +
+          "run.jobSecrets — an on-request run executes in the gateway's own process, which " +
+          "is not given that directory, so it would fail on that ref. Drop onRequest, move " +
+          "the ref to run.secrets and take the weaker guarantee knowingly, or give the " +
+          "credentialed work a job of its own that nothing may ask for",
+        path: ["jobs"],
+      });
+    }
+  })
+  // `envelope` merges the two maps, so a name in both would silently take whichever landed
+  // last — and which map a ref is in is what the rule above reads.
+  .superRefine((m, ctx) => {
+    for (const job of m.jobs) {
+      const both = Object.keys(job.run.jobSecrets).filter((name) => name in job.run.secrets);
+      if (!both.length) continue;
+      ctx.addIssue({
+        code: "custom",
+        message:
+          `job "${job.slug}" declares ${both.join(", ")} in both run.secrets and ` +
+          "run.jobSecrets — one variable comes from one place",
+        path: ["jobs"],
+      });
+    }
+  })
   // The soft switch is a value in the agent's memory, resolved through a brain it already
   // declares rather than a bespoke transport. With no brain there is nothing to read, so
   // the switch would silently be the fail-direction and nothing else.

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -321,6 +321,49 @@ describe("bounding", () => {
     expect(seen.GITHUB_TOKEN).toBe("github_pat_the_job_was_granted");
   });
 
+  it("resolves a jobSecrets ref out of the directory only this process was given", async () => {
+    const envelope = join(workDir, "envelope");
+    const jobSecretsDir = join(workDir, "job-secrets");
+    await mkdir(jobSecretsDir);
+    await writeFile(join(secretsDir, "GH_TOKEN"), "github_pat_the_agents_own");
+    await writeFile(join(jobSecretsDir, "GH_APP_PEM"), "-----BEGIN PRIVATE KEY-----\n");
+    // No `onRequest`: the manifest refuses that beside `jobSecrets`.
+    const declared = body(
+      `fs.writeFileSync(${JSON.stringify(envelope)},JSON.stringify(process.env));${PROVES}`,
+      { trigger: '{schedules: ["0 3 * * 0"]}' },
+    );
+    await new JobHost({
+      workDir,
+      env: { ...process.env, MARKER: marker },
+      secretOpts: { dir: [jobSecretsDir, secretsDir] },
+    }).tick({
+      ...declared,
+      run: {
+        ...declared.run,
+        secrets: { GITHUB_TOKEN: "GH_TOKEN" },
+        jobSecrets: { GH_APP_PEM: "GH_APP_PEM" },
+      },
+    });
+    const seen = JSON.parse(readFileSync(envelope, "utf8")) as Record<string, string>;
+
+    // Both, in one envelope: splitting a credential out never costs a job the agent's own,
+    // which is what its status post is signed with and its switch read with.
+    expect(seen.GITHUB_TOKEN).toBe("github_pat_the_agents_own");
+    expect(seen.GH_APP_PEM).toBe("-----BEGIN PRIVATE KEY-----");
+  });
+
+  it("names an unresolvable jobSecrets ref exactly as it names an unresolvable secret", async () => {
+    const declared = body(PROVES, { trigger: '{schedules: ["0 3 * * 0"]}' });
+    const run = await host().tick({
+      ...declared,
+      run: { ...declared.run, jobSecrets: { GH_APP_PEM: "NEVER_MOUNTED" } },
+    });
+
+    expect(run.outcome).toBe("crashed");
+    expect(run.reason).toContain("NEVER_MOUNTED");
+    expect(spawns()).toBe(0);
+  });
+
   it("cannot see an ambient variable it did not declare — cloud identity included", async () => {
     const envelope = join(workDir, "envelope");
     // This body writes no `MARKER`: the case below declares nothing but `AWS_ROLE_ARN`, and

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -589,14 +589,61 @@ describe("jobs", () => {
     ).toEqual({ GH_TOKEN: "GH_TOKEN" });
   });
 
-  it("defaults the three environment fields to empty, so a job declares its way out of nothing", () => {
+  it("defaults the four environment fields to empty, so a job declares its way out of nothing", () => {
     expect(loadManifest(withJob()).jobs[0].run).toEqual({
       command: "node",
       args: ["runner/src/sweep.ts"],
       env: {},
       secrets: {},
+      jobSecrets: {},
       passthrough: [],
     });
+  });
+
+  it("refuses a credential the gateway may not hold on a job a person may ask for", () => {
+    const both = withJob({
+      trigger: '{schedules: ["0 3 * * 0"], onRequest: true}',
+      run: "{command: node, jobSecrets: {GH_APP_PEM: GH_APP_PEM}}",
+    });
+    // Named, because "this job" would send an operator to read the whole `run` block.
+    expect(() => loadManifest(both)).toThrow(/GH_APP_PEM/);
+    expect(() => loadManifest(both)).toThrow(/trigger\.onRequest/);
+
+    // Every trigger but `onRequest` enters through `job run`, which takes the directory.
+    expect(
+      loadManifest(withJob({ run: "{command: node, jobSecrets: {GH_APP_PEM: GH_APP_PEM}}" }))
+        .jobs[0].run.jobSecrets,
+    ).toEqual({ GH_APP_PEM: "GH_APP_PEM" });
+    expect(() =>
+      loadManifest(
+        withJob({ trigger: "{webhook: true}", run: "{command: node, jobSecrets: {P: P}}" }),
+      ),
+    ).not.toThrow();
+    // And an on-request job whose refs are all in the directory every process gets is fine.
+    expect(() =>
+      loadManifest(
+        withJob({
+          trigger: '{schedules: ["0 3 * * 0"], onRequest: true}',
+          run: "{command: node, secrets: {GH_TOKEN: GH_TOKEN}}",
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("refuses one variable declared in both secret maps, which the envelope would merge", () => {
+    expect(() =>
+      loadManifest(
+        withJob({
+          run: "{command: node, secrets: {GH_TOKEN: GH_TOKEN}, jobSecrets: {GH_TOKEN: GH_APP_PEM}}",
+        }),
+      ),
+    ).toThrow(/both run\.secrets and run\.jobSecrets/);
+  });
+
+  it("holds a jobSecrets ref to the same grammar, since it names a file too", () => {
+    expect(() =>
+      loadManifest(withJob({ run: "{command: node, jobSecrets: {GH_APP_PEM: '../PEM'}}" })),
+    ).toThrow(/secretRef/);
   });
 
   it("is absent unless declared — an agent with no scheduled work is the default", () => {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a059c4-8331-7bdb-b1b3-d8887ba90465">Session</a>
<!-- /sageox:pr-header -->

Closes sageox/sageox-monorepo#3714.

## What was needed

`--job-secrets` lets a deployment hand `sageox-agent job run` a directory it does not give the gateway, so a credential only a job body needs is not a file in the process that runs an LLM over untrusted channel text. The Helm chart mounts it as `agents.<name>.jobSecrets`.

Nothing in the manifest recorded **which** ref lived there — and `onRequest` is the only trigger the gateway serves. So a job that was both scheduled and on-request resolved that ref on every tick and was refused by name the first time a person asked for it. The two paths differ in the deployment and in nothing the run can see, which makes it a run-time discovery of a deploy-time mistake.

## What this ships

`jobs[].run.jobSecrets` — the same env-var-to-`secretRef` map as `run.secrets`, resolved from the same directory list. A one-directory deployment satisfies both and nothing changes for it; the split is a claim about where the value is mounted, not a second resolver.

What it adds is a **load-time refusal**: a job declaring one may not arm `trigger.onRequest`. The message names the ref and the three ways out — drop `onRequest`, keep the credential in `secrets` and take the weaker guarantee knowingly, or give the credentialed work a job of its own that nothing may ask for. A name declared in both maps is refused too, since `envelope` merges them.

**The gateway gains no credential to achieve it**, which was the constraint the issue set. The field is also deliberately left out of the inventory `run` resolves before it opens a socket (`declaredSecrets`): that check is against the one directory the calling process was given, so listing it would refuse the launch of every agent that split a credential out — a crashlooping Deployment rather than the arrangement the field describes.

## On the three options in the issue

- *Mount `jobSecrets` on the Deployment too* — fails the issue's own second criterion.
- *Spawn an on-request run as a Job* — restores the property exactly, but needs a Kubernetes API client, RBAC, and a Pod per chat request, and does not exist under Compose or locally, where the same code runs.
- *Refuse at load* — taken. The blocker was that nothing could **make** that check: the manifest did not know a ref was job-only, and the chart cannot know either (an agent's values carry a job's slug, schedules and budget, never its refs). So the bundle now says it.

## Deliberately general

The rule keys on `trigger.onRequest`, which is a fact about this repository's own entry points, not about Kubernetes: `job-server.ts` calls `host.request` and nothing else, while `tick` and `webhook` are reachable only from `job run`, a separate process. A webhook-only job with `run.jobSecrets` stays legal. Kubernetes vocabulary is confined to `deploy/helm/`.

## Verification

- `pnpm test` — 63 files, 1061 tests, green. Six new: three in `manifest.test.ts` (the refusal names the ref; a name in both maps; the ref grammar), two in `job-host.test.ts` (a `jobSecrets` ref resolves out of the second directory alongside the agent's own; an unresolvable one is named), one in `credentials.test.ts` (a `jobSecrets` ref does not refuse a launch).
- `pnpm typecheck` — clean.
- `helm lint --strict` plus `jobs.sh`, `consume.sh`, `bundle.sh`, `networkpolicy.sh` — green. No chart template behaviour changed, so no chart version bump.

## Docs

Reference and contract docs: chart README, `validate.yaml`'s note, `docs/job-contract.md`, `docs/deployment-contract.md`, and a `CHANGELOG.md` entry under `[Unreleased]`.

And the two surfaces an agent reads *before* writing a job, because a refusal that names the ref at load is the right place to catch this and the wrong place to learn it:

- **`.agents/skills/agent-bringup/references/operations.md`** — beside "make scheduled work stoppable", where a trigger is defined, so the credential question gets answered before the trigger is armed.
- **`docs/guide/reference.md`** — in the `mcp__jobs__job_run` paragraph, which already answers "which jobs can be asked for in chat", alongside the other two ways that door is refused.

Both state the same choice: chat-triggerable and protected by policy, or kernel-separated and started only by a clock, a webhook, or `job run` at the host. Only the canonical `.agents/` copy is edited; `.claude/skills/agent-bringup` points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a059c4-8331-7bdb-b1b3-d8887ba90465

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790805885&installation_model_id=433550&pr_number=2&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F2&signature=c877816090629c323aadf94e749739e7798c9d6359a0014b46b508197463f555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for job-only credentials through `run.jobSecrets`.
  * Job secrets are resolved alongside regular secrets for scheduled jobs.
  * Added CLI and Helm configuration options for defining job-specific secrets.

* **Bug Fixes**
  * Missing job secrets now fail runs clearly without starting the job.
  * Prevented duplicate secret names and unsupported use with request-triggered jobs.

* **Documentation**
  * Updated deployment, job, CLI, Helm, operations, and changelog documentation with the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
