### PR TITLE
Let the person asking run a parked job, since the switch parks automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,11 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `allowlist`, and `respondTo`. The kind comes from that author's own `isAgent` and is not a
   field of the call, so `on-request` remains a trigger rather than an authorization — a
   sibling agent asking is automation and a parked job still refuses it, as it does when two
-  channels are mid-turn at once and no one person can be named. Either way the record now
-  names whoever asked, rather than the agent itself. The bypass answers only whether the
-  run starts: every gate governing what it may do is untouched, and it writes nothing, so a
-  parked job is still parked afterwards and the run carries `bypassedSwitch: true` for
-  whoever reads the record at 3am. Worst on a job with no schedule at all, where the switch
+  channels are mid-turn at once and no one person can be named. The record names that author
+  whichever kind it is — a sibling agent by its own id rather than by this agent's name — and
+  falls back to the brain only where there is no one turn to read it from. The bypass answers
+  only whether the run starts: every gate governing what it may do is untouched, and it
+  writes nothing, so a parked job is still parked afterwards and the run carries
+  `bypassedSwitch: true` for whoever reads the record at 3am. Worst on a job with no schedule at all, where the switch
   parked no clock and its only effect was to refuse the request it exists to permit; the
   workaround it replaces is arming a posture switch for one run and remembering to disarm it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,13 +61,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ever classified as one. A `tools/call` carries this server's bearer token and the tool
   arguments and nothing at all about the turn that produced it, so the author is read off the
   gateway instead: the same live-turn registry the reaction tool reads to mark "the message
-  you are answering", holding an author the manifest already admitted through `owner`,
-  `allowlist`, and `respondTo`. The kind comes from that author's own `isAgent` and is not a
-  field of the call, so `on-request` remains a trigger rather than an authorization — a
-  sibling agent asking is automation and a parked job still refuses it, as it does when two
-  channels are mid-turn at once and no one person can be named. The record names that author
-  whichever kind it is — a sibling agent by its own id rather than by this agent's name — and
-  falls back to the brain only where there is no one turn to read it from. The bypass answers
+  you are answering". **A person is an author the manifest names in `owner`**, not one whose
+  `isAgent` flag is false — only a surface can tell an agent from a person, and Buzz cannot
+  yet: `toActorRef` flags this agent's own pubkey and nobody else's, because recognising a
+  sibling needs a roster the relay does not serve, so a bypass keyed on that flag would reach
+  every sibling in a fleet. Everyone else is automation for the purpose of the switch,
+  including an allowlisted colleague — an allowlist says who may speak to this agent, and a
+  fleet's names siblings — and so is a call arriving while two channels are mid-turn at once,
+  where no one person can be named. `on-request` remains a trigger rather than an
+  authorization. The record names the turn's author whichever kind it is, rather than this
+  agent's name, and falls back to the brain only where there is no one turn to read it from. The bypass answers
   only whether the run starts: every gate governing what it may do is untouched, and it
   writes nothing, so a parked job is still parked afterwards and the run carries
   `bypassedSwitch: true` for whoever reads the record at 3am. Worst on a job with no schedule at all, where the switch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A job a person asks for runs, even when its kill switch is parked.** `job_run` records
+  the author of the message the agent is answering, so a request that arrives through a chat
+  surface is the human on-request run the host has always described — it has refused with
+  *"only a human's on-request run bypasses a parked job"* since jobs shipped, and nothing was
+  ever classified as one. A `tools/call` carries this server's bearer token and the tool
+  arguments and nothing at all about the turn that produced it, so the author is read off the
+  gateway instead: the same live-turn registry the reaction tool reads to mark "the message
+  you are answering", holding an author the manifest already admitted through `owner`,
+  `allowlist`, and `respondTo`. The kind comes from that author's own `isAgent` and is not a
+  field of the call, so `on-request` remains a trigger rather than an authorization — a
+  sibling agent asking is automation and a parked job still refuses it, as it does when two
+  channels are mid-turn at once and no one person can be named. Either way the record now
+  names whoever asked, rather than the agent itself. The bypass answers only whether the
+  run starts: every gate governing what it may do is untouched, and it writes nothing, so a
+  parked job is still parked afterwards and the run carries `bypassedSwitch: true` for
+  whoever reads the record at 3am. Worst on a job with no schedule at all, where the switch
+  parked no clock and its only effect was to refuse the request it exists to permit; the
+  workaround it replaces is arming a posture switch for one run and remembering to disarm it.
+
 - **A Slack message says what the brain wrote, and addresses only whom `mentions` names.**
   The adapter escapes `&`, `<` and `>` in the brain's text, so `<@U0ALICE>` renders as those
   characters instead of notifying that member. Slack's addressing primitive is in-band —

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -67,12 +67,16 @@ So is the job surface, under `jobs`: `mcp__jobs__job_run`, which lets a conversa
 start one of the agent's own jobs. Only jobs that declare `trigger.onRequest` are offered,
 the slug is the whole of what the tool takes for a job that declares no `parameters` — the
 argv is always `run.command` and `run.args` from `agent.yaml`, and nothing in the call
