### PR TITLE
Let a probing job address its post, so the agents it names wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A probing job body can address its post, so the agents it names actually wake.**
+  `post_message` takes `mentions`, and the adapter renders them as its surface's addressing
+  primitive — a `p` tag on Buzz, `<@id>` on Slack. Without it a probe posted into a channel
+  and woke nobody: a `p` tag is Buzz's only wake trigger, a channel post deliberately
+  carries none, and so a roll call read back an empty thread and reported the entire fleet
+  silent — a failure indistinguishable from a total outage, on the one job whose output is
+  consumed as fleet liveness. Recipients are **ids the surface resolves** (`npub…` or hex,
+  a Slack member id) and never display names, which render and wake no one; the adapter
+  refuses a name rather than publish a message that looks addressed and is not. At most 64
+  per message, and being addressed reaches no further than `jobs[].report` already did. The
+  field is the probe's alone: a status post — this body's own `report`, and every non-probe
+  job's — still addresses nobody, and the brain's `post_message` has no such field.
+
 ## [0.1.0] - 2026-08-31
 
 First full release of 0.1.0. It is `v0.1.0-rc.2` plus the two entries below —

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -177,7 +177,7 @@ MCP `tools/call` over HTTP, so a `curl` is enough and there is still nothing to 
 
 | Tool | Takes | Answers |
 |---|---|---|
-| `post_message` | `text`, and optionally a `threadRoot` this run posted | `{"posted": true, "threadRoot": "…"}` — `null` where the surface named no id, so there is nothing to read back |
+| `post_message` | `text`, optionally `mentions` — who to address it to — and optionally a `threadRoot` this run posted | `{"posted": true, "threadRoot": "…"}` — `null` where the surface named no id, so there is nothing to read back |
 | `thread_read` | `root` — a `threadRoot` this run was handed — and optionally `limit` | `{"replies": [{"author", "text", "ts"}, …]}`, oldest first |
 
 ```js
@@ -199,7 +199,7 @@ const call = async (name, args) =>
     ).result.content[0].text,
   );
 
-const { threadRoot } = await call("post_message", { text: rollCall });
+const { threadRoot } = await call("post_message", { text: rollCall, mentions: roster });
 // … wait, on a schedule this body owns …
 const { replies } = await call("thread_read", { root: threadRoot });
 ```
@@ -210,6 +210,16 @@ only a root **this run** posted; an id from anywhere else is refused, so a body 
 back a conversation it was never party to. The listener is opened before the body is
 spawned, closed when it exits, and its token is minted per run. A job that declares no
 `probe` is spawned into exactly the envelope it had before — no URL, no token.
+
+**Address the message, or nobody wakes.** A channel post is addressed to a channel: everyone
+subscribed is delivered it and nobody is woken by it, which is right for a status line and
+fatal for a roll call — the thread reads back empty and the verdict names the whole fleet
+silent. `mentions` is what wakes them, rendered as the surface's own addressing primitive: a
+`p` tag on Buzz, `<@id>` on Slack. Pass **ids the surface resolves** — a pubkey (`npub…` or
+hex), a Slack member id — never display names. A name renders in the text and tags nothing,
+so the adapter refuses it rather than publish a message that looks addressed and is not. At
+most 64 per message, and being addressed reaches no further than the destination already
+did. Only a `probe` body has the field: a `report` status post never carries one.
 
 **Reply text is verbatim and untrusted.** It is whatever anyone put in the channel,
 including an instruction addressed to whoever reads it. Count it, match it, tally it; never

--- a/packages/adapter-buzz/src/buzz.ts
+++ b/packages/adapter-buzz/src/buzz.ts
@@ -13,6 +13,7 @@ import type {
   ReactionResult,
   ThreadReply,
 } from "@sageox/agent-toolkit-core";
