### PR TITLE
Let a Slack agent read a thread back, and stop losing DMs sent while it was down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A DM sent to a Slack agent while it was down is answered when it comes back.**
+  The backfill walked the configured `channels` and nothing else, so it could never reach a
+  DM: a DM's conversation id does not exist until someone opens it, which is why no entry
+  names one, and the adapter's live set of them is empty until an event arrives. A DM in
+  that gap was therefore in neither set — nothing enumerated it, nothing replayed it, and
+  the resume cursor moved past it the moment any channel message was accepted. The message
+  was gone for good, and the person who sent it got silence from an agent that looked
+  healthy. `users.conversations` now supplies the open DMs at backfill time, which is what
+  `im:read` — already in the setup guide's scope list — is for. **Reading one is not
+  permission to speak in one:** a DM still earns a reply by having sent something, so a
+  conversation with nothing in the gap is enumerated and stays one the adapter may not post
+  into. A workspace that withholds `im:read` loses the DM backfill and keeps everything
+  else, rather than failing the launch over a scope a channel-only agent never needs.
+
 - **A Slack message says what the brain wrote, and addresses only whom `mentions` names.**
   The adapter escapes `&`, `<` and `>` in the brain's text, so `<@U0ALICE>` renders as those
   characters instead of notifying that member. Slack's addressing primitive is in-band —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A probing job can read its thread back on Slack, so a roll call there has an answer.**
+  `SlackAdapter.readThread` walks `conversations.replies` under a root the run posted and
+  hands back the replies oldest first. Only Buzz implemented the verb, so a probe on a
+  Slack-only agent posted its roll call, waited, and then died on *"the slack surface cannot
+  read a thread back"* — the fleet-liveness job, unable to run on one of the two surfaces
+  the toolkit ships. The endpoint was already in the adapter's API seam, used by backfill.
+  Replies are normalized through the same `toSlackInboundEvent` a turn is, so a join notice
+  or a hidden message is no more a reply than it is a turn, and the thread parent Slack
+  returns is dropped by `ts` — it is not in its own thread. Every failure throws and none
+  answers `[]`: an unstarted adapter, a root naming another surface, and a root in a
+  conversation this agent does not serve are all findings a probe must not read as silence.
+
 - **A probing job body can address its post, so the agents it names actually wake.**
   `post_message` takes `mentions`, and the adapter renders them as its surface's addressing
   primitive — a `p` tag on Buzz, `<@id>` on Slack. Without it a probe posted into a channel

--- a/docs/guide/chat-surfaces.md
+++ b/docs/guide/chat-surfaces.md
@@ -392,10 +392,11 @@ nobody, which is indistinguishable from a broken agent.
 Socket Mode does not replay missed events. On restart the adapter connects first and then
 pulls `conversations.history` from its saved cursor, deduplicating any overlap with live
 events. Because history returns thread parents but not their replies, it also pulls
-`conversations.replies` for every thread that moved during the gap. Two gaps remain: a
-reply under a parent older than the cursor stays missed — that parent is outside the
-history window, and Slack cannot enumerate the threads that moved in a period — and DMs
-are not backfilled at all, since the adapter has no list of them until they speak.
+`conversations.replies` for every thread that moved during the gap, and asks `im:read`
+which DMs are open so it can do the same for those. Two gaps remain: a reply under a parent
+older than the cursor stays missed — that parent is outside the history window, and Slack
+cannot enumerate the threads that moved in a period — and, without `im:read`, every DM,
+since the adapter then has no list of them until they speak.
 
 ### Publish its face on Slack
 

--- a/docs/guide/chat-surfaces.md
+++ b/docs/guide/chat-surfaces.md
@@ -341,6 +341,15 @@ its conversation ID appears only once someone opens it — so DMs need no entry,
 address: inside one the bot answers without being tagged. Drop `message.im` from the
 event subscriptions if you do not want that.
 