-reaches it — and a run asked for this way is recorded as `agent`, so it does **not** bypass
-a job that is parked or `suspend: true`. A job that declares `parameters` also takes those,
-under `params`, typed and bounded by its own declaration and refused at the call if they do
-not match; they reach the body as `JOB_PARAM_<NAME>` in its environment. They name a
-**target** — which issue, which document, which environment — and never a behaviour: a job
-whose work a caller can switch is two jobs with two slugs. See
+reaches it — and a run asked for this way is recorded against the author of the message the
+agent is answering, whom the gateway resolves and the tool cannot name. So a person's request
+**does** run a job that is parked or `suspend: true`: they are waiting on the result, which
+is not the unattended work a kill switch parks, and the posture is unchanged afterwards. When
+the author is another agent, or when two channels are mid-turn at once and no one person can
+be named, the run is recorded as `agent` and a parked job refuses. A job that declares
+`parameters` also takes those, under `params`, typed and bounded by its own declaration and
+refused at the call if they do not match; they reach the body as `JOB_PARAM_<NAME>` in its
+environment. They name a **target** — which issue, which document, which environment — and
+never a behaviour: a job whose work a caller can switch is two jobs with two slugs. See
 [the job body contract](../job-contract.md). A job short enough to finish inside a turn is
 waited for and the tool answers with its verdict; a job whose `wallClockMs +
 deadlineHeadroomMs` is longer than `limits.turnTimeoutMs` is **started** instead, and the

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -68,11 +68,15 @@ start one of the agent's own jobs. Only jobs that declare `trigger.onRequest` ar
 the slug is the whole of what the tool takes for a job that declares no `parameters` — the
 argv is always `run.command` and `run.args` from `agent.yaml`, and nothing in the call
 reaches it — and a run asked for this way is recorded against the author of the message the
-agent is answering, whom the gateway resolves and the tool cannot name. So a person's request
-**does** run a job that is parked or `suspend: true`: they are waiting on the result, which
-is not the unattended work a kill switch parks, and the posture is unchanged afterwards. When
-the author is another agent, or when two channels are mid-turn at once and no one person can
-be named, the run is recorded as `agent` and a parked job refuses. A job that declares
+agent is answering, whom the gateway resolves and the tool cannot name. A request from
+someone the manifest names in `owner` **does** run a job that is parked or `suspend: true`:
+they are waiting on the result, which is not the unattended work a kill switch parks, and the
+posture is unchanged afterwards. Every other author is recorded as `agent` and a parked job
+refuses — an allowlisted colleague, a sibling agent, and a call arriving while two channels
+are mid-turn at once, where no one person can be named. `owner` is the test rather than the
+author's agent flag because only a surface can tell an agent from a person, and Buzz cannot
+yet: it flags this agent's own key and nobody else's, so there a bypass keyed on that flag
+would reach every sibling in a fleet. A job that declares
 `parameters` also takes those, under `params`, typed and bounded by its own declaration and
 refused at the call if they do not match; they reach the body as `JOB_PARAM_<NAME>` in its
 environment. They name a **target** — which issue, which document, which environment — and

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -381,6 +381,12 @@ async function buildBrain(
         turnTimeoutMs: manifest.limits.turnTimeoutMs,
         host: jobs,
         agentName: manifest.name,
+        // Who the run record says asked. A `tools/call` carries nothing about the turn that
+        // produced it, and the gateway is what knows — the same live turn the reaction tool
+        // marks. Without it every request is automation, including the ones a person is
+        // waiting on, and a parked job could only be run by arming the switch and
+        // remembering to disarm it.
+        asking: egress && (() => egress.asking()),
       },
       serveAt,
     );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -387,6 +387,10 @@ async function buildBrain(
         // waiting on, and a parked job could only be run by arming the switch and
         // remembering to disarm it.
         asking: egress && (() => egress.asking()),
+        // Who that author has to be for the run to count as a person's. `owner` and not
+        // `respondTo`: an allowlist says who may speak to this agent, and a fleet's names
+        // siblings.
+        owner: manifest.owner ?? [],
       },
       serveAt,
     );

