### PR TITLE
Escape the brain's text on Slack, so only `mentions` addresses anyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field is the probe's alone: a status post — this body's own `report`, and every non-probe
   job's — still addresses nobody, and the brain's `post_message` has no such field.
 
+### Fixed
+
+- **A Slack message says what the brain wrote, and addresses only whom `mentions` names.**
+  The adapter escapes `&`, `<` and `>` in the brain's text, so `<@U0ALICE>` renders as those
+  characters instead of notifying that member. Slack's addressing primitive is in-band —
+  `<@id>` written into the text *is* the mention — while every other surface addresses in a
+  field of its own, so `GuardedMessage`'s inability to represent a recipient was a claim the
+  Slack surface did not keep. Inbound text is already un-escaped for the brain and a mention
+  of a third party reaches it as live markup, which made quoting the message that woke the
+  agent enough to page whoever it named: through none of the id validation `mentions` gets,
+  and recorded on the audit line as `mentions=0`. The recipients the adapter builds from
+  `mentions` are still markup — the one part of an outbound message it constructs itself.
+  The bulk-mention refusal is unchanged: `<!channel>` is refused, not rendered.
+
 ## [0.1.0] - 2026-08-31
 
 First full release of 0.1.0. It is `v0.1.0-rc.2` plus the two entries below —

--- a/docs/guide/chat-surfaces.md
+++ b/docs/guide/chat-surfaces.md
@@ -480,7 +480,9 @@ not a guess worth making on your behalf.
 
 The requested message is posted top-level in the destination, and the agent's ordinary
 response confirms the result back in the conversation where the request originated.