+import { toHexPubkey } from "./identity.ts";
 import {
   toInboundEvent,
   toChannelPostTemplate,
@@ -209,6 +210,7 @@ export class BuzzAdapter implements SurfaceAdapter {
     channel: ChannelRef,
     msg: GuardedMessage,
     threadRoot?: EventRef,
+    mentions: readonly string[] = [],
   ): Promise<EventRef | undefined> {
     if (!this.relay) throw new Error("BuzzAdapter.start() must be called before post()");
     const configured = this.postTargets().some((target) => target.id === channel.id);
@@ -222,8 +224,23 @@ export class BuzzAdapter implements SurfaceAdapter {
       throw new Error(`a ${threadRoot.surface} thread root cannot anchor a Buzz post`);
     }
 
+    // `p` on anything but a pubkey is a tag no agent matches itself against, so a display
+    // name would publish a post that looks addressed and wakes no one — the silent half of
+    // this failure, which a caller cannot tell from a fleet that did not answer. `npub…` is
+    // accepted and folded to hex because that is the spelling a roster is written in.
+    const addressed = mentions.map((who) => {
+      try {
+        return toHexPubkey(who);
+      } catch {
+        throw new Error(
+          "a Buzz post is addressed by pubkey (npub… or 64-char hex), and one recipient " +
+            "is neither — a display name renders but wakes nobody",
+        );
+      }
+    });
+
     const signed = await this.opts.signer.signEvent(
-      toChannelPostTemplate(msg, channel.id, threadRoot?.nativeId),
+      toChannelPostTemplate(msg, channel.id, threadRoot?.nativeId, addressed),
     );
     await this.relay.publish(signed);
     // The id the signature already committed to, not something scraped back out of the

--- a/packages/adapter-buzz/src/normalize.ts
+++ b/packages/adapter-buzz/src/normalize.ts
@@ -172,23 +172,32 @@ export function toReplyTemplate(msg: GuardedMessage, inReplyTo: InboundEvent): E
 }
 
 /**
- * A new channel post, deliberately carrying no invented reply or mention context.
+ * A new channel post, carrying no invented reply context and no mention the caller did not
+ * ask for.
  *
- * `threadRoot` is the one piece of context it may carry, and only ever an id this adapter
- * handed back from a post of its own — never one read off an inbound message, which is
- * what `toReplyTemplate` is for. No mention tag either way: a headline and the detail
- * beneath it are addressed to a channel, not to a person.
+ * `threadRoot` is context this adapter handed back from a post of its own — never an id
+ * read off an inbound message, which is what `toReplyTemplate` is for. A headline and the
+ * detail beneath it are addressed to a channel and get no `p` tag, which is why a status
+ * post pings nobody.
+ *
+ * `mentions` is the exception, and it is the only way a post wakes anyone: a `p` tag is the
+ * wake trigger this relay convention has (`toInboundEvent` reads `mentionsMe` off exactly
+ * these), so a probe that must be answered addresses its roster and a status line still
+ * does not. The pubkeys are hex, already normalised by the caller — `p` on a name is a tag
+ * no agent matches itself against.
  */
 export function toChannelPostTemplate(
   msg: GuardedMessage,
   channelId: string,
   threadRoot?: string,
+  mentions: readonly string[] = [],
 ): EventTemplate {
   const tags: string[][] = [[BUZZ_DEFAULTS.channelTag, channelId]];
   // The root of its own thread, so root and parent coincide — the same single marked tag
   // `toReplyTemplate` uses, and the same flatness: detail sits one level under the
   // headline rather than nesting beneath whichever detail line came before it.
   if (threadRoot) tags.push([BUZZ_DEFAULTS.replyTag, threadRoot, "", "reply"]);
+  for (const pubkey of mentions) tags.push([BUZZ_DEFAULTS.mentionTag, pubkey]);
 
   return {
     kind: BUZZ_DEFAULTS.kind,

--- a/packages/adapter-buzz/test/buzz.test.ts
+++ b/packages/adapter-buzz/test/buzz.test.ts
@@ -217,13 +217,13 @@ describe("BuzzAdapter", () => {
   it("wakes the recipients a post names, and nobody else in the channel", async () => {
     const a = newAdapter({ channels: [{ id: "hive", reply: "private" }] });
     await a.start(() => {});
-    await settle();
 
     const channel = { surface: "buzz", id: "hive", isPublic: false } as const;
     const drone = getPublicKey(generateSecretKey());
     const forager = getPublicKey(generateSecretKey());
+    // No `settle` on either side: `publish` resolves on the relay's OK, which the fake
+    // sends after recording the event, so `published` is populated by the time this returns.
     await a.post(channel, { text: "roll call" }, undefined, [drone, nip19.npubEncode(forager)]);
-    await settle();
 
     // A `p` tag is the wake trigger, and the whole of it: every agent subscribed to `hive`
     // is delivered this event, and only the two named here normalize it to `mentionsMe`.
@@ -240,7 +240,6 @@ describe("BuzzAdapter", () => {
   it("refuses to address a post to a display name", async () => {
     const a = newAdapter({ channels: [{ id: "hive", reply: "private" }] });
     await a.start(() => {});
-    await settle();
 
     // The silent half of this failure: a name renders in the text and tags nothing, so the
     // post would go out looking addressed and wake nobody — which reads back as an empty

--- a/packages/adapter-buzz/test/buzz.test.ts
+++ b/packages/adapter-buzz/test/buzz.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { nip19 } from "nostr-tools";
 import { finalizeEvent, generateSecretKey, getPublicKey, verifyEvent } from "nostr-tools/pure";
 import { PlainKeySigner } from "nostr-tools/signer";
 import type { InboundEvent } from "@sageox/agent-toolkit-core";
 import { BuzzAdapter } from "../src/buzz.ts";
-import { BUZZ_DEFAULTS } from "../src/normalize.ts";
+import { BUZZ_DEFAULTS, toInboundEvent } from "../src/normalize.ts";
 import { FakeRelay } from "./fake-relay.ts";
 
 const agentSk = generateSecretKey();
@@ -210,6 +211,45 @@ describe("BuzzAdapter", () => {
       expect(detail.tags.some((tag) => tag[0] === "p")).toBe(false);
     }
     expect(first!.nativeId).not.toBe(root!.nativeId);
+    await a.stop();
+  });
+
+  it("wakes the recipients a post names, and nobody else in the channel", async () => {
+    const a = newAdapter({ channels: [{ id: "hive", reply: "private" }] });
+    await a.start(() => {});
+    await settle();
+
+    const channel = { surface: "buzz", id: "hive", isPublic: false } as const;
+    const drone = getPublicKey(generateSecretKey());
+    const forager = getPublicKey(generateSecretKey());
+    await a.post(channel, { text: "roll call" }, undefined, [drone, nip19.npubEncode(forager)]);
+    await settle();
+
+    // A `p` tag is the wake trigger, and the whole of it: every agent subscribed to `hive`
+    // is delivered this event, and only the two named here normalize it to `mentionsMe`.
+    const published = relay.published[0];
+    expect(verifyEvent(published)).toBe(true);
+    expect(published.tags).toContainEqual(["p", drone]);
+    // A roster is written in npubs as readily as in hex, and both are the same recipient.
+    expect(published.tags).toContainEqual(["p", forager]);
+    expect(toInboundEvent(published, { pubkey: drone }).mentionsMe).toBe(true);
+    expect(toInboundEvent(published, { pubkey: agentPk }).mentionsMe).toBe(false);
+    await a.stop();
+  });
+
+  it("refuses to address a post to a display name", async () => {
+    const a = newAdapter({ channels: [{ id: "hive", reply: "private" }] });
+    await a.start(() => {});
+    await settle();
+
+    // The silent half of this failure: a name renders in the text and tags nothing, so the
+    // post would go out looking addressed and wake nobody — which reads back as an empty
+    // thread and reports the whole fleet silent.
+    const channel = { surface: "buzz", id: "hive", isPublic: false } as const;
+    await expect(
+      a.post(channel, { text: "roll call" }, undefined, ["beekeeper"]),
+    ).rejects.toThrow(/addressed by pubkey/i);
+    expect(relay.published).toHaveLength(0);
     await a.stop();
   });
 

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -250,6 +250,7 @@ export class SlackAdapter implements SurfaceAdapter {
     channel: ChannelRef,
     msg: GuardedMessage,
     threadRoot?: EventRef,
+    mentions: readonly string[] = [],
   ): Promise<EventRef | undefined> {
     if (!this.started) throw new Error("SlackAdapter.start() must be called before post()");
     this.assertChannel(channel);
@@ -265,7 +266,7 @@ export class SlackAdapter implements SurfaceAdapter {
 
     const ts = await this.api.postMessage({
       channel: channel.id,
-      text: msg.text,
+      text: address(mentions) + msg.text,
       threadTs: root?.ts,
     });
     return ts ? { surface: SLACK_SURFACE, nativeId: slackEventId(channel.id, ts) } : undefined;
@@ -583,6 +584,39 @@ function slackReactionName(emoji: string): string {
 
 /** Slack emoji names are lowercase and punctuation-poor; a character never matches one. */
 const SLACK_EMOJI_NAME = /^[a-z0-9_+'-]+$/;
+
+/**
+ * A Slack member id: `U…` for a person, `W…` on an Enterprise Grid, `B…` for a bot.
+ *
+ * Anchored and closed over the alphabet Slack actually issues, which is what makes the
+ * mention below safe to build by concatenation: a value carrying `>` would otherwise close
+ * the `<@…>` it was put inside and let the rest of it read as markup — `<!channel>` among
+ * the things it could then be, which is the broadcast `assertMessage` refuses in `text` and
+ * which must not have a second way in. The bound is generous; Slack ids are 9–11 characters.
+ */
+const SLACK_MEMBER_ID = /^[UWB][A-Z0-9]{1,31}$/;
+
+/**
+ * The recipients, as the prefix that wakes them — Slack's addressing primitive is in the
+ * text, so this is the whole of it.
+ *
+ * Every id is checked rather than the ones that look suspect: a mention list reaches here
+ * from a job body, and "a display name renders and pings nobody" is exactly the silent
+ * failure the caller is trying to avoid. Empty is the ordinary case and adds nothing —
+ * a status post is addressed to the channel.
+ */
+function address(mentions: readonly string[]): string {
+  if (!mentions.length) return "";
+  for (const id of mentions) {
+    if (!SLACK_MEMBER_ID.test(id)) {
+      throw new Error(
+        "a Slack post is addressed by member id (U…, W… or B…), and one recipient is " +
+          "neither — a display name renders but wakes nobody",
+      );
+    }
+  }
+  return `${mentions.map((id) => `<@${id}>`).join(" ")} `;
+}
 
 /**
  * `already_reacted` — the one `reactions.add` failure that means the call succeeded.

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -220,6 +220,25 @@ describe("SlackAdapter", () => {
     expect(api.posts).toHaveLength(2);
   });
 
+  it("addresses a post to the members it names, and refuses anything that is not one", async () => {
+    const { instance, api } = adapter();
+    await instance.start(() => {});
+    const channel = { surface: "slack", id: "GENG", isPublic: false } as const;
+
+    await instance.post(channel, { text: "roll call" }, undefined, ["U0DRONE", "B0FORAGER"]);
+    expect(api.posts[0].text).toBe("<@U0DRONE> <@B0FORAGER> roll call");
+
+    // A display name renders and wakes nobody, which is the silent failure the recipients
+    // exist to avoid — and an id carrying markup would close the `<@…>` it sits inside and
+    // smuggle back the broadcast `text` is already screened for.
+    for (const who of ["beekeeper", "U0X><!channel><@U0Y"]) {
+      await expect(
+        instance.post(channel, { text: "roll call" }, undefined, [who]),
+      ).rejects.toThrow(/addressed by member id/i);
+    }
+    expect(api.posts).toHaveLength(1);
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1473,7 +1473,8 @@ function jobSwitches(manifest: AgentManifest): { slug: string; key: string }[] {
  * about which guard a status post clears.
  */
 function jobPoster(egress: SurfaceEgress): JobPoster {
-  return (to, text, threadRoot) => egress.post(to.surface, to.channel, { text }, threadRoot);
+  return (to, text, threadRoot, mentions) =>
+    egress.post(to.surface, to.channel, { text }, threadRoot, mentions);
 }
 
 /**

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -62,11 +62,26 @@ export interface SurfaceAdapter {
    * thread, which is why `GuardedMessage` stays as narrow as it is. `undefined` when the
    * surface reports no id — a caller reads that as "no thread root" and posts the next line
    * at top level rather than dropping it.
+   *
+   * `mentions` addresses the post to a named set, rendered as whatever this surface's
+   * addressing primitive is — a `p` tag on Buzz, `<@id>` on Slack. A channel post is
+   * otherwise addressed to a channel and nobody in it wakes, which is right for a status
+   * line and is the whole failure mode of a probe: a roll call nobody was addressed by
+   * reads back as an empty thread and reports every agent silent. Only the per-run job
+   * channel passes it, and only for a `report.probe` job; a status post never does.
+   *
+   * **Ids the surface resolves, never display names.** A name renders and wakes no one, so
+   * an adapter validates the shape it was handed and refuses rather than posting a message
+   * that looks addressed and is not. An adapter on a surface with **no** addressing
+   * primitive must throw on a non-empty list for the same reason {@link readThread} is
+   * absent rather than answering `[]` — silence a caller cannot distinguish from an answer
+   * is the bug both rules exist to prevent.
    */
   post?(
     channel: ChannelRef,
     msg: GuardedMessage,
     threadRoot?: EventRef,
+    mentions?: readonly string[],
   ): Promise<EventRef | undefined>;
 
   /**

--- a/packages/core/src/job-channel.ts
+++ b/packages/core/src/job-channel.ts
@@ -17,6 +17,17 @@ const THREAD_READ = "thread_read";
  */
 const MAX_REPLIES = 500;
 
+/**
+ * The most recipients one post may address.
+ *
+ * A roster is fleet configuration this toolkit has no view of, so the bound is on the size
+ * of one message rather than on who is in it — a body may address whom it likes, and cannot
+ * turn one `post_message` into a broadcast to everyone a surface knows. Well above any real
+ * fleet, and the same order as `MAX_REPLIES`: a roll call that addresses more agents than it
+ * can read replies from has already stopped being one message.
+ */
+const MAX_MENTIONS = 64;
+
 export interface JobChannelOptions {
   /** The one channel this run may speak into — the job's own declared destination. */
   report: NonNullable<JobConfig["report"]>;
@@ -42,7 +53,11 @@ export interface JobChannelOptions {
  * Bounded twice, and both bounds are here rather than in the body's good behaviour:
  *
  * - `post_message` carries text to the channel `jobs[].report` names. There is no field
- *   for a destination, so no value the body computes can choose one.
+ *   for a destination, so no value the body computes can choose one. It may *address* that
+ *   line to named recipients, which is what wakes them — a channel post wakes nobody, and a
+ *   roll call that woke nobody reads back as an empty thread and reports the fleet silent.
+ *   The recipients are ids the surface resolves, and the reach is still one channel: being
+ *   addressed does not put the message anywhere the destination did not already.
  * - `thread_read` reads only a root **this run** posted. The set is built from what this
  *   server handed back, so a body cannot name an id it read somewhere and pull back
  *   channel history it was never party to.
@@ -78,10 +93,15 @@ export function jobChannelHandler(opts: JobChannelOptions): McpHandler {
     // accountability question here — there is no destination argument to record, and the
     // message itself is one the guard has already ruled on. A refused call names the id
     // that was tried, which is the line worth having at 3am.
+    //
+    // `mentions` is deliberately **not** declared, and that is what records it usefully: an
+    // undeclared argument is written as its shape, so a list of recipients lands as
+    // `<array 12>`. The count is the number that answers "did this roll call address
+    // anybody", and it stays one bounded field however long the roster gets.
     audit: { [POST_MESSAGE]: ["threadRoot"], [THREAD_READ]: ["root", "limit"] },
     call: async (tool, args) => {
       if (tool === POST_MESSAGE) {
-        const { text, threadRoot } = PostArgs.parse(args);
+        const { text, threadRoot, mentions } = PostArgs.parse(args);
         if (threadRoot !== undefined && !rooted.has(threadRoot)) {
           throw new Error(unrooted(threadRoot));
         }
@@ -89,6 +109,7 @@ export function jobChannelHandler(opts: JobChannelOptions): McpHandler {
           report,
           text,
           threadRoot ? { surface: report.surface, nativeId: threadRoot } : undefined,
+          mentions,
         );
         // `null` where the surface named no id, so a body reads "posted, and there is no
         // thread to read back" rather than being handed something to pass to `thread_read`
@@ -129,6 +150,15 @@ function unrooted(id: string): string {
 const PostArgs = z.object({
   text: z.string().min(1),
   threadRoot: z.string().min(1).optional(),
+  /**
+   * Who this line is addressed to, by the ids the surface itself resolves.
+   *
+   * Unvalidated beyond its shape here, because what an id looks like is the surface's to
+   * know and this file must not learn it — the adapter refuses a display name, which is the
+   * one wrong value worth naming: a name renders, wakes nobody, and reads back as the empty
+   * thread this field exists to prevent.
+   */
+  mentions: z.array(z.string().min(1)).max(MAX_MENTIONS).optional(),
 });
 
 const ReadArgs = z.object({
@@ -154,6 +184,18 @@ function tools(report: NonNullable<JobConfig["report"]>): unknown[] {
             description:
               "Thread this line under a message this same run posted. Omitted, it posts " +
               "at top level.",
+          },
+          mentions: {
+            type: "array",
+            items: { type: "string" },
+            maxItems: MAX_MENTIONS,
+            description:
+              "Address this line to these recipients, so each of them is woken by it. " +
+              "**Surface ids** — a Buzz pubkey, a Slack user id — never display names: a " +
+              "name renders in the text and wakes nobody, and a probe that addressed only " +
+              "names reads back an empty thread and reports everyone silent. Omitted, the " +
+              "line is addressed to the channel and no one is woken, which is what a status " +
+              `line wants. At most ${MAX_MENTIONS}.`,
           },
         },
         required: ["text"],

--- a/packages/core/src/job-host.ts
+++ b/packages/core/src/job-host.ts
@@ -161,11 +161,16 @@ interface Started extends JobStart {
  * The returned ref is the whole point of the type. A headline answers with its own id, and
  * that id is what threads the detail underneath it. `undefined` means the surface reported
  * no id, and the caller posts the next line at top level rather than losing it.
+ *
+ * `mentions` addresses the post to a named set, by the surface's own ids. Nothing on the
+ * status path passes it — only the per-run job channel does, and only for a `report.probe`
+ * job. See `SurfaceAdapter.post` in `adapter.ts` for what a surface makes of it.
  */
 export type JobPoster = (
   report: NonNullable<JobConfig["report"]>,
   text: string,
   threadRoot?: EventRef,
+  mentions?: readonly string[],
 ) => Promise<EventRef | undefined>;
 
 /**

--- a/packages/core/src/surface-egress.ts
+++ b/packages/core/src/surface-egress.ts
@@ -255,12 +255,17 @@ export class SurfaceEgress {
    * A message with no inbound context: the brain's explicit post, and a job's
    * status post. `threadRoot` threads the second kind under its own headline — the brain
    * has no way to name one, since the tool takes a surface, a channel, and text.
+   *
+   * `mentions` is the same shape of argument and reaches here from the same one caller: a
+   * probing job's `post_message`, which is the only kind of post that has to wake somebody.
+   * The brain's tool cannot reach it either — `PostArgs` has no such field.
    */
   async post(
     surface: string,
     channelId: string,
     msg: GuardedMessage,
     threadRoot?: EventRef,
+    mentions?: readonly string[],
   ): Promise<EventRef | undefined> {
     const adapter = this.byKind.get(surface);
     if (!adapter?.post || !adapter.postTargets) {
@@ -290,10 +295,13 @@ export class SurfaceEgress {
       throw new Error(`post refused by ${verdict.rule}: ${verdict.reason}`);
     }
 
-    const ref = await adapter.post(channel, msg, threadRoot);
+    const ref = await adapter.post(channel, msg, threadRoot, mentions);
     // The resolved id, not what was asked for: the audit line has to say where the
-    // message went, and those are now two different strings.
-    console.info(`post_message surface=${surface} channel=${channel.id} result=sent`);
+    // message went, and those are now two different strings. The recipient *count* and not
+    // the ids: how many were addressed is what separates a roll call that found silence
+    // from one that woke nobody, and a list would grow this line with the fleet.
+    const addressed = mentions?.length ? ` mentions=${mentions.length}` : "";
+    console.info(`post_message surface=${surface} channel=${channel.id}${addressed} result=sent`);
     return ref;
   }
 

--- a/packages/core/test/job-channel.test.ts
+++ b/packages/core/test/job-channel.test.ts
@@ -45,10 +45,15 @@ const speaker = (id: string): ThreadReply["author"] => ({
 describe("the job channel", () => {
   /** Every line this channel carried, and the ref each one was answered with. */
   const feed = (over: Partial<JobChannelOptions> = {}) => {
-    const posts: Array<{ channel: string; text: string; threadRoot?: EventRef }> = [];
+    const posts: Array<{
+      channel: string;
+      text: string;
+      threadRoot?: EventRef;
+      mentions?: readonly string[];
+    }> = [];
     const reads: Array<{ root: EventRef; limit?: number }> = [];
-    const post: JobPoster = async (report, text, threadRoot) => {
-      posts.push({ channel: `${report.surface}:${report.channel}`, text, threadRoot });
+    const post: JobPoster = async (report, text, threadRoot, mentions) => {
+      posts.push({ channel: `${report.surface}:${report.channel}`, text, threadRoot, mentions });
       return { surface: "console", nativeId: `e${posts.length}` };
     };
     const read: JobReader = async (root, limit) => {
@@ -83,7 +88,29 @@ describe("the job channel", () => {
     expect(await call(handle, "post_message", { text: "roll call", channel: "somewhere" })).toEqual(
       { posted: true, threadRoot: "e1" },
     );
-    expect(posts).toEqual([{ channel: "console:hive", text: "roll call", threadRoot: undefined }]);
+    expect(posts).toEqual([
+      { channel: "console:hive", text: "roll call", threadRoot: undefined, mentions: undefined },
+    ]);
+  });
+
+  it("carries the recipients a probe addresses, and refuses more than it may name", async () => {
+    const { posts, handle } = feed();
+    const roster = ["drone", "forager"];
+
+    await call(handle, "post_message", { text: "roll call", mentions: roster });
+    // Straight through to the surface, which is what renders them as its own addressing
+    // primitive. Nothing here knows what an id looks like — the adapter refuses a name.
+    expect(posts[0].mentions).toEqual(roster);
+
+    // A body may address whom it likes, and cannot turn one line into a broadcast to
+    // everyone the surface knows.
+    await expect(
+      call(handle, "post_message", {
+        text: "roll call",
+        mentions: Array.from({ length: 65 }, (_, i) => `agent-${i}`),
+      }),
+    ).rejects.toThrow();
+    expect(posts).toHaveLength(1);
   });
 
   it("threads a later line under a root this run posted", async () => {

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -567,13 +567,13 @@ describe("the status post", () => {
     id: (n: number) => EventRef | undefined = named,
     announce: JobAnnounce = "unproven",
   ) => {
-    const posts: Array<{ text: string; threadRoot?: EventRef }> = [];
-    const post: JobPoster = async (report, text, threadRoot) => {
+    const posts: Array<{ text: string; threadRoot?: EventRef; mentions?: readonly string[] }> = [];
+    const post: JobPoster = async (report, text, threadRoot, mentions) => {
       // Recorded before it is checked. `announce()` catches whatever a line throws and
       // charges it to that line, so an expectation that fails in here is swallowed — and a
       // test whose whole assertion is that `posts` stayed empty would then pass because the
       // check broke rather than because nothing was posted.
-      posts.push({ text, threadRoot });
+      posts.push({ text, threadRoot, mentions });
       // Whole-object, so a field added to the destination has to be accounted for here
       // rather than reaching every poster unnoticed.
       expect(report).toEqual({ surface: "console", channel: "hive", announce, probe: false });
@@ -581,6 +581,16 @@ describe("the status post", () => {
     };
     return { posts, post };
   };
+
+  it("addresses nobody, headline and detail alike", async () => {
+    const { posts, post } = feed();
+    await host(undefined, post).tick(body(MIXED, REPORTS));
+
+    // A status line is a report, not a page. Only a probing body's own `post_message` may
+    // name recipients, and it reaches this poster by a different call than this one.
+    expect(posts).not.toHaveLength(0);
+    expect(posts.every((line) => line.mentions === undefined)).toBe(true);
+  });
 
   it("puts one line at top level and threads every gate beneath it", async () => {
     const { posts, post } = feed();

--- a/packages/core/test/surface-egress.test.ts
+++ b/packages/core/test/surface-egress.test.ts
@@ -14,15 +14,20 @@ import { ToolPolicy } from "../src/tool-policy.ts";
 const SERVE_BOTH = { postMessage: true, react: true };
 
 function adapter(kind: string, targets: ChannelRef[]) {
-  const posted: Array<{ channel: ChannelRef; msg: GuardedMessage; threadRoot?: EventRef }> = [];
+  const posted: Array<{
+    channel: ChannelRef;
+    msg: GuardedMessage;
+    threadRoot?: EventRef;
+    mentions?: readonly string[];
+  }> = [];
   const reactions: Array<{ target: string; emoji: string }> = [];
   const value: SurfaceAdapter = {
     kind,
     start: async () => {},
     send: async () => {},
     postTargets: () => targets,
-    post: async (channel, msg, threadRoot) => {
-      posted.push({ channel, msg, threadRoot });
+    post: async (channel, msg, threadRoot, mentions) => {
+      posted.push({ channel, msg, threadRoot, mentions });
       return { surface: kind, nativeId: `e${posted.length}` };
     },
     // The ref identifies the reaction, so one emoji on one message answers alike however
@@ -77,6 +82,7 @@ describe("SurfaceEgress", () => {
       {
         channel: { surface: "buzz", id: "hive", isPublic: false },
         msg: { text: "shipped" },
+        mentions: undefined,
       },
     ]);
     await expect(egress.post("buzz", "other", { text: "no" })).rejects.toThrow(
@@ -95,6 +101,25 @@ describe("SurfaceEgress", () => {
     // buys no way around the public-channel or allowlist rules.
     await egress.post("buzz", "hive", { text: "NOT PROVEN: jscpd did not execute" }, root);
     expect(buzz.posted[1].threadRoot).toEqual(root);
+  });
+
+  it("carries recipients to the surface, and never from the brain's own tool", async () => {
+    const buzz = adapter("buzz", [{ surface: "buzz", id: "hive", isPublic: false }]);
+    const egress = new SurfaceEgress({ manifest: manifest(), adapters: [buzz.value] });
+
+    await egress.post("buzz", "hive", { text: "roll call" }, undefined, ["drone", "forager"]);
+    expect(buzz.posted[0].mentions).toEqual(["drone", "forager"]);
+
+    // The brain's `post_message` has no such field, and a call that names one is dropped
+    // by the schema rather than reaching a surface: being addressed is a job's capability.
+    await surfaceEgressHandler(egress, new ToolPolicy([SURFACE_EGRESS_TOOL], []), SERVE_BOTH)({
+      method: "tools/call",
+      params: {
+        name: "post_message",
+        arguments: { surface: "buzz", channel: "hive", text: "hi", mentions: ["drone"] },
+      },
+    });
+    expect(buzz.posted[1].mentions).toBeUndefined();
   });
 
   it("applies the public-channel guard to cross-posts", async () => {


### PR DESCRIPTION
Closes sageox/sageox-monorepo#3747.

## What was needed

`post_message` on the per-run job channel could not address anyone, so a probe posted into its report channel and **woke nobody**. On Buzz a `p` tag is the only wake trigger (`events.ts`: *"The ONLY wake trigger"*), and `toChannelPostTemplate` deliberately carries none — correct for a status line, fatal for a roll call. Every agent's REQ delivered the event, each normalized it to `mentionsMe: false`, and the probe read back an empty thread and reported the whole fleet silent.

That verdict is consumed as fleet liveness, and because the roll call reports on itself there is no second detector to contradict it — so the failure was indistinguishable from a total outage.

## What this ships

`post_message` takes `mentions`, carried through `JobPoster` → `SurfaceEgress.post` → `SurfaceAdapter.post`, where each adapter renders it as its own addressing primitive:

| Surface | Primitive |
|---|---|
| Buzz | one `p` tag per recipient, beside the `h` and any `e` tag |
| Slack | `<@id>` prefixed to the text |

**Ids, never names.** Buzz accepts `npub…` or 64-char hex (reusing `toHexPubkey`, so a roster written either way works); Slack accepts a member id (`U…`, `W…`, `B…`). Anything else is refused rather than published — a display name renders and wakes no one, which is the silent half of this bug. Slack's id pattern is anchored and closed over the alphabet Slack issues, so an id cannot close the `<@…>` it sits in and smuggle back the `<!channel>` broadcast `assertMessage` already refuses in `text`.

**Scoped to the probe.** The status path calls the poster with three arguments, so a `report` post — this body's own and every non-probe job's — still addresses nobody, and the brain's `post_message` has no such field (its `PostArgs` is unchanged; a call that passes `mentions` has it dropped by the schema). Reach is unmoved: being addressed does not put the message anywhere `jobs[].report` did not already.

**Audit the count, not the list.** `mentions` is left *undeclared* in the job channel's audit map, which is exactly what records it usefully — `auditArgs` writes an undeclared argument as its shape, so a roster lands as `<array 12>`. `SurfaceEgress` adds `mentions=<n>` to its own `post_message …` line.

At most 64 recipients per message.

## The open question from the issue

The issue asks whether recipients should be bounded to a roster the host knows, and leans no. This implements no — a roll call's roster is fleet configuration the toolkit has no view of, and the caller is reviewed job code rather than a brain. The bound is on the size of one message instead, so a body cannot turn one `post_message` into a broadcast to everyone a surface knows.

## One gap worth naming

*"A surface with no addressing primitive refuses rather than silently posting an unaddressed message"* is a documented obligation on `SurfaceAdapter.post`, not a structural one. Both surfaces that implement `post` today address, and console has no `post` at all — so there is no adapter in the repo that could violate it and therefore no test that pins it. Making it structural needs a capability flag with no second implementation; happy to add one if you'd rather have the enforcement than the note.

## Verification

`pnpm typecheck` and `pnpm test` green (1061 tests). Tests added:

- `job-channel.test.ts` — recipients reach the poster; more than 64 is refused.
- `surface-egress.test.ts` — recipients reach the adapter; the brain's tool cannot set them.
- `buzz.test.ts` — a `p` tag per recipient, npub folded to hex, and `toInboundEvent` reads `mentionsMe: true` for those named and `false` for another channel member; a display name is refused and nothing is published.
- `slack.test.ts` — `<@U…> <@B…> ` prefix; a name and a markup-carrying id are both refused.
- `job-host.test.ts` — the status post, headline and detail alike, addresses nobody.

Confirmed failing without the fix: the two core tests fail on a stashed source tree (the adapter and status-post tests pin behaviour that the adapters could not previously express).

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a059cd-595b-73b1-aca7-05671aa986d3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790805941&installation_model_id=433550&pr_number=3&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F3&signature=7e0b17b793338118bbcbd02d397c75bc26cf28098e6b56860e04402a4aa4e832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Probe messages can now address up to 64 recipients using platform-specific recipient IDs.
  * Mentions render appropriately across supported messaging surfaces.
  * Invalid IDs and display names are rejected before sending.
  * Recipient mentions do not change the configured report channel.
  * Status updates and non-probe messages remain unaffected.

* **Documentation**
  * Updated the job messaging contract with mention syntax, validation rules, limits, and scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->