--- a/packages/core/src/job-server.ts
+++ b/packages/core/src/job-server.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ActorRef } from "./events.ts";
 import type { JobRequester } from "./kill-switch.ts";
 import {
   describeJobRun,
@@ -66,11 +67,19 @@ export interface JobToolOptions {
   /** Shared with nothing else in this process, so single-flight per slug actually holds. */
   host: JobHost;
   /**
-   * This agent's name, which is the whole of the requester this surface can honestly
-   * report. Taken as a name rather than a {@link JobRequester} on purpose: a caller that
-   * could pass the kind could pass `human`, and that is the one claim nothing here may make.
+   * This agent's name, which is the requester when no one turn can be named — see
+   * {@link requester}.
    */
   agentName: string;
+  /**
+   * Who this agent is answering, or `null` when the gateway cannot name one person.
+   *
+   * An {@link ActorRef} the gateway resolved from an inbound event, never a
+   * {@link JobRequester}: a caller that could pass the kind could pass `human`, and the kind
+   * is what decides whether a parked job runs. It is derived here from `isAgent`, which only
+   * the surface that received the message sets.
+   */
+  asking?: () => ActorRef | null;
   /**
    * `limits.turnTimeoutMs` — the clock this tool's answer has to fit inside, and the whole
    * of what picks between {@link describeRun} and {@link describeStart}. Both numbers are
@@ -81,25 +90,28 @@ export interface JobToolOptions {
 }
 
 /**
- * Who the run record says asked, and why it is never `human`.
+ * Who the run record says asked: the author of the turn this call is inside.
  *
- * A hosted MCP server is process-level: `tools/call` arrives carrying this server's bearer
- * token and the tool arguments, and nothing at all about the turn that produced it. The
- * inbound author the manifest already classifies through `owner`, `allowlist`, and
- * `respondTo` is therefore unreadable from in here, and inventing a per-request author is a
- * change to the whole tool surface rather than to this one tool.
+ * A hosted MCP server is process-level — `tools/call` arrives carrying this server's bearer
+ * token and the tool arguments, and nothing at all about the turn that produced it — so the
+ * author is not on the call and is read off the gateway instead. That is the same
+ * live-turn registry the reaction tool reads to put a glyph on "the message you are
+ * answering", and it is the author the manifest already admitted through `owner`,
+ * `allowlist`, and `respondTo`.
  *
- * What *is* readable is what actually called: this agent's own brain, mid-turn. So that is
- * what gets recorded. Reporting it as the human in the channel would be the run naming its
- * own provenance, which is exactly what §6.3 forbids and what the host's three separate
- * entry points exist to prevent.
+ * The kind comes from the author's own `isAgent`, set by the surface that received the
+ * message. Nothing said inside the turn reaches it, so this is still not the run naming its
+ * own provenance: `on-request` remains a trigger rather than an authorization, and a sibling
+ * agent asking is automation exactly as a clock tick is.
  *
- * The consequence is deliberate and it is the safe direction: this tool does not bypass a
- * parked job. `on-request` is a trigger, not an authorization — an agent asking is
- * automation, and automation is what a kill switch parks.
+ * With no turn to name — none live, or two channels mid-turn at once, which names nobody —
+ * the requester is this agent's brain. That is what is left that is true, and it is the safe
+ * direction: it does not bypass a parked job.
  */
-function requester(agentName: string): JobRequester {
-  return { kind: "agent", id: agentName };
+function requester(agentName: string, asking: JobToolOptions["asking"]): JobRequester {
+  const author = asking?.() ?? null;
+  if (!author) return { kind: "agent", id: agentName };
+  return { kind: author.isAgent ? "agent" : "human", id: author.id };
 }
 
 const JobArgs = z.object({
@@ -194,9 +206,10 @@ function tools(jobs: readonly JobConfig[], turnTimeoutMs: number): unknown[] {
         "that proved nothing did not pass. A job whose budget is longer than a turn is " +
         "started rather than waited for, and the answer says only that it is running and " +
         "where its result will be posted: there is no verdict in it, so say it is running " +
-        "and report the result when it lands. A parked job refuses: a run asked for " +
-        "through a tool is automation, and only a human running the job directly bypasses " +
-        "that. A job listed below with params takes a target — which issue, which document, " +
+        "and report the result when it lands. A parked job runs when the person you are " +
+        "answering is the one who asked, because they are waiting on the result; it refuses " +
+        "when another agent is asking, and nothing in this call lets you claim otherwise. " +
+        "A job listed below with params takes a target — which issue, which document, " +
         "which environment — under `params`. No parameter changes what a job does: if the ask " +
         "is for different behaviour, it is a different job and a different slug.\n" +
         `Jobs this agent will run on request: ${
@@ -254,7 +267,7 @@ function tools(jobs: readonly JobConfig[], turnTimeoutMs: number): unknown[] {
  * difference between an attempt somebody can find at 3am and one that never happened.
  */
 export function jobHandler(opts: JobToolOptions): McpHandler {
-  const { jobs, policy, host, agentName, turnTimeoutMs } = opts;
+  const { jobs, policy, host, agentName, asking, turnTimeoutMs } = opts;
   return mcpToolServer({
     name: JOB_SERVER,
     tools: () => tools(jobs, turnTimeoutMs),
@@ -289,10 +302,10 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
       // could disagree with either number. A job that fits inside a turn is waited for and
       // quoted; one that cannot is started, and answers where it declared it would.
       if (jobDeadlineMs(job) > turnTimeoutMs) {
-        const start = await host.startRequest(job, requester(agentName), params);
+        const start = await host.startRequest(job, requester(agentName, asking), params);
         return start.refused ? describeRun(start.refused) : describeStart(job, start);
       }
-      return describeRun(await host.request(job, requester(agentName), params));
+      return describeRun(await host.request(job, requester(agentName, asking), params));
     },
   });
 }
@@ -303,10 +316,10 @@ function describeRun(run: JobRun): string {
   return (
     describeJobRun(run) +
     // Named here rather than left to the reason line, because the brain is about to
-    // explain the refusal to whoever asked, and "you have to do it yourself" is the
-    // part of it they can act on.
+    // explain the refusal to whoever asked, and which side of the bypass this run fell on
+    // is the part of it they can act on.
     (parked
-      ? "  a run asked for through this tool is `agent`, not a human, so it does not " +
+      ? "  this run counted as automation rather than a person's request, so it did not " +
         "bypass a parked job\n"
       : "")
   );

--- a/packages/core/src/job-server.ts
+++ b/packages/core/src/job-server.ts
@@ -76,10 +76,11 @@ export interface JobToolOptions {
    *
    * An {@link ActorRef} the gateway resolved from an inbound event, never a
    * {@link JobRequester}: a caller that could pass the kind could pass `human`, and the kind
-   * is what decides whether a parked job runs. It is derived here from `isAgent`, which only
-   * the surface that received the message sets.
+   * is what decides whether a parked job runs.
    */
   asking?: () => ActorRef | null;
+  /** `manifest.owner`, normalized. The whole of what {@link requester} calls a person. */
+  owner?: readonly string[];
   /**
    * `limits.turnTimeoutMs` — the clock this tool's answer has to fit inside, and the whole
    * of what picks between {@link describeRun} and {@link describeStart}. Both numbers are
@@ -94,24 +95,36 @@ export interface JobToolOptions {
  *
  * A hosted MCP server is process-level — `tools/call` arrives carrying this server's bearer
  * token and the tool arguments, and nothing at all about the turn that produced it — so the
- * author is not on the call and is read off the gateway instead. That is the same
- * live-turn registry the reaction tool reads to put a glyph on "the message you are
- * answering", and it is the author the manifest already admitted through `owner`,
- * `allowlist`, and `respondTo`.
+ * author is not on the call and is read off the gateway instead. That is the same live-turn
+ * registry the reaction tool reads to put a glyph on "the message you are answering".
  *
- * The kind comes from the author's own `isAgent`, set by the surface that received the
- * message. Nothing said inside the turn reaches it, so this is still not the run naming its
- * own provenance: `on-request` remains a trigger rather than an authorization, and a sibling
- * agent asking is automation exactly as a clock tick is.
+ * **`human` is `owner`, and it is not `!isAgent`.** Only the surface can tell an agent from a
+ * person, and Buzz cannot yet: `toActorRef` sets `isAgent` for this agent's own pubkey and
+ * nobody else's, because recognising siblings needs a roster the relay does not serve. So on
+ * that surface `isAgent: false` means *not known to be an agent*, and reading it as evidence
+ * of a person would hand every sibling in a fleet the bypass §6.3 rule 2 reserves for a
+ * human. `owner` is the manifest's own list of the people this deployment answers to — the
+ * one positive signal, written by an operator, that no surface has to compute — and
+ * `isAgent` is kept alongside it because when a surface *can* say so it is real evidence,
+ * and it can only narrow this.
+ *
+ * Everyone else is automation for the purpose of the switch, and that includes an
+ * allowlisted colleague: an allowlist says who may speak to this agent, and a fleet's names
+ * siblings. `on-request` is still a trigger rather than an authorization.
  *
  * With no turn to name — none live, or two channels mid-turn at once, which names nobody —
  * the requester is this agent's brain. That is what is left that is true, and it is the safe
  * direction: it does not bypass a parked job.
  */
-function requester(agentName: string, asking: JobToolOptions["asking"]): JobRequester {
+function requester(
+  agentName: string,
+  asking: JobToolOptions["asking"],
+  owner: readonly string[],
+): JobRequester {
   const author = asking?.() ?? null;
   if (!author) return { kind: "agent", id: agentName };
-  return { kind: author.isAgent ? "agent" : "human", id: author.id };
+  const person = !author.isAgent && owner.includes(author.id);
+  return { kind: person ? "human" : "agent", id: author.id };
 }
 
 const JobArgs = z.object({
@@ -206,9 +219,10 @@ function tools(jobs: readonly JobConfig[], turnTimeoutMs: number): unknown[] {
         "that proved nothing did not pass. A job whose budget is longer than a turn is " +
         "started rather than waited for, and the answer says only that it is running and " +
         "where its result will be posted: there is no verdict in it, so say it is running " +
-        "and report the result when it lands. A parked job runs when the person you are " +
-        "answering is the one who asked, because they are waiting on the result; it refuses " +
-        "when another agent is asking, and nothing in this call lets you claim otherwise. " +
+        "and report the result when it lands. A parked job runs when the message you are " +
+        "answering came from one of this agent's owners, because they are waiting on the " +
+        "result; it refuses for anyone else, and nothing in this call lets you claim " +
+        "otherwise. " +
         "A job listed below with params takes a target — which issue, which document, " +
         "which environment — under `params`. No parameter changes what a job does: if the ask " +
         "is for different behaviour, it is a different job and a different slug.\n" +
@@ -267,7 +281,7 @@ function tools(jobs: readonly JobConfig[], turnTimeoutMs: number): unknown[] {
  * difference between an attempt somebody can find at 3am and one that never happened.
  */
 export function jobHandler(opts: JobToolOptions): McpHandler {
-  const { jobs, policy, host, agentName, asking, turnTimeoutMs } = opts;
+  const { jobs, policy, host, agentName, asking, owner = [], turnTimeoutMs } = opts;
   return mcpToolServer({
     name: JOB_SERVER,
     tools: () => tools(jobs, turnTimeoutMs),
@@ -302,10 +316,10 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
       // could disagree with either number. A job that fits inside a turn is waited for and
       // quoted; one that cannot is started, and answers where it declared it would.
       if (jobDeadlineMs(job) > turnTimeoutMs) {
-        const start = await host.startRequest(job, requester(agentName, asking), params);
+        const start = await host.startRequest(job, requester(agentName, asking, owner), params);
         return start.refused ? describeRun(start.refused) : describeStart(job, start);
       }
-      return describeRun(await host.request(job, requester(agentName, asking), params));
+      return describeRun(await host.request(job, requester(agentName, asking, owner), params));
     },
   });
 }
@@ -319,8 +333,8 @@ function describeRun(run: JobRun): string {
     // explain the refusal to whoever asked, and which side of the bypass this run fell on
     // is the part of it they can act on.
     (parked
-      ? "  this run counted as automation rather than a person's request, so it did not " +
-        "bypass a parked job\n"
+      ? "  this run did not count as an owner's request, so it did not bypass a parked " +
+        "job\n"
       : "")
   );
 }

--- a/packages/core/src/surface-egress.ts
+++ b/packages/core/src/surface-egress.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { SurfaceAdapter } from "./adapter.ts";
 import type {
+  ActorRef,
   ChannelRef,
   EventRef,
   GuardedMessage,
@@ -158,6 +159,22 @@ export class SurfaceEgress {
         if (this.answering.get(key) === turn) this.answering.delete(key);
       },
     };
+  }
+
+  /**
+   * Who sent the message this agent is answering, when exactly one turn is live.
+   *
+   * The registry {@link react} reads, and the same ambiguity rule: a channel runs its turns
+   * one at a time, so one live turn names its author exactly and two at once name nobody.
+   * `null` rather than a guess — the job door reads it as automation, which is the safe
+   * direction there.
+   *
+   * The author is the surface's, from an event this gateway received. Nothing the brain
+   * says during the turn reaches it.
+   */
+  asking(): ActorRef | null {
+    const live = [...this.answering.values()];
+    return live.length === 1 ? live[0].event.author : null;
   }
 
   /**

--- a/packages/core/test/job-server.test.ts
+++ b/packages/core/test/job-server.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { JobHost, type JobRun } from "../src/job-host.ts";
-import type { EventRef } from "../src/events.ts";
+import type { ActorRef, EventRef } from "../src/events.ts";
 import type { SwitchSource } from "../src/kill-switch.ts";
 import { jobHandler, JOB_RUN_TOOL, JOB_RUN_TOOL_NAME } from "../src/job-server.ts";
 import { loadManifest, type JobConfig } from "../src/manifest.ts";
@@ -103,13 +103,28 @@ let marker: string;
 let runs: JobRun[];
 let posts: string[];
 
+/**
+ * Who the gateway says this agent is answering. With no argument it answers `null`, which is
+ * what the gateway itself hands over when no turn is live or when two channels are mid-turn
+ * at once — and is what every call below that is not about provenance gets.
+ */
+const turnAuthor = (by?: Partial<ActorRef>) => (): ActorRef | null =>
+  by ? { surface: "buzz", id: "npub1abc", isSelf: false, isAgent: false, ...by } : null;
+
 /** Calls the tool the way the brain does, and returns the text it reads back. */
 const call = async (
   declared: readonly JobConfig[],
   args: Record<string, unknown>,
-  { policy = ALLOWED, turnTimeoutMs = PATIENT_TURN, host = jobHost() } = {},
+  { policy = ALLOWED, turnTimeoutMs = PATIENT_TURN, host = jobHost(), asking = turnAuthor() } = {},
 ): Promise<string> => {
-  const handle = jobHandler({ jobs: declared, policy, host, agentName: "whittle", turnTimeoutMs });
+  const handle = jobHandler({
+    jobs: declared,
+    policy,
+    host,
+    agentName: "whittle",
+    asking,
+    turnTimeoutMs,
+  });
   const result = await handle({
     id: 1,
     method: "tools/call",
@@ -392,21 +407,59 @@ describe("a job that needs a target", () => {
 });
 
 describe("provenance", () => {
-  it("records the agent's own brain as the requester, never the human in the channel", async () => {
-    await call([withBody(jobs(SHIFT)[0], PROVES)], { job: "shift" });
-    expect(runs[0].requestedBy).toEqual({ kind: "agent", id: "whittle" });
+  /**
+   * The switch nobody has set, on a job that does not run on one it cannot read — the
+   * issue's repro, and the state a fail-closed job is in before anyone touches it.
+   */
+  const parked: SwitchSource = async () => ({ origin: "never-set" });
+
+  /** Fail-closed, so `never-set` parks it. `SHIFT` is fail-open and would not. */
+  const CLOSED = SHIFT.replace("failDirection: open", "failDirection: closed");
+
+  it("records the person the turn is answering, and runs their job though it is parked", async () => {
+    const host = jobHost({ switchSource: parked });
+    const asking = turnAuthor({ id: "npub1ryan" });
+    const declared = [withBody(jobs(CLOSED)[0], PROVES)];
+    const text = await call(declared, { job: "shift" }, { host, asking });
+
+    // They asked, they are waiting on the answer, and they can stop it: not the unattended
+    // work a kill switch parks.
+    expect(text).toContain("job shift completed");
+    expect(text).toContain("PROVEN: ci passed");
+    expect(argv()).toHaveLength(1);
+    expect(runs[0].requestedBy).toEqual({ kind: "human", id: "npub1ryan" });
     expect(runs[0].trigger).toBe("on-request");
+    // Greppable at 3am, and the posture is exactly as it was found: the run reads the
+    // switch and never writes it.
+    expect(runs[0].bypassedSwitch).toBe(true);
+    expect(runs[0].switch).toEqual({ state: "off", origin: "never-set" });
   });
 
-  it("does not bypass a parked job, and says whose job that is instead", async () => {
-    const [shift] = jobs(SHIFT.replace("archetype: shift", "archetype: shift, suspend: true"));
-    const text = await call([withBody(shift, SILENT)], { job: "shift" });
+  it("still refuses a parked job when the one asking is another agent", async () => {
+    const host = jobHost({ switchSource: parked });
+    const asking = turnAuthor({ id: "npub1monty", isAgent: true });
+    const declared = [withBody(jobs(CLOSED)[0], SILENT)];
+    const text = await call(declared, { job: "shift" }, { host, asking });
 
-    expect(text).toContain("job shift denied-suspend");
+    // `on-request` is a trigger, not an authorization — a sibling asking is automation.
+    expect(text).toContain("job shift denied-switch");
     expect(text).toContain("only a human's on-request run bypasses a parked job");
-    expect(text).toContain("a run asked for through this tool is `agent`");
+    expect(text).toContain("this run counted as automation");
     expect(argv()).toEqual([]);
+    expect(runs[0].requestedBy).toEqual({ kind: "agent", id: "npub1monty" });
     expect(runs[0].bypassedSwitch).toBe(false);
+  });
+
+  it("records the agent's own brain when the gateway can name no one turn", async () => {
+    // Two channels mid-turn at once, or none: the gateway answers `null` rather than
+    // guessing which person a call belongs to, and the safe reading of that is automation.
+    const host = jobHost({ switchSource: parked });
+    const text = await call([withBody(jobs(CLOSED)[0], SILENT)], { job: "shift" }, { host });
+
+    expect(text).toContain("job shift denied-switch");
+    expect(argv()).toEqual([]);
+    expect(runs[0].requestedBy).toEqual({ kind: "agent", id: "whittle" });
+    expect(runs[0].trigger).toBe("on-request");
   });
 });
 

--- a/packages/core/test/job-server.test.ts
+++ b/packages/core/test/job-server.test.ts
@@ -107,15 +107,28 @@ let posts: string[];
  * Who the gateway says this agent is answering. With no argument it answers `null`, which is
  * what the gateway itself hands over when no turn is live or when two channels are mid-turn
  * at once — and is what every call below that is not about provenance gets.
+ *
+ * `isAgent: false` by default, because that is what Buzz reports for everyone but this agent
+ * itself — the flag is a false negative there, which is why `owner` and not this decides who
+ * a person is.
  */
 const turnAuthor = (by?: Partial<ActorRef>) => (): ActorRef | null =>
   by ? { surface: "buzz", id: "npub1abc", isSelf: false, isAgent: false, ...by } : null;
+
+/** The one person this agent's manifest names. Every other author is automation. */
+const OWNER = ["npub1ryan"];
 
 /** Calls the tool the way the brain does, and returns the text it reads back. */
 const call = async (
   declared: readonly JobConfig[],
   args: Record<string, unknown>,
-  { policy = ALLOWED, turnTimeoutMs = PATIENT_TURN, host = jobHost(), asking = turnAuthor() } = {},
+  {
+    policy = ALLOWED,
+    turnTimeoutMs = PATIENT_TURN,
+    host = jobHost(),
+    asking = turnAuthor(),
+    owner = OWNER,
+  } = {},
 ): Promise<string> => {
   const handle = jobHandler({
     jobs: declared,
@@ -123,6 +136,7 @@ const call = async (
     host,
     agentName: "whittle",
     asking,
+    owner,
     turnTimeoutMs,
   });
   const result = await handle({
@@ -444,18 +458,37 @@ describe("provenance", () => {
     expect(runs[0].switch).toEqual({ state: "off", origin: "never-set" });
   });
 
-  it("still refuses a parked job when the one asking is another agent", async () => {
+  it("refuses a parked job for an author the manifest does not name as an owner", async () => {
+    // The hole a `!isAgent` reading of the author would leave. Buzz sets `isAgent` for this
+    // agent's own pubkey and nobody else's — recognising a sibling needs a roster the relay
+    // does not serve — so a sibling agent arrives here indistinguishable from a stranger,
+    // and neither is the person §6.3 rule 2 reserves the bypass for.
     const host = jobHost({ switchSource: parked });
-    const asking = turnAuthor({ id: "npub1monty", isAgent: true });
+    const asking = turnAuthor({ id: "npub1monty" });
     const declared = [withBody(jobs(CLOSED)[0], SILENT)];
     const text = await call(declared, { job: "shift" }, { host, asking });
+
+    expect(text).toContain("job shift denied-switch");
+    expect(text).toContain("this run did not count as an owner's request");
+    expect(argv()).toEqual([]);
+    expect(runs[0].requestedBy).toEqual({ kind: "agent", id: "npub1monty" });
+    expect(runs[0].bypassedSwitch).toBe(false);
+  });
+
+  it("still refuses a parked job when the surface does say the author is an agent", async () => {
+    const host = jobHost({ switchSource: parked });
+    // Named as an owner *and* flagged an agent: where a surface can tell the two apart, the
+    // flag it sets is real evidence and only ever narrows this.
+    const asking = turnAuthor({ id: "npub1bot", isAgent: true });
+    const declared = [withBody(jobs(CLOSED)[0], SILENT)];
+    const text = await call(declared, { job: "shift" }, { host, asking, owner: ["npub1bot"] });
 
     // `on-request` is a trigger, not an authorization — a sibling asking is automation.
     expect(text).toContain("job shift denied-switch");
     expect(text).toContain("only a human's on-request run bypasses a parked job");
-    expect(text).toContain("this run counted as automation");
+    expect(text).toContain("this run did not count as an owner's request");
     expect(argv()).toEqual([]);
-    expect(runs[0].requestedBy).toEqual({ kind: "agent", id: "npub1monty" });
+    expect(runs[0].requestedBy).toEqual({ kind: "agent", id: "npub1bot" });
     expect(runs[0].bypassedSwitch).toBe(false);
   });
 

--- a/packages/core/test/job-server.test.ts
+++ b/packages/core/test/job-server.test.ts
@@ -416,6 +416,15 @@ describe("provenance", () => {
   /** Fail-closed, so `never-set` parks it. `SHIFT` is fail-open and would not. */
   const CLOSED = SHIFT.replace("failDirection: open", "failDirection: closed");
 
+  /**
+   * The shape the refusal was worst on: no schedule at all, so the switch parks no clock and
+   * its only effect is on the request it exists to permit.
+   */
+  const SCHEDULELESS =
+    "{slug: sweep, archetype: sweep, description: 'A pass nothing but a person starts.', " +
+    "trigger: {onRequest: true}, killSwitch: {failDirection: closed}, " +
+    "budget: {wallClockMs: 4000}, run: {command: node, args: [runner/src/sweep.ts]}}";
+
   it("records the person the turn is answering, and runs their job though it is parked", async () => {
     const host = jobHost({ switchSource: parked });
     const asking = turnAuthor({ id: "npub1ryan" });
@@ -448,6 +457,33 @@ describe("provenance", () => {
     expect(argv()).toEqual([]);
     expect(runs[0].requestedBy).toEqual({ kind: "agent", id: "npub1monty" });
     expect(runs[0].bypassedSwitch).toBe(false);
+  });
+
+  it("runs a parked job that has no clock for the switch to park", async () => {
+    const host = jobHost({ switchSource: parked });
+    const asking = turnAuthor({ id: "npub1ryan" });
+    const declared = [withBody(jobs(SCHEDULELESS)[0], PROVES)];
+    const text = await call(declared, { job: "sweep" }, { host, asking });
+
+    expect(text).toContain("job sweep completed");
+    expect(argv()).toHaveLength(1);
+    expect(runs[0].requestedBy).toEqual({ kind: "human", id: "npub1ryan" });
+    expect(runs[0].bypassedSwitch).toBe(true);
+  });
+
+  it("carries the person through the shape that is started rather than waited for", async () => {
+    // A deadline past the turn takes `startRequest`, the tool's other call site for the
+    // requester — and the one that answers before the admission has been recorded.
+    const host = jobHost({ switchSource: parked });
+    const asking = turnAuthor({ id: "npub1ryan" });
+    const declared = [withBody(jobs(CLOSED)[0], PROVES)];
+    const text = await call(declared, { job: "shift" }, { host, asking, turnTimeoutMs: 1000 });
+
+    expect(text).toContain("job shift is running now");
+    await vi.waitFor(() => expect(runs).toHaveLength(1), { timeout: 5000 });
+    expect(runs[0].outcome).toBe("completed");
+    expect(runs[0].requestedBy).toEqual({ kind: "human", id: "npub1ryan" });
+    expect(runs[0].bypassedSwitch).toBe(true);
   });
 
   it("records the agent's own brain when the gateway can name no one turn", async () => {

--- a/packages/core/test/surface-egress.test.ts
+++ b/packages/core/test/surface-egress.test.ts
@@ -338,6 +338,25 @@ describe("reacting to the message a turn is answering", () => {
     expect(buzz.reactions).toEqual([{ target: "m2", emoji: "👍" }]);
   });
 
+  // The job door asks the same registry a different question: not which message, but who
+  // sent it. A run a person is waiting on is not the unattended work a kill switch parks.
+  it("names the author of the one live turn, and nobody when two are", () => {
+    const buzz = adapter("buzz", [...hive, { surface: "buzz", id: "town", isPublic: false }]);
+    const egress = new SurfaceEgress({ manifest: manifest(), adapters: [buzz.value] });
+    expect(egress.asking()).toBeNull();
+
+    const first = egress.answers(event("buzz", "hive"));
+    expect(egress.asking()).toMatchObject({ id: "npub1abc", isAgent: false });
+
+    const second = egress.answers(event("buzz", "town", false, "m2"));
+    expect(egress.asking()).toBeNull();
+
+    second.close();
+    expect(egress.asking()).toMatchObject({ id: "npub1abc" });
+    first.close();
+    expect(egress.asking()).toBeNull();
+  });
+
   // A closer removes only its own event: a superseded turn must not delete the live one.
   it("keeps the live target when a finished turn's closer runs late", async () => {
     const buzz = adapter("buzz", hive);

--- a/packages/core/test/surface-egress.test.ts
+++ b/packages/core/test/surface-egress.test.ts
@@ -348,12 +348,15 @@ describe("reacting to the message a turn is answering", () => {
     const first = egress.answers(event("buzz", "hive"));
     expect(egress.asking()).toMatchObject({ id: "npub1abc", isAgent: false });
 
-    const second = egress.answers(event("buzz", "town", false, "m2"));
+    // A different person in the second channel, so what comes back once one turn ends says
+    // which turn it was read from rather than repeating the only author in the test.
+    const inTown = event("buzz", "town", false, "m2");
+    const second = egress.answers({ ...inTown, author: { ...inTown.author, id: "npub1ryan" } });
     expect(egress.asking()).toBeNull();
 
-    second.close();
-    expect(egress.asking()).toMatchObject({ id: "npub1abc" });
     first.close();
+    expect(egress.asking()).toMatchObject({ id: "npub1ryan" });
+    second.close();
     expect(egress.asking()).toBeNull();
   });
 


### PR DESCRIPTION
Closes #8.

## What was needed

A job declaring `trigger.onRequest: true` was refused whenever its `killSwitch` key was
parked — even when a person in a channel asked for it, and was sitting there waiting on
the answer.

`admitJob` has had the bypass since jobs shipped. A parked job refuses with *"only a
human's on-request run bypasses a parked job"*, and nothing ever produced a `human`
requester: `job_run` hard-coded `{ kind: "agent", id: agentName }`, so the refusal named a
run the toolkit could not mint. The only way through was to arm the switch for one run and
disarm it afterwards, and the disarm is the step people forget — a posture switch borrowed
as a one-off button is how a job ends up left armed by somebody who wanted one unit of work
done. It is worst on a job with no schedule at all, where the switch parks no clock and its
only effect is to refuse the request it exists to permit.

## What ships

The author is genuinely not on the call: a hosted MCP server is process-level, and
`tools/call` arrives carrying this server's bearer token and the tool arguments and nothing
about the turn that produced it. So it is read off the gateway instead, from the registry
`SurfaceEgress` already keeps of the message each turn is answering — the one that lets the
reaction tool take an emoji and nothing else.

```mermaid
flowchart LR
  A["inbound message"] --> B["gateway registers the live turn"]
  B --> C["brain calls job_run"]
  C --> D["egress.asking(): the one live turn's author, or null"]
  D --> E["requester kind: human only for an owner"]
  E --> F["admitJob"]
```

- **`SurfaceEgress.asking()`** answers that registry's other question — not *which message*
  but *who sent it* — under the same ambiguity rule `react` follows: one live turn names its
  author exactly, and two channels mid-turn at once name nobody.
- **`job-server.ts`** takes it as `asking?: () => ActorRef | null` plus the manifest's
  `owner`, and mints the kind itself. Deliberately not a `JobRequester`: a caller that could
  pass the kind could pass `human`, and the kind is what decides the bypass. With no turn to
  name, the requester falls back to this agent's brain and a parked job refuses, which is the
  safe direction.
- **`cli.ts`** wires `asking: egress && (() => egress.asking())`.

`on-request` is still a trigger rather than an authorization. Anyone who is not an owner is
automation and a parked job still refuses them — see the section below for why that is the
gate.

The bypass stays the one [RFC §6.3](docs/design/2026-08-19-jobs-rfc.md#63-the-switch-parks-automation-not-the-job)
describes: it answers whether the run starts and nothing about what it may do — every fence,
window and veto the body meets is untouched — and it writes nothing, so a parked job is
still parked afterwards and the record carries `bypassedSwitch: true` for whoever reads it
at 3am.

One behaviour change beyond the issue, called out because it touches the run record: the
requester is now the turn's author in the agent case too (a sibling's id rather than this
agent's own name). One rule instead of two.

## How it was verified

`pnpm typecheck` and `pnpm test` (1070 tests, 63 files) green. Four new tests, and the two
behavioural ones were run against the old `requester` first and fail there:

- `job-server.test.ts` — the issue's exact repro (fail-closed switch, never set) runs for the
  owner the turn is answering, records `{ kind: "human", id }`, `bypassedSwitch: true`, and
  the unchanged switch reading. Two more cover the shapes the tool reaches differently: a job
  with no schedule at all, and one started rather than waited for (`startRequest`).
- `job-server.test.ts` — an author the manifest does not name as an owner is still
  `denied-switch`, with `isAgent: false` as Buzz reports it. This is the regression test for
  the finding above.
- `job-server.test.ts` — an owner the surface *does* flag as an agent is still
  `denied-switch`.
- `job-server.test.ts` — no nameable turn still records the brain and still refuses.
- `surface-egress.test.ts` — `asking()` names the one live turn's author and nobody when two
  are live.

## Who counts as a person, and why it is `owner`

The first draft read `human` off `!author.isAgent`. Greptile caught that this is unsound, and
it is: `packages/adapter-buzz/src/normalize.ts:91` sets `isAgent: event.pubkey === pubkey` —
this agent's own key and nobody else's, because recognising a sibling needs a roster the relay
does not serve. There, `isAgent: false` means *not known to be an agent*, so a bypass keyed on
it would have handed every sibling in a fleet the pass §6.3 rule 2 reserves for a human.

The gate is now positive evidence rather than the absence of contrary evidence: **a person is
an author the manifest names in `owner`**, compared exactly as the gateway's own
`authorAllowed` compares it. `isAgent` is kept beside it, because where a surface *can* tell
the two apart the flag it sets is real evidence and can only narrow the gate.

That also settles the `respondTo: anyone` question this PR would otherwise have raised: an
allowlisted colleague and a stranger in a public channel are both automation for the purpose
of the switch. An allowlist says who may speak to this agent, and a fleet's names siblings.

SageOx-Session: https://sageox.ai/c/ses_01a05f05-f0c0-720b-ab2c-262dd01b916b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Human-initiated job runs can start parked or suspended jobs without changing their safety posture.
  * Job runs now record whether they were requested by a human or automated process.
  * Request attribution is preserved for both immediate and background job runs.
  * Requests with ambiguous or automated origins remain blocked for parked jobs.

* **Documentation**
  * Updated reference documentation and changelog to describe job authorization and request attribution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->