+That same "no entry names it" is why `im:read` matters on restart. Socket Mode has no
+replay, so a restarted agent refills the gap from `conversations.history` — and it can only
+call that for conversations it can name. Channels come from `channels`; DMs come from
+`im:read`, which is what lets it ask Slack which DMs it has open. Without the scope the
+channels still backfill and a DM sent while the agent was down is simply lost, which reads
+from the other side as an agent that ignored a question. Asking is not permission to speak:
+a DM still earns a reply by having sent something, so one with nothing in the gap is
+enumerated and left alone.
+
 The author gate is the second thing `surface slack` settles with you. You are one person
 with one id per surface, and an id is only ever matched against the surface it arrived
 from — so an agent that is `owner-only` with only an npub answers nobody on Slack. When

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -35,6 +35,8 @@ export interface SlackHistoryPage {
 export interface SlackApiClient {
   authTest(): Promise<{ userId?: string; botId?: string }>;
   channelIsPrivate(channel: string): Promise<boolean | undefined>;
+  /** Every DM conversation this bot has open — the ids no configuration could name. */
+  openDirectChannels(): Promise<string[]>;
   history(args: { channel: string; oldest: string; cursor?: string }): Promise<SlackHistoryPage>;
   replies(args: {
     channel: string;
@@ -453,7 +455,7 @@ export class SlackAdapter implements SurfaceAdapter {
    * moved in a period — only the replies of a thread you can already name.
    */
   private async backfill(oldest: number): Promise<void> {
-    for (const channel of this.allowedChannels) {
+    for (const channel of [...this.allowedChannels, ...(await this.directChannels())]) {
       const parents = await this.collect((cursor) =>
         this.api.history({ channel, oldest: String(oldest), cursor }),
       );
@@ -481,6 +483,33 @@ export class SlackAdapter implements SurfaceAdapter {
           channel_type: this.privateChannels.has(channel) ? "group" : "channel",
         });
       }
+    }
+  }
+
+  /**
+   * The DMs a backfill has to cover, which no configuration could have named.
+   *
+   * `channels` never holds a DM — its conversation id does not exist until someone opens
+   * it — and `dmChannels` is populated by `accept`, so at startup it is empty. Between
+   * them that left a DM sent while the agent was down in neither set: nothing enumerated
+   * it, nothing replayed it, and the cursor moved past it the moment any channel message
+   * was accepted. The message was gone, and a person who had asked something in a DM got
+   * silence back from an agent that looked healthy.
+   *
+   * **Read, never granted.** These ids are backfilled and nothing else. A DM still earns
+   * the right to be answered by having spoken, which `accept` is what records — so a
+   * conversation with nothing in the gap stays one this adapter may not post into, and
+   * enumerating open DMs cannot become a way to open one.
+   *
+   * A failed lookup costs the backfill, not the launch. Without `im:read` there is nothing
+   * to enumerate, and taking a working channel-only agent down over it would be refusing
+   * the wrong thing.
+   */
+  private async directChannels(): Promise<string[]> {
+    try {
+      return await this.api.openDirectChannels();
+    } catch {
+      return [];
     }
   }
 
@@ -569,6 +598,22 @@ export class WebSlackApi implements SlackApiClient {
 
   async channelIsPrivate(channel: string): Promise<boolean | undefined> {
     return privacyOf((await this.client.conversations.info({ channel })).channel);
+  }
+
+  /** `users.conversations` rather than `conversations.list`: the bot's own DMs, not the workspace's. */
+  async openDirectChannels(): Promise<string[]> {
+    const ids: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const response = await this.client.users.conversations({
+        types: "im",
+        exclude_archived: true,
+        ...(cursor ? { cursor } : {}),
+      });
+      for (const channel of response.channels ?? []) if (channel.id) ids.push(channel.id);
+      cursor = response.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+    return ids;
   }
 
   async history(args: { channel: string; oldest: string; cursor?: string }): Promise<SlackHistoryPage> {

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -8,6 +8,7 @@ import type {
   InboundEvent,
   ReactionResult,
   SurfaceAdapter,
+  ThreadReply,
 } from "@sageox/agent-toolkit-core";
 import {
   SLACK_SURFACE,
@@ -270,6 +271,54 @@ export class SlackAdapter implements SurfaceAdapter {
     return ts ? { surface: SLACK_SURFACE, nativeId: slackEventId(channel.id, ts) } : undefined;
   }
 
+  /**
+   * Replies beneath a thread root this adapter posted — one `conversations.replies` walk.
+   *
+   * Every way this can fail throws, and none of them answers `[]`. A probe mints a verdict
+   * from what comes back, so "nobody replied" has to stay distinguishable from "this read
+   * did not happen" — see {@link SurfaceAdapter.readThread}.
+   *
+   * `oldest: "0"` because a thread read is not a backfill: the caller wants everything
+   * under the root, not what arrived after some cursor. Slack returns the parent whatever
+   * `oldest` says, and the parent is not in its own thread — dropped by `ts` rather than by
+   * position, since a page boundary promises nothing about which message comes first.
+   *
+   * Normalized through `toSlackInboundEvent`, so a join notice or a hidden message is no
+   * more a reply here than it is a turn. One answer to "what counts as a message" rather
+   * than a second one that drifts.
+   */
+  async readThread(root: EventRef, limit?: number): Promise<readonly ThreadReply[]> {
+    if (!this.started) throw new Error("SlackAdapter.start() must be called before readThread()");
+    if (root.surface !== SLACK_SURFACE) {
+      throw new Error(`a ${root.surface} thread root names no Slack thread`);
+    }
+    const at = this.locate(root);
+    if (!at) {
+      throw new Error(
+        "a Slack thread root must name a message in a conversation this agent serves",
+      );
+    }
+
+    const messages = await this.collect((cursor) =>
+      this.api.replies({ channel: at.channel, ts: at.ts, oldest: "0", cursor }),
+    );
+
+    // Sorted on the Slack `ts` rather than the ISO string it becomes: `ts` carries
+    // microseconds and the ISO form is truncated to milliseconds, so two replies inside one
+    // millisecond would tie and come back in whatever order the pages happened to arrive.
+    const replies = messages
+      .filter((message) => message.ts !== at.ts)
+      .sort((a, b) => Number(a.ts ?? 0) - Number(b.ts ?? 0))
+      .flatMap((message) => {
+        const event = toSlackInboundEvent(
+          { ...message, type: message.type ?? "message", channel: at.channel },
+          this.normalizeOptions(),
+        );
+        return event ? [{ author: event.author, text: event.text, ts: event.ts }] : [];
+      });
+    return limit === undefined ? replies : replies.slice(0, limit);
+  }
+
   async react(target: InboundEvent, emoji: string): Promise<ReactionResult | undefined> {
     if (!this.started) return undefined;
     const at = this.locate(target.id);
@@ -367,12 +416,7 @@ export class SlackAdapter implements SurfaceAdapter {
     // app's `message.im` subscription is the switch; the guard still sees a DM as private.
     const direct = isDirectSlackChannel(message);
     if (!direct && !this.allowedChannels.has(message.channel)) return;
-    const normalized = toSlackInboundEvent(message, {
-      botUserId: this.botUserId!,
-      botId: this.botId,
-      privateChannels: this.privateChannels,
-      publicChannels: this.publicChannels,
-    });
+    const normalized = toSlackInboundEvent(message, this.normalizeOptions());
     if (!normalized) return;
 
     const key = normalized.id.nativeId;
@@ -384,6 +428,16 @@ export class SlackAdapter implements SurfaceAdapter {
     this.since = Math.max(this.since ?? 0, Number(message.ts));
     this.lastByChannel.set(normalized.channel.id, contextOf(normalized));
     this.onEvent?.(normalized);
+  }
+
+  /** What the privacy answers resolved at startup amount to. Only valid once `started`. */
+  private normalizeOptions() {
+    return {
+      botUserId: this.botUserId!,
+      botId: this.botId,
+      privateChannels: this.privateChannels,
+      publicChannels: this.publicChannels,
+    };
   }
 
   /**

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -31,12 +31,20 @@ export interface SlackHistoryPage {
   nextCursor?: string;
 }
 
+export interface SlackDirectPage {
+  ids?: string[];
+  nextCursor?: string;
+}
+
 /** Narrow API seam: production wraps WebClient and tests never touch the network. */
 export interface SlackApiClient {
   authTest(): Promise<{ userId?: string; botId?: string }>;
   channelIsPrivate(channel: string): Promise<boolean | undefined>;
-  /** Every DM conversation this bot has open — the ids no configuration could name. */
-  openDirectChannels(): Promise<string[]>;
+  /**
+   * One page of the DM conversations this bot has open — the ids no configuration names.
+   * Paged like `history` and `replies`, so the walk stays on the tested side of this seam.
+   */
+  openDirectChannels(cursor?: string): Promise<SlackDirectPage>;
   history(args: { channel: string; oldest: string; cursor?: string }): Promise<SlackHistoryPage>;
   replies(args: {
     channel: string;
@@ -506,11 +514,19 @@ export class SlackAdapter implements SurfaceAdapter {
    * the wrong thing.
    */
   private async directChannels(): Promise<string[]> {
+    const ids: string[] = [];
     try {
-      return await this.api.openDirectChannels();
+      let cursor: string | undefined;
+      do {
+        const page = await this.api.openDirectChannels(cursor);
+        ids.push(...(page.ids ?? []));
+        cursor = page.nextCursor || undefined;
+      } while (cursor);
     } catch {
-      return [];
+      // Whatever paged in before the failure is still worth refilling. Without `im:read`
+      // that is nothing, which is the case this catch is really here for.
     }
+    return ids;
   }
 
   /** Drains one cursor-paged endpoint. Slack pages backwards in time; the caller sorts. */
@@ -601,19 +617,16 @@ export class WebSlackApi implements SlackApiClient {
   }
 
   /** `users.conversations` rather than `conversations.list`: the bot's own DMs, not the workspace's. */
-  async openDirectChannels(): Promise<string[]> {
-    const ids: string[] = [];
-    let cursor: string | undefined;
-    do {
-      const response = await this.client.users.conversations({
-        types: "im",
-        exclude_archived: true,
-        ...(cursor ? { cursor } : {}),
-      });
-      for (const channel of response.channels ?? []) if (channel.id) ids.push(channel.id);
-      cursor = response.response_metadata?.next_cursor || undefined;
-    } while (cursor);
-    return ids;
+  async openDirectChannels(cursor?: string): Promise<SlackDirectPage> {
+    const response = await this.client.users.conversations({
+      types: "im",
+      exclude_archived: true,
+      ...(cursor ? { cursor } : {}),
+    });
+    return {
+      ids: response.channels?.flatMap((channel) => (channel.id ? [channel.id] : [])),
+      nextCursor: response.response_metadata?.next_cursor,
+    };
   }
 
   async history(args: { channel: string; oldest: string; cursor?: string }): Promise<SlackHistoryPage> {

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -532,6 +532,32 @@ describe("SlackAdapter", () => {
     ).rejects.toThrow(/DQUIET is not configured/);
   });
 
+  it("keeps the DMs it paged in when the lookup fails partway", async () => {
+    const { instance, api } = adapter({ since: 1786760000 });
+    api.dms = [{ ids: ["DALICE"], nextCursor: "page2" }];
+    const pages = api.openDirectChannels.bind(api);
+    // Page two never arrives. Discarding page one on that basis would drop a DM the agent
+    // was told about, and take the configured channels down with it.
+    api.openDirectChannels = async (cursor?: string) => {
+      if (!cursor) return pages(cursor);
+      api.dmCalls.push(cursor);
+      throw new Error("ratelimited");
+    };
+    api.histories.push(
+      { messages: [mention("1786761000.000100")] },
+      { messages: [{ type: "message", user: "U123", text: "ping", ts: "1786761000.000200" }] },
+    );
+    const got: InboundEvent[] = [];
+
+    await instance.start((event) => got.push(event));
+
+    expect(api.dmCalls).toEqual([undefined, "page2"]);
+    expect(got.map((event) => event.id.nativeId)).toEqual([
+      "GENG:1786761000.000100",
+      "DALICE:1786761000.000200",
+    ]);
+  });
+
   it("still backfills its channels when it may not ask which DMs are open", async () => {
     const { instance, api } = adapter({ since: 1786760000 });
     // No `im:read`. A channel-only agent must not be taken down by a scope it never needs.

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -220,6 +220,65 @@ describe("SlackAdapter", () => {
     expect(api.posts).toHaveLength(2);
   });
 
+  it("reads back the replies to a post of its own, oldest first and without the parent", async () => {
+    const { instance, api } = adapter();
+    await instance.start(() => {});
+    const channel = { surface: "slack", id: "GENG", isPublic: false } as const;
+    const root = await instance.post(channel, { text: "roll call" }, undefined, ["U0DRONE"]);
+
+    // Slack hands back the parent whatever `oldest` says, pages a long thread, and does not
+    // promise the order — and a join notice is no more a reply than it is a turn.
+    api.threads = [
+      {
+        messages: [
+          { type: "message", user: "UBOT", text: "roll call", ts: "1786761001.000200" },
+          { type: "message", user: "U0DRONE", text: "<@UBOT> awake", ts: "1786761003.000000" },
+        ],
+        nextCursor: "page2",
+      },
+      {
+        messages: [
+          { type: "message", subtype: "channel_join", user: "U0LATE", text: "", ts: "1786761004.000000" },
+          { type: "message", user: "U0FORAGER", text: "here", ts: "1786761002.000000" },
+        ],
+      },
+    ];
+
+    const replies = await instance.readThread!(root!);
+    expect(api.replyCalls).toEqual([
+      { channel: "GENG", ts: "1786761001.000200", oldest: "0", cursor: undefined },
+      { channel: "GENG", ts: "1786761001.000200", oldest: "0", cursor: "page2" },
+    ]);
+    expect(replies.map((reply) => [reply.author.id, reply.text])).toEqual([
+      ["U0FORAGER", "here"],
+      ["U0DRONE", "awake"],
+    ]);
+    expect(replies[0].ts).toBe(new Date(1786761002_000).toISOString());
+    // The bot's own reply is its own, so a tally can tell an answer from an echo.
+    expect(replies.map((reply) => reply.author.isSelf)).toEqual([false, false]);
+
+    api.threads = [{ messages: [{ type: "message", user: "U0A", text: "1", ts: "1786761005.000000" }] }];
+    expect(await instance.readThread!(root!, 0)).toEqual([]);
+  });
+
+  it("refuses a thread read it cannot answer, rather than reporting an empty thread", async () => {
+    const { instance } = adapter();
+    const root = { surface: "slack", nativeId: "GENG:1786761001.000200" } as const;
+
+    // Each of these would mint a verdict naming every agent silent if it answered `[]`.
+    await expect(instance.readThread!(root)).rejects.toThrow(/must be called before readThread/);
+    await instance.start(() => {});
+    await expect(
+      instance.readThread!({ surface: "buzz", nativeId: "abc" }),
+    ).rejects.toThrow(/buzz thread root names no Slack thread/);
+    await expect(
+      instance.readThread!({ surface: "slack", nativeId: "GOPS:1786761001.000200" }),
+    ).rejects.toThrow(/conversation this agent serves/);
+    await expect(
+      instance.readThread!({ surface: "slack", nativeId: "nonsense" }),
+    ).rejects.toThrow(/conversation this agent serves/);
+  });
+
   it("addresses a post to the members it names, and refuses anything that is not one", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -4,6 +4,7 @@ import {
   SlackAdapter,
   privacyOf,
   type SlackApiClient,
+  type SlackDirectPage,
   type SlackHistoryPage,
   type SlackSocketClient,
 } from "../src/slack.ts";
@@ -46,12 +47,14 @@ class FakeApi implements SlackApiClient {
   async authTest() {
     return { userId: "UBOT", botId: "BBOT" };
   }
-  openDms: string[] = [];
+  dms: SlackDirectPage[] = [];
+  dmCalls: Array<string | undefined> = [];
   async channelIsPrivate(channel: string) {
     return channel.startsWith("G");
   }
-  async openDirectChannels() {
-    return this.openDms;
+  async openDirectChannels(cursor?: string) {
+    this.dmCalls.push(cursor);
+    return this.dms.shift() ?? {};
   }
   async history(args: { channel: string; oldest: string; cursor?: string }) {
     this.historyCalls.push(args);
@@ -266,7 +269,7 @@ describe("SlackAdapter", () => {
   });
 
   it("refuses a thread read it cannot answer, rather than reporting an empty thread", async () => {
-    const { instance } = adapter();
+    const { instance, api } = adapter();
     const root = { surface: "slack", nativeId: "GENG:1786761001.000200" } as const;
 
     // Each of these would mint a verdict naming every agent silent if it answered `[]`.
@@ -281,6 +284,13 @@ describe("SlackAdapter", () => {
     await expect(
       instance.readThread!({ surface: "slack", nativeId: "nonsense" }),
     ).rejects.toThrow(/conversation this agent serves/);
+
+    // The one that would not announce itself: a root this adapter does serve, refused by
+    // Slack. Swallowing it into `[]` is how a probe comes to report a live fleet silent.
+    api.replies = async () => {
+      throw new Error("ratelimited");
+    };
+    await expect(instance.readThread!(root)).rejects.toThrow(/ratelimited/);
   });
 
   it("addresses a post to the members it names, and refuses anything that is not one", async () => {
@@ -494,7 +504,8 @@ describe("SlackAdapter", () => {
 
   it("backfills the DMs it has open, which no config could have named", async () => {
     const { instance, api } = adapter({ since: 1786760000 });
-    api.openDms = ["DALICE", "DQUIET"];
+    // Paged, so the cursor has to be carried back or the second DM is never enumerated.
+    api.dms = [{ ids: ["DALICE"], nextCursor: "page2" }, { ids: ["DQUIET"] }];
     api.histories.push(
       { messages: [] }, // GENG
       // A history result carries no `channel_type`; the `D` prefix is what says "DM" here.
@@ -505,6 +516,7 @@ describe("SlackAdapter", () => {
 
     await instance.start((event) => got.push(event));
 
+    expect(api.dmCalls).toEqual([undefined, "page2"]);
     expect(api.historyCalls.map((call) => call.channel)).toEqual(["GENG", "DALICE", "DQUIET"]);
     expect(got.map((event) => event.id.nativeId)).toEqual(["DALICE:1786761000.000100"]);
     // A DM is private and is itself a direct address, whichever door it came in through.

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -46,8 +46,12 @@ class FakeApi implements SlackApiClient {
   async authTest() {
     return { userId: "UBOT", botId: "BBOT" };
   }
+  openDms: string[] = [];
   async channelIsPrivate(channel: string) {
     return channel.startsWith("G");
+  }
+  async openDirectChannels() {
+    return this.openDms;
   }
   async history(args: { channel: string; oldest: string; cursor?: string }) {
     this.historyCalls.push(args);
@@ -486,6 +490,48 @@ describe("SlackAdapter", () => {
       "GENG:1786761000.000300",
       "GENG:1786761000.000400",
     ]);
+  });
+
+  it("backfills the DMs it has open, which no config could have named", async () => {
+    const { instance, api } = adapter({ since: 1786760000 });
+    api.openDms = ["DALICE", "DQUIET"];
+    api.histories.push(
+      { messages: [] }, // GENG
+      // A history result carries no `channel_type`; the `D` prefix is what says "DM" here.
+      { messages: [{ type: "message", user: "U123", text: "did the sweep finish?", ts: "1786761000.000100" }] },
+      { messages: [] }, // DQUIET — open, but nothing arrived while the agent was away
+    );
+    const got: InboundEvent[] = [];
+
+    await instance.start((event) => got.push(event));
+
+    expect(api.historyCalls.map((call) => call.channel)).toEqual(["GENG", "DALICE", "DQUIET"]);
+    expect(got.map((event) => event.id.nativeId)).toEqual(["DALICE:1786761000.000100"]);
+    // A DM is private and is itself a direct address, whichever door it came in through.
+    expect(got[0].channel.isPublic).toBe(false);
+    expect(got[0].mentionsMe).toBe(true);
+
+    // Reading a DM is not permission to speak in one. DALICE spoke in the gap and may be
+    // answered; DQUIET was only ever enumerated, so it is still a conversation this
+    // adapter must not open.
+    await instance.send({ surface: "slack", id: "DALICE", isPublic: false }, { text: "yes" });
+    await expect(
+      instance.send({ surface: "slack", id: "DQUIET", isPublic: false }, { text: "hello" }),
+    ).rejects.toThrow(/DQUIET is not configured/);
+  });
+
+  it("still backfills its channels when it may not ask which DMs are open", async () => {
+    const { instance, api } = adapter({ since: 1786760000 });
+    // No `im:read`. A channel-only agent must not be taken down by a scope it never needs.
+    api.openDirectChannels = async () => {
+      throw new Error("missing_scope");
+    };
+    api.histories.push({ messages: [mention("1786761000.000100")] });
+    const got: InboundEvent[] = [];
+
+    await instance.start((event) => got.push(event));
+
+    expect(got.map((event) => event.id.nativeId)).toEqual(["GENG:1786761000.000100"]);
   });
 
   it("asks for replies only in threads that moved after the cursor", async () => {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a05ecd-d383-7403-ab89-dd6fff06ad50">Session</a>
<!-- /sageox:pr-header -->

Two gaps found by reading `packages/adapter-slack/` against `SurfaceAdapter`. Both are
things the toolkit promises elsewhere and Slack did not keep. **Two commits, and they are
separable** — say so and I will split them, per the one-change-per-PR rule.

## 1. A probe can read its thread back on Slack (`readThread`)

`SurfaceAdapter.readThread` had exactly one implementation, Buzz's. So a probing job on a
Slack-only agent posted its roll call, waited, and then died on `SurfaceEgress`'s honest
refusal — *"the slack surface cannot read a thread back"*. The fleet-liveness job could not
run on one of the two surfaces this toolkit ships.

`conversations.replies` was already in `SlackApiClient`; backfill walks it to recover
threaded mentions. This asks the same endpoint a different question — `oldest: "0"`,
because a thread read wants the whole thread rather than what arrived after a cursor.

Three details the contract forces:

- **The parent is dropped by `ts`, not by position.** Slack returns it whatever `oldest`
  says and it is not in its own thread; a page boundary promises nothing about which
  message comes first.
- **Sorted on the Slack `ts`, not the ISO string it becomes.** `ts` carries microseconds
  and the ISO form is truncated to milliseconds, so two replies inside one millisecond
  would tie and come back in page-arrival order.
- **Every failure throws and none answers `[]`.** An unstarted adapter, a root naming
  another surface, and a root in a conversation this agent does not serve are all findings
  a probe must not read as silence.

Replies normalize through the same `toSlackInboundEvent` a turn does, so a join notice is
no more a reply here than it is a turn. That call site is now shared with `accept` instead
of a second copy of the privacy options.

## 2. A DM sent while the agent was down is no longer lost

The quieter bug, and the one with a person on the other end.

The backfill walked `allowedChannels` and nothing else. A DM can never be in that set — its
conversation id does not exist until someone opens it, which is the whole reason DMs need
no config entry — and `dmChannels`, the live set `accept` builds, is empty at startup.

So a DM sent while the agent was down was in **neither** set. Nothing enumerated it,
nothing replayed it, and `since` advanced past it the moment any channel message was
accepted. The message was gone for good. From the sender's side that is an agent that read
the question and ignored it: silence indistinguishable from health.

`users.conversations` now answers which DMs the bot has open at backfill time, under
`im:read` — a scope [the setup guide](docs/guide/chat-surfaces.md) already tells you to
install. `users.conversations` rather than `conversations.list`: the bot's own DMs, not the
workspace's.

**Reading a DM is not permission to speak in one.** The enumerated ids go to the backfill
loop and never touch `dmChannels`, so a DM still earns the right to be answered by having
sent something — `accept` records that, unchanged. A DM with nothing in the gap is
enumerated and stays a conversation this adapter must not open. There is a test asserting
exactly that: `DQUIET` is backfilled, and a `send` to it is still refused.

A failed lookup costs the backfill, not the launch — a workspace withholding `im:read`
keeps its channel backfill rather than failing to start over a scope a channel-only agent
never needs.

## Verification

`pnpm typecheck` and `pnpm test` green — 1072 tests across 63 files.

Each of the four new tests was checked to fail without its change:

| Test | Fails without |
|---|---|
| reads back the replies to a post of its own, oldest first and without the parent | `readThread` |
| refuses a thread read it cannot answer, rather than reporting an empty thread | `readThread` |
| backfills the DMs it has open, which no config could have named | the DM enumeration |
| still backfills its channels when it may not ask which DMs are open | the `catch` around it |

## Not in this PR

`setTyping` is still absent on Slack while `README.md:86` advertises typing indicators for
"Buzz and Slack". Slack has no bot typing API — only `assistant.threads.setStatus`, which
is AI-app-only — so the honest fix is to scope the README claim to Buzz rather than build
an adapter method that cannot work for most installs. Left out deliberately; happy to take
it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a05ecd-d383-7403-ab89-dd6fff06ad50

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790890537&installation_model_id=433550&pr_number=7&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F7&signature=4ce083e488fc65ec8508042d71c21882ce991b57534b81d911f5438ef5d7acc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack thread reading with chronological replies, pagination, and optional result limits.
  * Added recovery of missed direct-message conversations after adapter restarts.
  * Preserved channel recovery when direct-message access is unavailable.
* **Documentation**
  * Documented direct-message backfill behavior, permissions, and recovery limitations.
* **Bug Fixes**
  * Improved reply normalization and excluded thread parent messages and join notices from results.
  * Continued recovery when direct-message discovery encounters permission limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->