-Unknown channels, unconsented public channels, and Slack bulk mentions are refused.
+Unknown channels, unconsented public channels, and Slack bulk mentions are refused. Slack
+mention markup written into the text is neither refused nor honoured: it renders as the
+characters the agent typed, so a cross-post notifies nobody it names.
 Cross-posts never reuse an unrelated message as a fake thread parent.
 
 ### Let the agent react with an emoji

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -224,9 +224,7 @@ export class SlackAdapter implements SurfaceAdapter {
     const target = inReplyTo ? contextOf(inReplyTo) : this.lastByChannel.get(channel.id);
     if (!target) throw new Error(`no inbound context for Slack channel ${channel.id}`);
 
-    // The message type cannot represent a broadcast. Reject Slack's native encodings as
-    // well, otherwise text such as <!channel> would smuggle one through that type boundary.
-    this.assertMessage(msg);
+    const text = this.outboundText(msg);
 
     // In a channel, threading the answer onto the question is what keeps the channel
     // readable. A 1:1 DM has nothing to keep tidy, and a threaded answer there hides
@@ -234,7 +232,7 @@ export class SlackAdapter implements SurfaceAdapter {
     // question asked inside a thread is still answered in that thread.
     const threadTs =
       target.threadTs ?? (this.dmChannels.has(channel.id) ? undefined : target.eventTs);
-    await this.api.postMessage({ channel: channel.id, text: msg.text, threadTs });
+    await this.api.postMessage({ channel: channel.id, text, threadTs });
   }
 
   postTargets(): ChannelRef[] {
@@ -254,7 +252,7 @@ export class SlackAdapter implements SurfaceAdapter {
   ): Promise<EventRef | undefined> {
     if (!this.started) throw new Error("SlackAdapter.start() must be called before post()");
     this.assertChannel(channel);
-    this.assertMessage(msg);
+    const text = this.outboundText(msg);
 
     // A Slack `ts` is unique only within a conversation, so an anchor from a different
     // channel names a real message somewhere else — and `thread_ts` pointing at one starts
@@ -266,7 +264,7 @@ export class SlackAdapter implements SurfaceAdapter {
 
     const ts = await this.api.postMessage({
       channel: channel.id,
-      text: address(mentions) + msg.text,
+      text: address(mentions) + text,
       threadTs: root?.ts,
     });
     return ts ? { surface: SLACK_SURFACE, nativeId: slackEventId(channel.id, ts) } : undefined;
@@ -453,10 +451,29 @@ export class SlackAdapter implements SurfaceAdapter {
     }
   }
 
-  private assertMessage(msg: GuardedMessage): void {
+  /**
+   * The brain's text, screened and then written as Slack's encoding of those same
+   * characters. Both outbound paths go through it, so neither can screen without encoding.
+   *
+   * A broadcast is refused rather than encoded. `GuardedMessage` cannot represent one, and
+   * `<!channel>` in text is the way back through that boundary; waking every member of the
+   * channel is worth failing the turn over rather than delivering as literal text.
+   *
+   * The rest is escaped, which is the half of `normalizeSlackText` that was missing. That
+   * function un-escapes `&lt;`, `&gt;` and `&amp;` on the way in, so the brain reads
+   * characters and never Slack's encoding — but with no encoder on the way out the round
+   * trip is not symmetric, and text that reached the brain carrying `<@U0ALICE>` went back
+   * out as live markup and notified that member. Quoting the message that woke the agent is
+   * ordinary and must not be an act of addressing. Addressing is `mentions`, whose ids
+   * {@link address} validates and whose count the `post_message` audit line carries.
+   *
+   * `&` is replaced first, or it escapes the ampersands the other two introduce.
+   */
+  private outboundText(msg: GuardedMessage): string {
     if (/<!\s*(?:channel|here|everyone)(?:\^[^>]*)?>/i.test(msg.text)) {
       throw new Error("Slack bulk mentions are not supported");
     }
+    return msg.text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
   }
 
 }
@@ -591,8 +608,10 @@ const SLACK_EMOJI_NAME = /^[a-z0-9_+'-]+$/;
  * Anchored and closed over the alphabet Slack actually issues, which is what makes the
  * mention below safe to build by concatenation: a value carrying `>` would otherwise close
  * the `<@…>` it was put inside and let the rest of it read as markup — `<!channel>` among
- * the things it could then be, which is the broadcast `assertMessage` refuses in `text` and
- * which must not have a second way in. The bound is generous; Slack ids are 9–11 characters.
+ * the things it could then be, which is the broadcast `outboundText` refuses in `text` and
+ * which must not have a second way in. This prefix is the one part of an outbound message
+ * the adapter builds itself, so it is the one part that is not escaped. The bound is
+ * generous; Slack ids are 9–11 characters.
  */
 const SLACK_MEMBER_ID = /^[UWB][A-Z0-9]{1,31}$/;
 

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -239,6 +239,25 @@ describe("SlackAdapter", () => {
     expect(api.posts).toHaveLength(1);
   });
 
+  it("renders the brain's own text literally, so only `mentions` addresses anyone", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    await instance.start((event) => got.push(event));
+    // Slack delivers a mention of a third party as live markup and `normalizeSlackText`
+    // hands it to the brain as those characters, so quoting the message that woke the agent
+    // is enough to page whoever it named — through none of the screening `mentions` gets.
+    socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE> & <@U0BOB>" }));
+
+    await instance.send(got[0].channel, { text: got[0].text }, got[0]);
+    expect(api.posts[0].text).toBe("ask &lt;@U0ALICE&gt; &amp; &lt;@U0BOB&gt;");
+
+    // The recipients the adapter builds from validated ids stay markup; the text beside
+    // them does not, so the two ways to address somebody have not become one again.
+    const channel = { surface: "slack", id: "GENG", isPublic: false } as const;
+    await instance.post(channel, { text: "who is <@U0ALICE>?" }, undefined, ["U0DRONE"]);
+    expect(api.posts[1].text).toBe("<@U0DRONE> who is &lt;@U0ALICE&gt;?");
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});

--- a/packages/core/src/guard.ts
+++ b/packages/core/src/guard.ts
@@ -60,7 +60,11 @@ export function strings(value: unknown): string[] {
  * through here, and every rule fails closed.
  *
  * Attachments and broadcasts need no rule here: `GuardedMessage` cannot represent
- * either, so the type refuses them structurally.
+ * either, so the type refuses them structurally. Where a surface encodes them in the
+ * message text instead of in a field of its own, keeping that refusal true is the
+ * adapter's job and not this function's: `SlackAdapter.outboundText` refuses `<!channel>`
+ * and escapes the rest, so `<@U0ALICE>` in text renders as those characters rather than
+ * notifying that member.
  */
 export function evaluateEgress(
   msg: GuardedMessage,


### PR DESCRIPTION
## Summary

Closes #4.

On Slack, addressing is **in-band**: `<@U0ALICE>` written into the message text *is* the mention. Every other surface addresses in a field of its own, so `GuardedMessage`'s inability to represent a recipient was a claim the Slack surface did not keep. `assertMessage` refused `<!channel>` and let a single mention straight through on both outbound paths.

The half that was missing is an **encoder**. `normalizeSlackText` already un-escapes `&lt;`, `&gt;` and `&amp;` on the way in, so the brain reads characters and never Slack's encoding — with nothing doing the reverse on the way out, the round trip was not symmetric. Slack delivers a mention of a third party as live markup, so **quoting the message that woke the agent was enough to page whoever it named**: through none of the id validation `mentions` gets, and recorded on the audit line as `mentions=0`.

`SlackAdapter.outboundText` screens and then encodes, and both `send` and `post` go through it, so neither path can do one without the other.

### The three questions #4 asked

1. **Refuse, strip, or escape? → Escape.** Not the least-bad of three compromises — the adapter had already made this call inbound, and this is the other half of it. Escaping is also the only one of the three that neither drops the turn over text the brain may have meant innocently nor changes what it said: the characters render exactly as written.
2. **Both paths, or only `post`? → Both.** Once it is an encoding rather than a policy the question answers itself: the decoder runs on both inbound paths, so the encoder runs on both outbound ones.
3. **Does the guard want to see it? → No.** Encoding is surface-specific and `evaluateEgress` is not. But `guard.ts`'s claim now names where the refusal is actually kept, so it can be checked against the adapter rather than taken on faith.

The `address(mentions)` prefix is built from validated ids and is the one part of an outbound message the adapter constructs itself, so it stays live markup. The bulk-mention refusal is unchanged: `<!channel>` is still refused, not rendered, and both existing tests still pin it.

### Follow-up filed, not fixed here

#5 — that refusal `throw`s from the adapter rather than feeding back through `GuardFeedback`, so a brain quoting a message containing `<!channel>` loses the whole turn. It predates this PR and changing it is its own decision.

## Test Plan

`packages/adapter-slack/test/slack.test.ts:242` walks the real round trip: an inbound message carrying `<@U0ALICE> & <@U0BOB>`, quoted back, asserted to leave as `&lt;@U0ALICE&gt; &amp; &lt;@U0BOB&gt;`. It also pins that a `post` keeps its `mentions` prefix live while escaping the text beside it, so the two ways to address somebody have not become one again.

Verified it fails without the change by reverting `slack.ts` alone:

```
Expected: "ask &lt;@U0ALICE&gt; &amp; &lt;@U0BOB&gt;"
Received: "ask <@U0ALICE> & <@U0BOB>"
 Test Files  1 failed | 2 passed (3)
```

Restored, full suite:

```
$ pnpm test
 Test Files  63 passed (63)
      Tests  1062 passed (1062)

$ pnpm typecheck
(clean)
```

No `deploy/` changes. CHANGELOG entry under `### Fixed`; `docs/guide/chat-surfaces.md` updated where it lists what a cross-post refuses.

---

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a05a68-8ba6-7eb1-bc1f-a6d96c7b79dc

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790815746&installation_model_id=433550&pr_number=6&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F6&signature=19dcf8fa8327cae83413f3c80fa4916124e7232c20be9e1f9164decebe9b74ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack message safety by escaping special HTML characters in outbound text.
  * Explicit recipient mentions continue to render correctly, while bulk mentions remain blocked.
  * Slack mention markup in cross-posted text is sent literally and does not notify named users.

* **Documentation**
  * Clarified Slack cross-posting behavior, channel restrictions, and mention handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->