### PR TITLE
Name the people a Slack message mentions, so the brain knows who they are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-band, so a mention of a third party arrived as `<@U0ALICE>` — which tells a brain that
   somebody was addressed and not who. It answered about an id, and could not tell that two
   mentions of one person were one person. The adapter now resolves member ids through
-  `users.info` and renders them as `@alice`, preferring the label Slack supplies where there
-  is one. Needs the **`users:read`** scope; without it every mention keeps rendering as its
+  `users.info` and renders them as `@alice`. The directory outranks any label the sending
+  client embedded — `<@U0ALICE|bob>` reads as alice, because the two disagree after a rename
+  and the id is who Slack will actually notify. Needs the **`users:read`** scope; without it
+  the label is used where there is one, and otherwise every mention keeps rendering as its
   id, which is what it did before, and a refusal is remembered so a name Slack will not give
   is asked for once rather than once per message. An unnamed mention still reads as a
   mention: dropping it would lose the fact that somebody was named.
@@ -23,10 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `outboundText` already kept by escaping, now held one step earlier as well.
 
   **Inbound delivery is asynchronous as a result.** Resolving a name is a network call, so
-  the adapter normalizes one message at a time in arrival order rather than concurrently:
+  the adapter normalizes one message at a time *per conversation*, in arrival order:
   `ChannelQueue` preserves the order it is submitted in, so two messages racing on their
   lookups would have the agent answer the second question first, and a reply with no inbound
-  context thread onto the wrong message. After the first mention of a person every lookup is
+  context thread onto the wrong message. Ordering is kept per conversation rather than
+  adapter-wide, since that is all `ChannelQueue` asks for and one message's lookups must not
+  delay another channel. A message still resolving when `stop()` runs is discarded rather
+  than finishing into a later `start()`. After the first mention of a person every lookup is
   a cache hit.
 
 - **A probing job can read its thread back on Slack, so a roll call there has an answer.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adapter-wide, since that is all `ChannelQueue` asks for and one message's lookups must not
   delay another channel. A message still resolving when `stop()` runs is discarded rather
   than finishing into a later `start()`. After the first mention of a person every lookup is
-  a cache hit.
+  a cache hit. An envelope that arrives before the connection is up waits for it rather
+  than being dropped, and a start that then fails delivers none of what it heard — the
+  caller's `start()` throwing and a turn having been spent answering would otherwise both
+  be true at once.
 
 - **A probing job can read its thread back on Slack, so a roll call there has an answer.**
   `SlackAdapter.readThread` walks `conversations.replies` under a root the run posted and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A Slack agent reads a mention as a name, not an id.** Slack's addressing primitive is
+  in-band, so a mention of a third party arrived as `<@U0ALICE>` — which tells a brain that
+  somebody was addressed and not who. It answered about an id, and could not tell that two
+  mentions of one person were one person. The adapter now resolves member ids through
+  `users.info` and renders them as `@alice`, preferring the label Slack supplies where there
+  is one. Needs the **`users:read`** scope; without it every mention keeps rendering as its
+  id, which is what it did before, and a refusal is remembered so a name Slack will not give
+  is asked for once rather than once per message. An unnamed mention still reads as a
+  mention: dropping it would lose the fact that somebody was named.
+
+  The rendered form is text, not markup, so quoting it addresses nobody — the property
+  `outboundText` already kept by escaping, now held one step earlier as well.
+
+  **Inbound delivery is asynchronous as a result.** Resolving a name is a network call, so
+  the adapter normalizes one message at a time in arrival order rather than concurrently:
+  `ChannelQueue` preserves the order it is submitted in, so two messages racing on their
+  lookups would have the agent answer the second question first, and a reply with no inbound
+  context thread onto the wrong message. After the first mention of a person every lookup is
+  a cache hit.
+
 - **A probing job can read its thread back on Slack, so a roll call there has an answer.**
   `SlackAdapter.readThread` walks `conversations.replies` under a root the run posted and
   hands back the replies oldest first. Only Buzz implemented the verb, so a probe on a

--- a/docs/guide/chat-surfaces.md
+++ b/docs/guide/chat-surfaces.md
@@ -199,6 +199,10 @@ Create a Slack app, enable **Socket Mode**, and create an app-level token with
 `connections:write`. Install the app with these bot scopes:
 
 - `app_mentions:read`, `chat:write`, and `reactions:write`
+- `users:read`, so a mention reads as a name. Slack puts mentions in message text as
+  `<@U0ALICE>`, which tells a brain that somebody was addressed and not who — it answers
+  about an id, or mistakes two mentions of one person for two people. Without the scope
+  every mention keeps rendering as its id, which is what it did before.
 - the matching history and read scopes for the conversations you configure
   (`channels:history`/`channels:read`, `groups:history`/`groups:read`,
   `im:history`/`im:read`, or `mpim:history`/`mpim:read`)

--- a/packages/adapter-slack/src/normalize.ts
+++ b/packages/adapter-slack/src/normalize.ts
@@ -33,6 +33,26 @@ export interface SlackNormalizeOptions {
    * answer, or the egress guard is deciding on the wrong fact.
    */
   publicChannels?: ReadonlySet<string>;
+  /**
+   * Member id to the name a person reads, for rendering the mentions in a message.
+   *
+   * Passed in rather than looked up, so this stays a pure function: resolving a name is a
+   * network call, and the adapter is what owns the cache and the ordering. An id missing
+   * from the map renders as itself, which is what every mention did before there was a map.
+   */
+  memberNames?: ReadonlyMap<string, string>;
+}
+
+/**
+ * A member mention, as Slack writes it in message text: `<@U0ALICE>`, or `<@U0ALICE|alice>`
+ * where an older client supplied the label. Also matches the bot's own id, which
+ * {@link normalizeSlackText} strips before this runs.
+ */
+export const SLACK_MENTION = /<@([UWB][A-Z0-9]+)(?:\|([^>]*))?>/g;
+
+/** Every member a message mentions, which is what the adapter has to resolve names for. */
+export function slackMentionedMembers(text: string): string[] {
+  return [...text.matchAll(SLACK_MENTION)].map((match) => match[1]);
 }
 
 const MESSAGE_SUBTYPES = new Set([undefined, "bot_message", "file_share", "me_message", "thread_broadcast"]);
@@ -94,7 +114,7 @@ export function toSlackInboundEvent(
       isSelf: authorId === opts.botUserId || (!!opts.botId && message.bot_id === opts.botId),
       isAgent: !!message.bot_id || authorId === opts.botUserId,
     },
-    text: normalizeSlackText(message.text, opts.botUserId),
+    text: normalizeSlackText(message.text, opts.botUserId, opts.memberNames),
     // A DM is itself a direct address; requiring an @mention inside it makes normal DMs deaf.
     mentionsMe: direct || mention || message.type === "app_mention",
     ...(root
@@ -127,12 +147,28 @@ export function parseSlackEventId(nativeId: string): { channel: string; ts: stri
 }
 
 /** Slack's three XML entities are the only ones its message text escapes. */
-function normalizeSlackText(text: string, botUserId: string): string {
+function normalizeSlackText(
+  text: string,
+  botUserId: string,
+  memberNames?: ReadonlyMap<string, string>,
+): string {
   const withoutMention = text.replace(
     new RegExp(`<@${escapeRegExp(botUserId)}(?:\\|[^>]+)?>`, "g"),
     "",
   );
-  return withoutMention
+  // Everyone else stays, named. `<@U0ALICE>` is Slack's wire encoding, not something a
+  // person reads — a brain handed it can see that somebody was addressed and not who, so
+  // it answers about an id. The label Slack itself supplies is preferred where there is
+  // one, then the directory, then the raw id: a mention nobody could name still has to
+  // read as a mention rather than vanish.
+  //
+  // Rendered as `@name`, which is text and not markup. Quoting it back cannot address
+  // anyone — the same property `SlackAdapter.outboundText` keeps by escaping.
+  const named = withoutMention.replace(
+    SLACK_MENTION,
+    (_whole, id: string, label?: string) => `@${label || memberNames?.get(id) || id}`,
+  );
+  return named
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
     .replaceAll("&amp;", "&")

--- a/packages/adapter-slack/src/normalize.ts
+++ b/packages/adapter-slack/src/normalize.ts
@@ -156,20 +156,11 @@ function normalizeSlackText(
     new RegExp(`<@${escapeRegExp(botUserId)}(?:\\|[^>]+)?>`, "g"),
     "",
   );
-  // Everyone else stays, named. `<@U0ALICE>` is Slack's wire encoding, not something a
-  // person reads — a brain handed it can see that somebody was addressed and not who, so
-  // it answers about an id.
-  //
-  // The directory outranks the label, because the label is whatever the sending client
-  // embedded and the id is who Slack says was addressed. `<@U0ALICE|bob>` renders as
-  // alice: the two disagree after a rename, and on the reading that a label decides, the
-  // brain is told a different person was named than the one who will be notified.
-  // The label is still better than nothing where there is no directory — no `users:read`,
-  // or an id Slack would not name — and an id nobody could name still reads as a mention
-  // rather than vanishing.
-  //
-  // Rendered as `@name`, which is text and not markup. Quoting it back cannot address
-  // anyone — the same property `SlackAdapter.outboundText` keeps by escaping.
+  // Everyone else stays, named: `<@U0ALICE>` tells a brain somebody was addressed and not
+  // who. The directory outranks the label, which is whatever the sending client embedded
+  // and disagrees after a rename; the label beats a bare id, and a bare id still reads as
+  // a mention rather than vanishing. `@name` is text, not markup, so quoting it addresses
+  // nobody — the property `outboundText` keeps by escaping.
   const named = withoutMention.replace(
     SLACK_MENTION,
     (_whole, id: string, label?: string) => `@${memberNames?.get(id) || label || id}`,

--- a/packages/adapter-slack/src/normalize.ts
+++ b/packages/adapter-slack/src/normalize.ts
@@ -158,15 +158,21 @@ function normalizeSlackText(
   );
   // Everyone else stays, named. `<@U0ALICE>` is Slack's wire encoding, not something a
   // person reads — a brain handed it can see that somebody was addressed and not who, so
-  // it answers about an id. The label Slack itself supplies is preferred where there is
-  // one, then the directory, then the raw id: a mention nobody could name still has to
-  // read as a mention rather than vanish.
+  // it answers about an id.
+  //
+  // The directory outranks the label, because the label is whatever the sending client
+  // embedded and the id is who Slack says was addressed. `<@U0ALICE|bob>` renders as
+  // alice: the two disagree after a rename, and on the reading that a label decides, the
+  // brain is told a different person was named than the one who will be notified.
+  // The label is still better than nothing where there is no directory — no `users:read`,
+  // or an id Slack would not name — and an id nobody could name still reads as a mention
+  // rather than vanishing.
   //
   // Rendered as `@name`, which is text and not markup. Quoting it back cannot address
   // anyone — the same property `SlackAdapter.outboundText` keeps by escaping.
   const named = withoutMention.replace(
     SLACK_MENTION,
-    (_whole, id: string, label?: string) => `@${label || memberNames?.get(id) || id}`,
+    (_whole, id: string, label?: string) => `@${memberNames?.get(id) || label || id}`,
   );
   return named
     .replaceAll("&lt;", "<")

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -248,17 +248,23 @@ export class SlackAdapter implements SurfaceAdapter {
     if (!onEvent) return;
 
     const resumeFrom = this.since;
+    // The run every message from here belongs to. The listener is registered before the
+    // connection is up, so an event can already be queued when the start below fails.
+    const session = this.generation;
     this.socket.on("slack_event", this.handleEnvelope);
     try {
       await this.socket.start();
       this.listening = true;
       // Socket Mode has no replay. Connect first, then fill the earlier gap; deduplication
       // makes overlap safe and avoids a new gap between the history call and the socket.
-      if (resumeFrom !== undefined) await this.backfill(resumeFrom);
+      if (resumeFrom !== undefined) await this.backfill(resumeFrom, session);
     } catch (error) {
       this.started = false;
       this.socket.off?.("slack_event", this.handleEnvelope);
       this.onEvent = undefined;
+      // As on `stop`: a start that failed leaves no run for queued work to belong to, and
+      // without this it would belong to whichever run starts next.
+      this.invalidate();
       await this.socket.disconnect().catch(() => {});
       throw error;
     }
@@ -455,9 +461,21 @@ export class SlackAdapter implements SurfaceAdapter {
       this.started = false;
       this.onEvent = undefined;
       // Whatever is mid-lookup belongs to the run being stopped, and to nothing after it.
-      this.generation++;
-      this.chains.clear();
+      this.invalidate();
     }
+  }
+
+  /**
+   * Ends the run that queued work belongs to.
+   *
+   * Every asynchronous producer here — a live envelope waiting on a lookup, a replay still
+   * paging history — stamps the run it started in, and `accept` drops anything stamped with
+   * a run that has ended. Both ways a run ends go through this, because the stamp is only
+   * worth anything if nothing can outlive it unstamped.
+   */
+  private invalidate(): void {
+    this.generation++;
+    this.chains.clear();
   }
 
   /**
@@ -479,9 +497,9 @@ export class SlackAdapter implements SurfaceAdapter {
    * The returned promise settles when *this* message has been delivered, which is what
    * lets a backfill wait for its own replay without a second ordering rule.
    */
-  private enqueue(message: SlackMessage): Promise<void> {
+  private enqueue(message: SlackMessage, session = this.generation): Promise<void> {
     const conversation = message.channel ?? "";
-    const generation = this.generation;
+    const generation = session;
     // Errors are absorbed rather than left on the chain: one message nobody could
     // normalize must not stop every message behind it in the same conversation.
     const next = (this.chains.get(conversation) ?? Promise.resolve())
@@ -571,8 +589,11 @@ export class SlackAdapter implements SurfaceAdapter {
    * outside the history window, and Slack offers no way to enumerate the threads that
    * moved in a period — only the replies of a thread you can already name.
    */
-  private async backfill(oldest: number): Promise<void> {
+  private async backfill(oldest: number, session: number): Promise<void> {
     for (const channel of [...this.allowedChannels, ...(await this.directChannels())]) {
+      // A replay outlives a `stop` that lands mid-page otherwise, and goes on spending
+      // history calls on a run that has ended.
+      if (session !== this.generation) return;
       const parents = await this.collect((cursor) =>
         this.api.history({ channel, oldest: String(oldest), cursor }),
       );
@@ -598,7 +619,7 @@ export class SlackAdapter implements SurfaceAdapter {
           type: message.type ?? "message",
           channel,
           channel_type: this.privateChannels.has(channel) ? "group" : "channel",
-        });
+        }, session);
       }
     }
   }

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -145,41 +145,37 @@ export class SlackAdapter implements SurfaceAdapter {
   private readonly lastByChannel = new Map<string, SlackInboundContext>();
   private readonly seen = new Set<string>();
   /**
-   * Member id to name, filled as messages mention people and never expired.
-   *
-   * A miss costs one `users.info`; a rename goes unnoticed until restart. Both are the
-   * right trade for a directory that only decides how a mention reads — the alternative,
-   * pulling `users.list` at boot, spends a large workspace's whole member table to answer
-   * about the handful of people who actually speak.
+   * Member id to name, filled as messages mention people and never expired. A rename goes
+   * unnoticed until restart — the alternative, `users.list` at boot, spends a whole
+   * workspace's member table to answer about the few people who speak.
    */
   private readonly memberNames = new Map<string, string>();
   /** Ids Slack would not name, so a second message does not ask about them again. */
   private readonly unnamed = new Set<string>();
   /**
-   * Normalization runs one message at a time per conversation, in arrival order.
+   * One message at a time per conversation, in arrival order.
    *
-   * Resolving a name is a network call, so `accept` has to be able to wait — and two
-   * messages waiting concurrently would be delivered in whichever order Slack answered
-   * about their mentions. `ChannelQueue` preserves the order it is submitted in, so that
-   * scrambling would reach the brain: the agent answers the second question first, and a
-   * reply with no inbound context threads onto the wrong message.
-   *
-   * Per conversation and not one chain for the adapter, because that is the whole of what
-   * ordering means here — `ChannelQueue` serializes a channel and runs channels in
-   * parallel, so a single chain would impose a stricter order than anything downstream
-   * asks for and let one message's lookups delay every other conversation. A chain is
-   * dropped once it drains, so this holds an entry per conversation in flight rather than
-   * one per conversation ever seen.
+   * Resolving a name is a network call, and `ChannelQueue` preserves the order it is
+   * submitted in — so two messages racing on their lookups would have the agent answer the
+   * second question first. Per conversation, not adapter-wide, because that queue
+   * serializes a channel and runs channels in parallel. Dropped once drained.
    */
   private readonly chains = new Map<string, Promise<void>>();
   /**
-   * Which run of this adapter queued work belongs to.
-   *
-   * `stop()` bumps it, so a message still waiting on a lookup is discarded rather than
-   * finishing into a later `start()` — delivering an event the previous session heard to
-   * the callback the new one installed, and dragging its reply target along with it.
+   * Which run of this adapter queued work belongs to. Ending a run bumps it, so a message
+   * still waiting on a lookup is discarded rather than delivered into a later `start()`.
    */
   private generation = 0;
+  /**
+   * Resolves once this run's socket has settled — connected, or failed to.
+   *
+   * The listener is registered before `socket.start()`, because Socket Mode delivers from
+   * the moment it connects. Delivery still waits: a start that then fails throws out of
+   * `start`, and a turn already spent answering would make that a lie. Held rather than
+   * dropped — it is a real message either way.
+   */
+  private socketSettled: Promise<void> = Promise.resolve();
+  private releaseSocket: () => void = () => {};
   private botUserId?: string;
   private botId?: string;
   private onEvent?: (event: InboundEvent) => void;
@@ -251,10 +247,14 @@ export class SlackAdapter implements SurfaceAdapter {
     // The run every message from here belongs to. The listener is registered before the
     // connection is up, so an event can already be queued when the start below fails.
     const session = this.generation;
+    this.socketSettled = new Promise((resolve) => {
+      this.releaseSocket = resolve;
+    });
     this.socket.on("slack_event", this.handleEnvelope);
     try {
       await this.socket.start();
       this.listening = true;
+      this.releaseSocket(); // before the backfill, which enqueues through the same gate
       // Socket Mode has no replay. Connect first, then fill the earlier gap; deduplication
       // makes overlap safe and avoids a new gap between the history call and the socket.
       if (resumeFrom !== undefined) await this.backfill(resumeFrom, session);
@@ -329,18 +329,11 @@ export class SlackAdapter implements SurfaceAdapter {
   /**
    * Replies beneath a thread root this adapter posted — one `conversations.replies` walk.
    *
-   * Every way this can fail throws, and none of them answers `[]`. A probe mints a verdict
-   * from what comes back, so "nobody replied" has to stay distinguishable from "this read
-   * did not happen" — see {@link SurfaceAdapter.readThread}.
-   *
-   * `oldest: "0"` because a thread read is not a backfill: the caller wants everything
-   * under the root, not what arrived after some cursor. Slack returns the parent whatever
-   * `oldest` says, and the parent is not in its own thread — dropped by `ts` rather than by
-   * position, since a page boundary promises nothing about which message comes first.
-   *
-   * Normalized through `toSlackInboundEvent`, so a join notice or a hidden message is no
-   * more a reply here than it is a turn. One answer to "what counts as a message" rather
-   * than a second one that drifts.
+   * Every failure throws and none answers `[]`, per {@link SurfaceAdapter.readThread}.
+   * `oldest: "0"` because a thread read wants the whole thread, not what followed a cursor.
+   * Slack returns the parent whatever `oldest` says and it is not in its own thread, so it
+   * is dropped by `ts` — a page boundary promises nothing about order. Normalized through
+   * `toSlackInboundEvent`, so a join notice is no more a reply here than it is a turn.
    */
   async readThread(root: EventRef, limit?: number): Promise<readonly ThreadReply[]> {
     if (!this.started) throw new Error("SlackAdapter.start() must be called before readThread()");
@@ -476,6 +469,7 @@ export class SlackAdapter implements SurfaceAdapter {
   private invalidate(): void {
     this.generation++;
     this.chains.clear();
+    this.releaseSocket(); // parked work wakes to a moved generation; without this it hangs
   }
 
   /**
@@ -521,11 +515,10 @@ export class SlackAdapter implements SurfaceAdapter {
     // app's `message.im` subscription is the switch; the guard still sees a DM as private.
     const direct = isDirectSlackChannel(message);
     if (!direct && !this.allowedChannels.has(message.channel)) return;
-    // Twice around the lookup, and both matter. Before, because a message already stale
-    // when it reaches the front of its chain must not spend a `users.info` — the chain is
-    // per conversation, so that lookup would hold up the run that is actually serving it.
-    // After, because the run can end while the lookup is outstanding, which is the window
-    // the stamp exists for.
+    await this.socketSettled; // see the field: a replay passes through, the socket is up
+    // Checked before the lookup as well as after: a message already stale when its turn
+    // comes must not spend a `users.info` that the run still serving this conversation
+    // would wait behind.
     if (generation !== this.generation) return;
     // Before normalizing, because the text is rendered there and a name that arrives after
     // is a name the brain never saw.
@@ -541,11 +534,8 @@ export class SlackAdapter implements SurfaceAdapter {
 
     if (direct) this.dmChannels.add(message.channel);
     this.since = Math.max(this.since ?? 0, Number(message.ts));
-    // The newest message, never merely the most recently processed one. A backfill replays
-    // messages older than the live ones that arrived while it was paging — deliberately, as
-    // `start` connects before it fills the gap — so the two arrive interleaved. A reply with
-    // no inbound context has to thread onto the latest thing said, not onto whatever
-    // happened to finish last.
+    // The newest, not the most recently processed: `start` connects before it fills the
+    // gap, so a replay lands among live messages older than it.
     const context = contextOf(normalized);
     const latest = this.lastByChannel.get(normalized.channel.id);
     if (!latest || Number(context.eventTs) > Number(latest.eventTs)) {
@@ -568,14 +558,9 @@ export class SlackAdapter implements SurfaceAdapter {
   /**
    * Names the members a message mentions, so normalization can render them.
    *
-   * Sequential rather than concurrent: a message mentions a handful of people at most, and
-   * every one after the first conversation is already cached. Slack rate-limits
-   * `users.info` per workspace, and a burst is what that limit is aimed at.
-   *
-   * A refusal is remembered as a refusal. Without `unnamed`, an id Slack will not name —
-   * no `users:read`, a deactivated account, someone in another Enterprise Grid workspace —
-   * would cost one failed call per message forever, and a channel that talks about that
-   * person often would spend the rate limit on an answer that never changes.
+   * Sequential, because Slack rate-limits `users.info` per workspace and a burst is what
+   * that limit is aimed at. A refusal is remembered: an id Slack will not name would
+   * otherwise cost a failed call per message forever.
    */
   private async learnNames(text: string): Promise<void> {
     for (const id of new Set(slackMentionedMembers(text))) {
@@ -630,10 +615,8 @@ export class SlackAdapter implements SurfaceAdapter {
       const replay = missed
         .filter((message) => Number(message.ts ?? 0) > oldest)
         .sort((a, b) => Number(a.ts ?? 0) - Number(b.ts ?? 0));
-      // Queued in one turn, then awaited — never awaited one at a time. Each `await` here
-      // was a point where a live message could land in the middle of a sorted replay, and
-      // the older messages still to come would then overwrite the newer one's reply target.
-      // The chain already orders them, so nothing is lost by not waiting between them.
+      // One turn, not one await per message: each await was a point where a live message
+      // could land in the middle of a sorted replay. The chain already orders them.
       await Promise.all(
         replay.map((message) =>
           this.enqueue({
@@ -648,23 +631,12 @@ export class SlackAdapter implements SurfaceAdapter {
   }
 
   /**
-   * The DMs a backfill has to cover, which no configuration could have named.
+   * The DMs a backfill has to cover. `channels` never holds one — the id does not exist
+   * until someone opens it — and `dmChannels` is empty until `accept` fills it, so without
+   * this a DM sent while the agent was down is in neither set and is lost.
    *
-   * `channels` never holds a DM — its conversation id does not exist until someone opens
-   * it — and `dmChannels` is populated by `accept`, so at startup it is empty. Between
-   * them that left a DM sent while the agent was down in neither set: nothing enumerated
-   * it, nothing replayed it, and the cursor moved past it the moment any channel message
-   * was accepted. The message was gone, and a person who had asked something in a DM got
-   * silence back from an agent that looked healthy.
-   *
-   * **Read, never granted.** These ids are backfilled and nothing else. A DM still earns
-   * the right to be answered by having spoken, which `accept` is what records — so a
-   * conversation with nothing in the gap stays one this adapter may not post into, and
-   * enumerating open DMs cannot become a way to open one.
-   *
-   * A failed lookup costs the backfill, not the launch. Without `im:read` there is nothing
-   * to enumerate, and taking a working channel-only agent down over it would be refusing
-   * the wrong thing.
+   * **Read, never granted:** these ids are backfilled and nothing else. A DM still earns a
+   * reply by having spoken. A failed lookup costs the backfill, not the launch.
    */
   private async directChannels(live: () => boolean): Promise<string[]> {
     const ids: string[] = [];
@@ -685,9 +657,8 @@ export class SlackAdapter implements SurfaceAdapter {
   /**
    * Drains one cursor-paged endpoint. Slack pages backwards in time; the caller sorts.
    *
-   * `live` is asked between pages, so a walk started by a run that has since ended stops
-   * rather than paging to the end of the gap on its behalf. A backfill passes it; a thread
-   * read does not, being a caller's own request rather than a run's background work.
+   * `live` is asked between pages, so a walk whose run has ended stops. A backfill passes
+   * it; a thread read does not, being a caller's request rather than background work.
    */
   private async collect(
     page: (cursor?: string) => Promise<SlackHistoryPage>,

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -521,11 +521,15 @@ export class SlackAdapter implements SurfaceAdapter {
     // app's `message.im` subscription is the switch; the guard still sees a DM as private.
     const direct = isDirectSlackChannel(message);
     if (!direct && !this.allowedChannels.has(message.channel)) return;
+    // Twice around the lookup, and both matter. Before, because a message already stale
+    // when it reaches the front of its chain must not spend a `users.info` — the chain is
+    // per conversation, so that lookup would hold up the run that is actually serving it.
+    // After, because the run can end while the lookup is outstanding, which is the window
+    // the stamp exists for.
+    if (generation !== this.generation) return;
     // Before normalizing, because the text is rendered there and a name that arrives after
     // is a name the brain never saw.
     await this.learnNames(message.text ?? "");
-    // The lookup above is the one place this can lose the thread of its own lifecycle.
-    // Checked after it and before anything is recorded or delivered.
     if (generation !== this.generation) return;
     const normalized = toSlackInboundEvent(message, this.normalizeOptions());
     if (!normalized) return;
@@ -594,16 +598,20 @@ export class SlackAdapter implements SurfaceAdapter {
       // A replay outlives a `stop` that lands mid-page otherwise, and goes on spending
       // history calls on a run that has ended.
       if (session !== this.generation) return;
-      const parents = await this.collect((cursor) =>
-        this.api.history({ channel, oldest: String(oldest), cursor }),
+      const live = () => session === this.generation;
+      const parents = await this.collect(
+        (cursor) => this.api.history({ channel, oldest: String(oldest), cursor }),
+        live,
       );
 
       const missed = [...parents];
       for (const parent of parents) {
+        if (!live()) return;
         if (!hasRepliesSince(parent, oldest)) continue;
         missed.push(
-          ...(await this.collect((cursor) =>
-            this.api.replies({ channel, ts: parent.ts!, oldest: String(oldest), cursor }),
+          ...(await this.collect(
+            (cursor) => this.api.replies({ channel, ts: parent.ts!, oldest: String(oldest), cursor }),
+            live,
           )),
         );
       }
@@ -659,15 +667,24 @@ export class SlackAdapter implements SurfaceAdapter {
     return ids;
   }
 
-  /** Drains one cursor-paged endpoint. Slack pages backwards in time; the caller sorts. */
-  private async collect(page: (cursor?: string) => Promise<SlackHistoryPage>): Promise<SlackMessage[]> {
+  /**
+   * Drains one cursor-paged endpoint. Slack pages backwards in time; the caller sorts.
+   *
+   * `live` is asked between pages, so a walk started by a run that has since ended stops
+   * rather than paging to the end of the gap on its behalf. A backfill passes it; a thread
+   * read does not, being a caller's own request rather than a run's background work.
+   */
+  private async collect(
+    page: (cursor?: string) => Promise<SlackHistoryPage>,
+    live: () => boolean = () => true,
+  ): Promise<SlackMessage[]> {
     const messages: SlackMessage[] = [];
     let cursor: string | undefined;
     do {
       const result = await page(cursor);
       messages.push(...(result.messages ?? []));
       cursor = result.nextCursor || undefined;
-    } while (cursor);
+    } while (cursor && live());
     return messages;
   }
 

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -569,8 +569,10 @@ export class SlackAdapter implements SurfaceAdapter {
         const name = await this.api.userName(id);
         if (name) this.memberNames.set(id, name);
         else this.unnamed.add(id);
-      } catch {
-        this.unnamed.add(id);
+      } catch (error) {
+        // Only a refusal that will not change on its own. `unnamed` is never cleared, so a
+        // transient failure recorded here renders that member by id for the whole process.
+        if (isPermanentNameFailure(error)) this.unnamed.add(id);
       }
     }
   }
@@ -895,6 +897,25 @@ function address(mentions: readonly string[]): string {
     }
   }
   return `${mentions.map((id) => `<@${id}>`).join(" ")} `;
+}
+
+/**
+ * `users.info` failures that outlast the request, so the id is worth not asking about again.
+ *
+ * Read off `data.error` like {@link isAlreadyReacted}, and deliberately a short list: the
+ * default `WebClient` retries 429 itself, so what reaches this is usually a network fault,
+ * which must stay retryable. Everything unrecognised is treated that way.
+ */
+const PERMANENT_NAME_FAILURES = new Set([
+  "missing_scope",
+  "not_allowed_token_type",
+  "user_not_found",
+  "account_inactive",
+]);
+
+function isPermanentNameFailure(error: unknown): boolean {
+  const code = (error as { data?: { error?: unknown } } | null)?.data?.error;
+  return typeof code === "string" && PERMANENT_NAME_FAILURES.has(code);
 }
 
 /**

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -135,6 +135,8 @@ export class SlackAdapter implements SurfaceAdapter {
   private readonly socket: SlackSocketClient;
   private readonly allowedChannels: Set<string>;
   private readonly privateChannels: Set<string>;
+  /** `reply: private` as configured — what a lookup that cannot answer falls back to. */
+  private readonly configuredPrivate: ReadonlySet<string>;
   /** Display names as configured, so a cross-post can be asked for by the name people say. */
   private readonly channelNames: Map<string, string>;
   /** Channels Slack answered `is_private: false` for. Outranks the ID-prefix guess. */
@@ -187,9 +189,10 @@ export class SlackAdapter implements SurfaceAdapter {
 
   constructor(opts: SlackAdapterOptions) {
     this.allowedChannels = new Set(opts.channels.map((channel) => channel.id));
-    this.privateChannels = new Set(
+    this.configuredPrivate = new Set(
       opts.channels.filter((channel) => channel.reply === "private").map((channel) => channel.id),
     );
+    this.privateChannels = new Set(this.configuredPrivate);
     this.channelNames = new Map(
       opts.channels.flatMap((channel) => (channel.name ? [[channel.id, channel.name]] : [])),
     );
@@ -230,6 +233,13 @@ export class SlackAdapter implements SurfaceAdapter {
       }),
     );
     if (session !== this.generation) return;
+    // From configuration plus this run's answers, and nothing earlier. Both sets outlive a
+    // `stop`, so a previous run's answer would decide a lookup that fails now — and in the
+    // direction where it once said "private", the guard would allow a reply into a channel
+    // configured public.
+    this.privateChannels.clear();
+    for (const channel of this.configuredPrivate) this.privateChannels.add(channel);
+    this.publicChannels.clear();
     for (const { channel, isPrivate } of privacy) {
       if (isPrivate) this.privateChannels.add(channel);
       // Recorded, not merely "not added": normalization otherwise falls back to the ID

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -594,11 +594,11 @@ export class SlackAdapter implements SurfaceAdapter {
    * moved in a period — only the replies of a thread you can already name.
    */
   private async backfill(oldest: number, session: number): Promise<void> {
-    for (const channel of [...this.allowedChannels, ...(await this.directChannels())]) {
-      // A replay outlives a `stop` that lands mid-page otherwise, and goes on spending
-      // history calls on a run that has ended.
-      if (session !== this.generation) return;
-      const live = () => session === this.generation;
+    const live = () => session === this.generation;
+    // Built before the walk it guards: enumerating DMs pages too, and a `stop` landing in
+    // the middle of that is the same waste as one landing in the middle of a history page.
+    for (const channel of [...this.allowedChannels, ...(await this.directChannels(live))]) {
+      if (!live()) return;
       const parents = await this.collect(
         (cursor) => this.api.history({ channel, oldest: String(oldest), cursor }),
         live,
@@ -621,14 +621,20 @@ export class SlackAdapter implements SurfaceAdapter {
       const replay = missed
         .filter((message) => Number(message.ts ?? 0) > oldest)
         .sort((a, b) => Number(a.ts ?? 0) - Number(b.ts ?? 0));
-      for (const message of replay) {
-        await this.enqueue({
-          ...message,
-          type: message.type ?? "message",
-          channel,
-          channel_type: this.privateChannels.has(channel) ? "group" : "channel",
-        }, session);
-      }
+      // Queued in one turn, then awaited — never awaited one at a time. Each `await` here
+      // was a point where a live message could land in the middle of a sorted replay, and
+      // the older messages still to come would then overwrite the newer one's reply target.
+      // The chain already orders them, so nothing is lost by not waiting between them.
+      await Promise.all(
+        replay.map((message) =>
+          this.enqueue({
+            ...message,
+            type: message.type ?? "message",
+            channel,
+            channel_type: this.privateChannels.has(channel) ? "group" : "channel",
+          }, session),
+        ),
+      );
     }
   }
 
@@ -651,7 +657,7 @@ export class SlackAdapter implements SurfaceAdapter {
    * to enumerate, and taking a working channel-only agent down over it would be refusing
    * the wrong thing.
    */
-  private async directChannels(): Promise<string[]> {
+  private async directChannels(live: () => boolean): Promise<string[]> {
     const ids: string[] = [];
     try {
       let cursor: string | undefined;
@@ -659,7 +665,7 @@ export class SlackAdapter implements SurfaceAdapter {
         const page = await this.api.openDirectChannels(cursor);
         ids.push(...(page.ids ?? []));
         cursor = page.nextCursor || undefined;
-      } while (cursor);
+      } while (cursor && live());
     } catch {
       // Whatever paged in before the failure is still worth refilling. Without `im:read`
       // that is nothing, which is the case this catch is really here for.

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -156,16 +156,30 @@ export class SlackAdapter implements SurfaceAdapter {
   /** Ids Slack would not name, so a second message does not ask about them again. */
   private readonly unnamed = new Set<string>();
   /**
-   * Normalization runs one message at a time, in arrival order.
+   * Normalization runs one message at a time per conversation, in arrival order.
    *
    * Resolving a name is a network call, so `accept` has to be able to wait — and two
    * messages waiting concurrently would be delivered in whichever order Slack answered
    * about their mentions. `ChannelQueue` preserves the order it is submitted in, so that
    * scrambling would reach the brain: the agent answers the second question first, and a
-   * reply with no inbound context threads onto the wrong message. After the first mention
-   * of a person every lookup is a cache hit, so this chain idles.
+   * reply with no inbound context threads onto the wrong message.
+   *
+   * Per conversation and not one chain for the adapter, because that is the whole of what
+   * ordering means here — `ChannelQueue` serializes a channel and runs channels in
+   * parallel, so a single chain would impose a stricter order than anything downstream
+   * asks for and let one message's lookups delay every other conversation. A chain is
+   * dropped once it drains, so this holds an entry per conversation in flight rather than
+   * one per conversation ever seen.
    */
-  private chain: Promise<void> = Promise.resolve();
+  private readonly chains = new Map<string, Promise<void>>();
+  /**
+   * Which run of this adapter queued work belongs to.
+   *
+   * `stop()` bumps it, so a message still waiting on a lookup is discarded rather than
+   * finishing into a later `start()` — delivering an event the previous session heard to
+   * the callback the new one installed, and dragging its reply target along with it.
+   */
+  private generation = 0;
   private botUserId?: string;
   private botId?: string;
   private onEvent?: (event: InboundEvent) => void;
@@ -433,6 +447,9 @@ export class SlackAdapter implements SurfaceAdapter {
       this.listening = false;
       this.started = false;
       this.onEvent = undefined;
+      // Whatever is mid-lookup belongs to the run being stopped, and to nothing after it.
+      this.generation++;
+      this.chains.clear();
     }
   }
 
@@ -456,13 +473,23 @@ export class SlackAdapter implements SurfaceAdapter {
    * lets a backfill wait for its own replay without a second ordering rule.
    */
   private enqueue(message: SlackMessage): Promise<void> {
+    const conversation = message.channel ?? "";
+    const generation = this.generation;
     // Errors are absorbed rather than left on the chain: one message nobody could
-    // normalize must not stop every message behind it.
-    this.chain = this.chain.then(() => this.accept(message)).catch(() => {});
-    return this.chain;
+    // normalize must not stop every message behind it in the same conversation.
+    const next = (this.chains.get(conversation) ?? Promise.resolve())
+      .then(() => this.accept(message, generation))
+      .catch(() => {});
+    this.chains.set(conversation, next);
+    // Only if nothing has queued behind it, or the entry dropped here is one another
+    // message is already waiting on.
+    void next.then(() => {
+      if (this.chains.get(conversation) === next) this.chains.delete(conversation);
+    });
+    return next;
   }
 
-  private async accept(message: SlackMessage): Promise<void> {
+  private async accept(message: SlackMessage, generation: number): Promise<void> {
     if (!message.channel) return;
     // A DM cannot be addressed to anyone but this bot, and its conversation ID does not
     // exist until someone opens it — so it can never be configured ahead of time. The
@@ -472,6 +499,9 @@ export class SlackAdapter implements SurfaceAdapter {
     // Before normalizing, because the text is rendered there and a name that arrives after
     // is a name the brain never saw.
     await this.learnNames(message.text ?? "");
+    // The lookup above is the one place this can lose the thread of its own lifecycle.
+    // Checked after it and before anything is recorded or delivered.
+    if (generation !== this.generation) return;
     const normalized = toSlackInboundEvent(message, this.normalizeOptions());
     if (!normalized) return;
 

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -15,6 +15,7 @@ import {
   isDirectSlackChannel,
   parseSlackEventId,
   slackEventId,
+  slackMentionedMembers,
   toSlackInboundEvent,
   type SlackMessage,
 } from "./normalize.ts";
@@ -52,6 +53,8 @@ export interface SlackApiClient {
     oldest: string;
     cursor?: string;
   }): Promise<SlackHistoryPage>;
+  /** The name a person reads for a member id, or `undefined` when Slack will not say. */
+  userName(id: string): Promise<string | undefined>;
   /** Answers with the posted message's `ts`, when Slack reports one. */
   postMessage(args: {
     channel: string;
@@ -141,6 +144,28 @@ export class SlackAdapter implements SurfaceAdapter {
   /** One entry per channel, for a reply with no triggering event to thread onto. */
   private readonly lastByChannel = new Map<string, SlackInboundContext>();
   private readonly seen = new Set<string>();
+  /**
+   * Member id to name, filled as messages mention people and never expired.
+   *
+   * A miss costs one `users.info`; a rename goes unnoticed until restart. Both are the
+   * right trade for a directory that only decides how a mention reads — the alternative,
+   * pulling `users.list` at boot, spends a large workspace's whole member table to answer
+   * about the handful of people who actually speak.
+   */
+  private readonly memberNames = new Map<string, string>();
+  /** Ids Slack would not name, so a second message does not ask about them again. */
+  private readonly unnamed = new Set<string>();
+  /**
+   * Normalization runs one message at a time, in arrival order.
+   *
+   * Resolving a name is a network call, so `accept` has to be able to wait — and two
+   * messages waiting concurrently would be delivered in whichever order Slack answered
+   * about their mentions. `ChannelQueue` preserves the order it is submitted in, so that
+   * scrambling would reach the brain: the agent answers the second question first, and a
+   * reply with no inbound context threads onto the wrong message. After the first mention
+   * of a person every lookup is a cache hit, so this chain idles.
+   */
+  private chain: Promise<void> = Promise.resolve();
   private botUserId?: string;
   private botId?: string;
   private onEvent?: (event: InboundEvent) => void;
@@ -411,21 +436,42 @@ export class SlackAdapter implements SurfaceAdapter {
     }
   }
 
-  private readonly handleEnvelope = (payload: unknown): void => {
+  /**
+   * Answers when this envelope has been delivered, which Socket Mode ignores and a caller
+   * that needs to know an event has landed can await. The ack above is deliberately not
+   * part of it — Slack retries an envelope that waits, so it goes first and alone.
+   */
+  private readonly handleEnvelope = async (payload: unknown): Promise<void> => {
     const envelope = payload as SocketEnvelope;
     // Acknowledge before normalization or user code. Slack retries envelopes that wait.
     if (envelope.ack) void envelope.ack().catch(() => {});
     if (envelope.type !== "events_api" || !envelope.body?.event) return;
-    this.accept(envelope.body.event);
+    await this.enqueue(envelope.body.event);
   };
 
-  private accept(message: SlackMessage): void {
+  /**
+   * Normalizes and delivers one message, behind everything already queued.
+   *
+   * The returned promise settles when *this* message has been delivered, which is what
+   * lets a backfill wait for its own replay without a second ordering rule.
+   */
+  private enqueue(message: SlackMessage): Promise<void> {
+    // Errors are absorbed rather than left on the chain: one message nobody could
+    // normalize must not stop every message behind it.
+    this.chain = this.chain.then(() => this.accept(message)).catch(() => {});
+    return this.chain;
+  }
+
+  private async accept(message: SlackMessage): Promise<void> {
     if (!message.channel) return;
     // A DM cannot be addressed to anyone but this bot, and its conversation ID does not
     // exist until someone opens it — so it can never be configured ahead of time. The
     // app's `message.im` subscription is the switch; the guard still sees a DM as private.
     const direct = isDirectSlackChannel(message);
     if (!direct && !this.allowedChannels.has(message.channel)) return;
+    // Before normalizing, because the text is rendered there and a name that arrives after
+    // is a name the brain never saw.
+    await this.learnNames(message.text ?? "");
     const normalized = toSlackInboundEvent(message, this.normalizeOptions());
     if (!normalized) return;
 
@@ -447,7 +493,33 @@ export class SlackAdapter implements SurfaceAdapter {
       botId: this.botId,
       privateChannels: this.privateChannels,
       publicChannels: this.publicChannels,
+      memberNames: this.memberNames,
     };
+  }
+
+  /**
+   * Names the members a message mentions, so normalization can render them.
+   *
+   * Sequential rather than concurrent: a message mentions a handful of people at most, and
+   * every one after the first conversation is already cached. Slack rate-limits
+   * `users.info` per workspace, and a burst is what that limit is aimed at.
+   *
+   * A refusal is remembered as a refusal. Without `unnamed`, an id Slack will not name —
+   * no `users:read`, a deactivated account, someone in another Enterprise Grid workspace —
+   * would cost one failed call per message forever, and a channel that talks about that
+   * person often would spend the rate limit on an answer that never changes.
+   */
+  private async learnNames(text: string): Promise<void> {
+    for (const id of new Set(slackMentionedMembers(text))) {
+      if (id === this.botUserId || this.memberNames.has(id) || this.unnamed.has(id)) continue;
+      try {
+        const name = await this.api.userName(id);
+        if (name) this.memberNames.set(id, name);
+        else this.unnamed.add(id);
+      } catch {
+        this.unnamed.add(id);
+      }
+    }
   }
 
   /**
@@ -484,7 +556,7 @@ export class SlackAdapter implements SurfaceAdapter {
         .filter((message) => Number(message.ts ?? 0) > oldest)
         .sort((a, b) => Number(a.ts ?? 0) - Number(b.ts ?? 0));
       for (const message of replay) {
-        this.accept({
+        await this.enqueue({
           ...message,
           type: message.type ?? "message",
           channel,
@@ -672,6 +744,12 @@ export class WebSlackApi implements SlackApiClient {
       unfurl_media: false,
     });
     return response.ts;
+  }
+
+  /** `display_name` is what the workspace shows; the rest are Slack's own fallbacks. */
+  async userName(id: string): Promise<string | undefined> {
+    const user = (await this.client.users.info({ user: id })).user;
+    return user?.profile?.display_name || user?.profile?.real_name || user?.name;
   }
 
   async addReaction(args: { channel: string; timestamp: string; name: string }): Promise<void> {

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -204,9 +204,14 @@ export class SlackAdapter implements SurfaceAdapter {
 
   async start(onEvent?: (event: InboundEvent) => void): Promise<void> {
     if (this.started) throw new Error("SlackAdapter is already started");
+    // Before the first await, not after the last: a `stop` during either lookup below ends
+    // this run, and capturing afterwards would read the replacement's stamp and pass every
+    // ownership check downstream as though this were the live run.
+    const session = this.generation;
 
     const identity = await this.api.authTest();
     if (!identity.userId) throw new Error("Slack auth.test did not return the bot user id");
+    if (session !== this.generation) return;
     this.botUserId = identity.userId;
     this.botId = identity.botId;
     this.onEvent = onEvent;
@@ -214,28 +219,28 @@ export class SlackAdapter implements SurfaceAdapter {
     // Slack Connect and shared channels do not always follow an ID-prefix privacy rule.
     // A failed lookup is not trusted as private: the configured assertion remains, and
     // everything else stays public so the egress guard fails closed.
-    await Promise.all(
+    const privacy = await Promise.all(
       [...this.allowedChannels].map(async (channel) => {
         try {
-          const isPrivate = await this.api.channelIsPrivate(channel);
-          if (isPrivate) this.privateChannels.add(channel);
-          // Recorded, not merely "not added": normalization otherwise falls back to the
-          // ID prefix and calls a public G-prefixed channel private, which is the one
-          // case where the guard would let workspace-visible output through.
-          //
-          // The configured assertion is dropped in the same step, because Slack answering
-          // "public" outranks it. Leaving it in place kept `postTargets` reporting the
-          // channel private off the configured entries alone, so the guard never saw a
-          // public channel to refuse and a cross-surface post reached the whole workspace.
-          else if (isPrivate === false) {
-            this.publicChannels.add(channel);
-            this.privateChannels.delete(channel);
-          }
+          return { channel, isPrivate: await this.api.channelIsPrivate(channel) };
         } catch {
           // Missing channels:read/groups:read must not widen egress.
+          return { channel, isPrivate: undefined };
         }
       }),
     );
+    if (session !== this.generation) return;
+    for (const { channel, isPrivate } of privacy) {
+      if (isPrivate) this.privateChannels.add(channel);
+      // Recorded, not merely "not added": normalization otherwise falls back to the ID
+      // prefix and calls a public G-prefixed channel private, the one case where the guard
+      // would let workspace-visible output through. The configured assertion is dropped in
+      // the same step, because Slack answering "public" outranks it.
+      else if (isPrivate === false) {
+        this.publicChannels.add(channel);
+        this.privateChannels.delete(channel);
+      }
+    }
 
     // Everything `post` and the egress guard rely on is now in place. Saying so before the
     // socket is what lets a caller with nothing to listen for stop here — and it is why an
@@ -244,9 +249,8 @@ export class SlackAdapter implements SurfaceAdapter {
     if (!onEvent) return;
 
     const resumeFrom = this.since;
-    // The run every message from here belongs to. The listener is registered before the
-    // connection is up, so an event can already be queued when the start below fails.
-    const session = this.generation;
+    // The listener goes on before the connection is up, so an envelope can already be
+    // queued when the start below fails.
     this.socketSettled = new Promise((resolve) => {
       this.releaseSocket = resolve;
     });

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -355,9 +355,16 @@ export class SlackAdapter implements SurfaceAdapter {
     // Sorted on the Slack `ts` rather than the ISO string it becomes: `ts` carries
     // microseconds and the ISO form is truncated to milliseconds, so two replies inside one
     // millisecond would tie and come back in whatever order the pages happened to arrive.
-    const replies = messages
+    const ordered = messages
       .filter((message) => message.ts !== at.ts)
-      .sort((a, b) => Number(a.ts ?? 0) - Number(b.ts ?? 0))
+      .sort((a, b) => Number(a.ts ?? 0) - Number(b.ts ?? 0));
+    // The same directory the inbound path fills, filled the same way before rendering.
+    // Sharing the map without sharing the lookup is what makes one mention read two ways
+    // depending on which door it came through — and a probe tallying replies is exactly
+    // the caller that would then disagree with the channel it is reading.
+    for (const message of ordered) await this.learnNames(message.text ?? "");
+
+    const replies = ordered
       .flatMap((message) => {
         const event = toSlackInboundEvent(
           { ...message, type: message.type ?? "message", channel: at.channel },

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -541,7 +541,16 @@ export class SlackAdapter implements SurfaceAdapter {
 
     if (direct) this.dmChannels.add(message.channel);
     this.since = Math.max(this.since ?? 0, Number(message.ts));
-    this.lastByChannel.set(normalized.channel.id, contextOf(normalized));
+    // The newest message, never merely the most recently processed one. A backfill replays
+    // messages older than the live ones that arrived while it was paging — deliberately, as
+    // `start` connects before it fills the gap — so the two arrive interleaved. A reply with
+    // no inbound context has to thread onto the latest thing said, not onto whatever
+    // happened to finish last.
+    const context = contextOf(normalized);
+    const latest = this.lastByChannel.get(normalized.channel.id);
+    if (!latest || Number(context.eventTs) > Number(latest.eventTs)) {
+      this.lastByChannel.set(normalized.channel.id, context);
+    }
     this.onEvent?.(normalized);
   }
 

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -253,19 +253,25 @@ export class SlackAdapter implements SurfaceAdapter {
     this.socket.on("slack_event", this.handleEnvelope);
     try {
       await this.socket.start();
+      // A `stop` and a fresh `start` can both have happened while that was pending. The
+      // gate, the listener and `onEvent` are single fields, so touching any of them now
+      // would be reaching into a run this one does not own.
+      if (session !== this.generation) return;
       this.listening = true;
       this.releaseSocket(); // before the backfill, which enqueues through the same gate
       // Socket Mode has no replay. Connect first, then fill the earlier gap; deduplication
       // makes overlap safe and avoids a new gap between the history call and the socket.
       if (resumeFrom !== undefined) await this.backfill(resumeFrom, session);
     } catch (error) {
-      this.started = false;
-      this.socket.off?.("slack_event", this.handleEnvelope);
-      this.onEvent = undefined;
-      // As on `stop`: a start that failed leaves no run for queued work to belong to, and
-      // without this it would belong to whichever run starts next.
-      this.invalidate();
-      await this.socket.disconnect().catch(() => {});
+      // Same rule on the way out: a late failure must not unsubscribe, disconnect or
+      // invalidate a run that replaced this one. Still thrown — the caller asked this one.
+      if (session === this.generation) {
+        this.started = false;
+        this.socket.off?.("slack_event", this.handleEnvelope);
+        this.onEvent = undefined;
+        this.invalidate();
+        await this.socket.disconnect().catch(() => {});
+      }
       throw error;
     }
   }

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -30,8 +30,9 @@ class FakeSocket implements SlackSocketClient {
     this.disconnected = true;
   }
 
-  emit(event: Record<string, unknown>, ack = async () => {}): void {
-    this.listener?.({ type: "events_api", body: { event }, ack });
+  /** Answers when the adapter has finished with the envelope: delivery is not synchronous. */
+  emit(event: Record<string, unknown>, ack = async () => {}): unknown {
+    return this.listener?.({ type: "events_api", body: { event }, ack });
   }
 }
 
@@ -63,6 +64,12 @@ class FakeApi implements SlackApiClient {
   async replies(args: { channel: string; ts: string; oldest: string; cursor?: string }) {
     this.replyCalls.push(args);
     return this.threads.shift() ?? {};
+  }
+  names: Record<string, string> = {};
+  nameCalls: string[] = [];
+  async userName(id: string): Promise<string | undefined> {
+    this.nameCalls.push(id);
+    return this.names[id];
   }
   async postMessage(args: { channel: string; text: string; threadTs?: string }) {
     this.posts.push(args);
@@ -112,10 +119,10 @@ describe("SlackAdapter", () => {
     let acked = false;
     await instance.start((event) => got.push(event));
 
-    socket.emit(mention(), async () => {
+    await socket.emit(mention(), async () => {
       acked = true;
     });
-    socket.emit({ ...mention("1786761000.000200"), channel: "GOTHER" });
+    await socket.emit({ ...mention("1786761000.000200"), channel: "GOTHER" });
     await Promise.resolve();
 
     expect(acked).toBe(true);
@@ -127,7 +134,7 @@ describe("SlackAdapter", () => {
     const { instance, socket, api } = adapter();
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
-    socket.emit(mention("1786761000.000200", { thread_ts: "1786760000.000001" }));
+    await socket.emit(mention("1786761000.000200", { thread_ts: "1786760000.000001" }));
 
     const acknowledged = await instance.react(got[0], "👀");
     await instance.send(got[0].channel, { text: "all green" });
@@ -148,8 +155,8 @@ describe("SlackAdapter", () => {
     const { instance, socket, api } = adapter();
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
-    socket.emit(mention("1786761000.000100"));
-    socket.emit(mention("1786761000.000200"));
+    await socket.emit(mention("1786761000.000100"));
+    await socket.emit(mention("1786761000.000200"));
 
     await instance.send(got[0].channel, { text: "first reply" }, got[0]);
 
@@ -316,19 +323,80 @@ describe("SlackAdapter", () => {
     const { instance, socket, api } = adapter();
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
-    // Slack delivers a mention of a third party as live markup and `normalizeSlackText`
-    // hands it to the brain as those characters, so quoting the message that woke the agent
-    // is enough to page whoever it named — through none of the screening `mentions` gets.
-    socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE> & <@U0BOB>" }));
+    // Quoting the message that woke the agent must not page whoever it named. Two
+    // independent things now stop it, and this asserts both: the mention reaches the brain
+    // as a name rather than markup, and what the brain sends is escaped regardless.
+    api.names = { U0ALICE: "alice" };
+    await socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE> & <@U0BOB>" }));
+    expect(got[0].text).toBe("ask @alice & @U0BOB");
 
     await instance.send(got[0].channel, { text: got[0].text }, got[0]);
-    expect(api.posts[0].text).toBe("ask &lt;@U0ALICE&gt; &amp; &lt;@U0BOB&gt;");
+    expect(api.posts[0].text).toBe("ask @alice &amp; @U0BOB");
 
     // The recipients the adapter builds from validated ids stay markup; the text beside
     // them does not, so the two ways to address somebody have not become one again.
     const channel = { surface: "slack", id: "GENG", isPublic: false } as const;
     await instance.post(channel, { text: "who is <@U0ALICE>?" }, undefined, ["U0DRONE"]);
     expect(api.posts[1].text).toBe("<@U0DRONE> who is &lt;@U0ALICE&gt;?");
+  });
+
+  it("names the members a message mentions, and asks Slack about each one once", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    api.names = { U0ALICE: "alice", U0BOB: "bob" };
+    await instance.start((event) => got.push(event));
+
+    await socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE> and <@U0BOB>" }));
+    await socket.emit(mention("1786761000.000200", { text: "<@UBOT> and <@U0ALICE> again" }));
+
+    expect(got.map((event) => event.text)).toEqual(["ask @alice and @bob", "and @alice again"]);
+    // Each member once across both messages, and never the bot: its own mention is stripped.
+    expect(api.nameCalls).toEqual(["U0ALICE", "U0BOB"]);
+  });
+
+  it("keeps a mention Slack will not name, and stops asking about it", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    await instance.start((event) => got.push(event));
+
+    // No `users:read`, a deactivated account, another Grid workspace — all the same here.
+    api.userName = async (id: string) => {
+      api.nameCalls.push(id);
+      throw new Error("missing_scope");
+    };
+    await socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0GHOST>" }));
+    await socket.emit(mention("1786761000.000200", { text: "<@UBOT> ask <@U0GHOST> again" }));
+
+    // The mention still reads as a mention. Dropping it would lose the fact that somebody
+    // was named, which is worse than naming them by id.
+    expect(got.map((event) => event.text)).toEqual(["ask @U0GHOST", "ask @U0GHOST again"]);
+    // Asked once. A refusal that is not remembered spends the rate limit re-asking forever.
+    expect(api.nameCalls).toEqual(["U0GHOST"]);
+  });
+
+  it("delivers in arrival order even when the first message waits on a lookup", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    await instance.start((event) => got.push(event));
+
+    // The first message needs a name and the second does not. Without the chain the second
+    // overtakes it, `ChannelQueue` submits them reversed, and the agent answers backwards.
+    let release: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    api.userName = async (id: string) => {
+      await held;
+      return id === "U0ALICE" ? "alice" : undefined;
+    };
+    const first = socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
+    const second = socket.emit(mention("1786761000.000200", { text: "<@UBOT> second" }));
+
+    expect(got).toHaveLength(0);
+    release!();
+    await Promise.all([first, second]);
+
+    expect(got.map((event) => event.text)).toEqual(["ask @alice", "second"]);
   });
 
   it("refuses a top-level post to an unconfigured channel", async () => {
@@ -358,7 +426,7 @@ describe("SlackAdapter", () => {
       });
     };
     await instance.start((event) => got.push(event));
-    socket.emit(mention());
+    await socket.emit(mention());
 
     const adding = instance.react(got[0], "👀");
     // Nothing can be removed yet, and not because anything here is holding it back: the
@@ -377,7 +445,7 @@ describe("SlackAdapter", () => {
     const { instance, socket, api } = adapter();
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
-    socket.emit(mention());
+    await socket.emit(mention());
 
     const acknowledged = await instance.react(got[0], "👀");
     await instance.react(got[0], ":tada:");
@@ -405,7 +473,7 @@ describe("SlackAdapter", () => {
     const { instance, socket, api } = adapter();
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
-    socket.emit(mention());
+    await socket.emit(mention());
 
     const first = await instance.react(got[0], "👀");
     api.addReaction = async () => {
@@ -436,7 +504,7 @@ describe("SlackAdapter", () => {
     const { instance, socket, api } = adapter();
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
-    socket.emit(mention());
+    await socket.emit(mention());
 
     await instance.react(got[0], "rocket");
     await instance.react(got[0], ":sparkles:");
@@ -454,7 +522,7 @@ describe("SlackAdapter", () => {
     const got: InboundEvent[] = [];
 
     await instance.start((event) => got.push(event));
-    socket.emit(mention("1786761000.000200"));
+    await socket.emit(mention("1786761000.000200"));
 
     expect(socket.started).toBe(true);
     expect(api.historyCalls).toEqual([
@@ -586,7 +654,7 @@ describe("SlackAdapter", () => {
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
 
-    socket.emit({
+    await socket.emit({
       type: "message",
       channel: "D9001",
       channel_type: "im",
@@ -612,7 +680,7 @@ describe("SlackAdapter", () => {
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
 
-    socket.emit({
+    await socket.emit({
       type: "message",
       channel: "D9001",
       channel_type: "im",
@@ -633,10 +701,10 @@ describe("SlackAdapter", () => {
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
 
-    socket.emit(mention("1786761000.000001"));
+    await socket.emit(mention("1786761000.000001"));
     const acknowledged = await instance.react(got[0], "👀");
     for (let i = 2; i <= 2_100; i++) {
-      socket.emit(mention(`1786761000.${String(i).padStart(6, "0")}`));
+      await socket.emit(mention(`1786761000.${String(i).padStart(6, "0")}`));
     }
 
     await instance.send(got[0].channel, { text: "answer" }, got[0]);
@@ -656,11 +724,11 @@ describe("SlackAdapter", () => {
       const { instance, socket, api } = adapter();
       const got: InboundEvent[] = [];
       await instance.start((event) => got.push(event));
-      socket.emit(mention("1786761000.000001"));
+      await socket.emit(mention("1786761000.000001"));
       const acknowledged = await instance.react(got[0], "👀");
 
       vi.setSystemTime(Date.now() + 60 * 60_000);
-      socket.emit(mention("1786761000.000002"));
+      await socket.emit(mention("1786761000.000002"));
 
       await instance.send(got[0].channel, { text: "worth the wait" }, got[0]);
       await instance.unreact(acknowledged!.ref);
@@ -675,7 +743,7 @@ describe("SlackAdapter", () => {
     const { instance, socket } = adapter();
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
-    socket.emit(mention());
+    await socket.emit(mention());
 
     await expect(
       instance.send({ surface: "slack", id: "GOTHER", isPublic: false }, { text: "hi" }),
@@ -728,7 +796,7 @@ describe("SlackAdapter", () => {
 
     const events: InboundEvent[] = [];
     await instance.start((event) => events.push(event));
-    socket.emit(mention());
+    await socket.emit(mention());
     await Promise.resolve();
 
     expect(events[0]?.channel.isPublic).toBe(true);
@@ -752,7 +820,7 @@ describe("SlackAdapter", () => {
 
     const events: InboundEvent[] = [];
     await instance.start((event) => events.push(event));
-    socket.emit(mention());
+    await socket.emit(mention());
     await Promise.resolve();
 
     expect(events[0]?.channel.isPublic).toBe(false);

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -386,10 +386,11 @@ describe("SlackAdapter", () => {
     const got: InboundEvent[] = [];
     await instance.start((event) => got.push(event));
 
-    // No `users:read`, a deactivated account, another Grid workspace — all the same here.
+    // No `users:read`. Slack reports it on `data.error`, which is how a refusal that will
+    // not change is told apart from a request that merely failed.
     api.userName = async (id: string) => {
       api.nameCalls.push(id);
-      throw new Error("missing_scope");
+      throw Object.assign(new Error("missing_scope"), { data: { error: "missing_scope" } });
     };
     await socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0GHOST>" }));
     await socket.emit(mention("1786761000.000200", { text: "<@UBOT> ask <@U0GHOST> again" }));
@@ -399,6 +400,28 @@ describe("SlackAdapter", () => {
     expect(got.map((event) => event.text)).toEqual(["ask @U0GHOST", "ask @U0GHOST again"]);
     // Asked once. A refusal that is not remembered spends the rate limit re-asking forever.
     expect(api.nameCalls).toEqual(["U0GHOST"]);
+  });
+
+  it("retries a lookup that merely failed, rather than naming by id forever", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    await instance.start((event) => got.push(event));
+
+    // A network fault, not a refusal. `WebClient` retries 429 itself, so what reaches this
+    // is usually of this kind — and `unnamed` is never cleared, so caching it would render
+    // that member by id for the life of the process.
+    let attempts = 0;
+    api.userName = async (id: string) => {
+      api.nameCalls.push(id);
+      attempts += 1;
+      if (attempts === 1) throw new Error("socket hang up");
+      return "alice";
+    };
+    await socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
+    await socket.emit(mention("1786761000.000200", { text: "<@UBOT> ask <@U0ALICE>" }));
+
+    expect(got.map((event) => event.text)).toEqual(["ask @U0ALICE", "ask @alice"]);
+    expect(api.nameCalls).toEqual(["U0ALICE", "U0ALICE"]);
   });
 
   it("delivers in arrival order even when the first message waits on a lookup", async () => {
@@ -529,6 +552,12 @@ describe("SlackAdapter", () => {
     await instance.start((event) => second.push(event));
     await queued;
     expect(second).toEqual([]);
+
+    // Nor a message for this run to thread onto. Read before it hears anything of its own,
+    // since `lastByChannel` keeps the newest and a live message would mask a stale write.
+    await expect(
+      instance.send({ surface: "slack", id: "GENG", isPublic: false }, { text: "ok" }),
+    ).rejects.toThrow(/no inbound context/);
 
     // And that run works normally.
     await socket.emit(mention("1786761000.000200"));

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -718,6 +718,43 @@ describe("SlackAdapter", () => {
     expect(got).toEqual([]);
   });
 
+  it("threads a context-free reply onto the newest message, not the last replayed one", async () => {
+    const { instance, socket, api } = adapter({ since: 1786760000 });
+    const got: InboundEvent[] = [];
+    let release: () => void;
+    let entered: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inHistory = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    api.histories.push({ messages: [mention("1786761000.000100")] });
+    const pages = api.history.bind(api);
+    // `start` connects before it fills the gap, so a live message can arrive while history
+    // is still being collected — and it is newer than everything the replay will contain.
+    api.history = async (args) => {
+      entered();
+      await held;
+      return pages(args);
+    };
+
+    const starting = instance.start((event) => got.push(event));
+    await inHistory;
+    const live = socket.emit(mention("1786761000.000900"));
+    release!();
+    await Promise.all([starting, live]);
+
+    // The replay lands after the live message and is older than it. The reply target is
+    // the latest thing said, not whatever was processed last.
+    expect(got.map((event) => event.id.nativeId)).toEqual([
+      "GENG:1786761000.000900",
+      "GENG:1786761000.000100",
+    ]);
+    await instance.send({ surface: "slack", id: "GENG", isPublic: false }, { text: "ok" });
+    expect(api.posts[0].threadTs).toBe("1786761000.000900");
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -1331,6 +1331,35 @@ describe("SlackAdapter", () => {
     expect(socket.listener).toBeUndefined();
   });
 
+  it("classifies from configuration and this run's answers, not a previous run's", async () => {
+    const { instance, api } = adapter({
+      channels: [
+        { id: "GPRIV", reply: "private" },
+        { id: "CPUB", reply: "public" },
+      ],
+    });
+    // A first run in which Slack contradicts both configured assertions.
+    api.channelIsPrivate = async (channel: string) => channel !== "GPRIV";
+    await instance.start(() => {});
+    expect(instance.postTargets()).toEqual([
+      { surface: "slack", id: "GPRIV", isPublic: true },
+      { surface: "slack", id: "CPUB", isPublic: false },
+    ]);
+    await instance.stop();
+
+    // A second run that cannot ask. Both sets outlive the stop, so without a reset the
+    // answers above still decide — including the one that would let a reply into a channel
+    // configured public.
+    api.channelIsPrivate = async () => {
+      throw new Error("missing_scope");
+    };
+    await instance.start(() => {});
+    expect(instance.postTargets()).toEqual([
+      { surface: "slack", id: "GPRIV", isPublic: false },
+      { surface: "slack", id: "CPUB", isPublic: true },
+    ]);
+  });
+
   it("keeps an explicit is_private:false as false, not unknown", async () => {
     // This is what conversations.info returns for a public channel: is_private false, the
     // IM flags absent. `is_private || is_im || is_mpim` yields undefined for it, laundering

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -502,38 +502,37 @@ describe("SlackAdapter", () => {
     expect(api.posts[0].threadTs).toBe("1786761000.000300");
   });
 
-  it("drops a queued event when the start that heard it fails", async () => {
-    const { instance, socket, api } = adapter();
+  it("delivers nothing from a start that never connected, and not into the next one", async () => {
+    const { instance, socket } = adapter();
     const first: InboundEvent[] = [];
-    let release: () => void;
-    const held = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    // The lookup is what holds the message past the failure. Without one it settles while
-    // `onEvent` is still cleared, and nothing about the run it belongs to is ever tested.
-    api.userName = async () => {
-      await held;
-      return "alice";
-    };
-    // The listener is registered before the connection is up, so an envelope can already be
-    // queued when the start fails.
     let queued: unknown;
+    // The listener is registered before the connection is up, so an envelope can arrive
+    // here. No held lookup and a full drain before the failure, so it has every chance to
+    // complete: if delivery were merely racing the cleanup, this is where it would win.
     socket.start = async () => {
-      queued = socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
+      queued = socket.emit(mention("1786761000.000100"));
+      await new Promise((resolve) => setImmediate(resolve));
       throw new Error("socket mode unavailable");
     };
 
     await expect(instance.start((event) => first.push(event))).rejects.toThrow(/unavailable/);
+    await queued;
 
+    // `start` threw, so the caller believes this adapter never came up. A turn spent
+    // answering under an identity that is not online would make that a lie.
+    expect(first).toEqual([]);
+
+    // Nor does it surface later: the run it belonged to is over, and the next one is not
+    // the same run.
     const second: InboundEvent[] = [];
     socket.start = async () => {};
     await instance.start((event) => second.push(event));
-    release!();
     await queued;
-
-    // It belongs to the run that heard it, and that run never came up.
-    expect(first).toEqual([]);
     expect(second).toEqual([]);
+
+    // And that run works normally.
+    await socket.emit(mention("1786761000.000200"));
+    expect(second.map((event) => event.id.nativeId)).toEqual(["GENG:1786761000.000200"]);
   });
 
   it("abandons a replay when the adapter is stopped mid-backfill", async () => {
@@ -628,9 +627,16 @@ describe("SlackAdapter", () => {
     const held = new Promise<void>((resolve) => {
       release = resolve;
     });
+    let entered: () => void;
+    const inLookup = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
     api.userName = async (id: string) => {
       looked.push(id);
-      if (id === "U0ALICE") await held;
+      if (id === "U0ALICE") {
+        entered();
+        await held;
+      }
       return id.toLowerCase();
     };
     await instance.start((event) => got.push(event));
@@ -640,6 +646,10 @@ describe("SlackAdapter", () => {
     // run actually serving that conversation waits behind.
     const a = socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
     const b = socket.emit(mention("1786761000.000200", { text: "<@UBOT> ask <@U0BOB>" }));
+    // Stopped once the first lookup is genuinely in flight, so the run was live when it
+    // began. Stopping earlier would make both messages stale and prove nothing about the
+    // second one in particular.
+    await inLookup;
     await instance.stop();
     release!();
     await Promise.all([a, b]);

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -644,6 +644,80 @@ describe("SlackAdapter", () => {
     expect(got).toEqual([]);
   });
 
+  it("keeps a sorted replay contiguous when a live message lands mid-backfill", async () => {
+    const { instance, socket, api } = adapter({ since: 1786760000 });
+    const got: InboundEvent[] = [];
+    let release: () => void;
+    let entered: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inLookup = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    api.userName = async () => {
+      entered();
+      await held;
+      return "alice";
+    };
+    // History pages newest-first, so the replay sorts to 000100 then 000200. Only the
+    // first mentions anyone, which is what holds the replay open midway through.
+    api.histories.push({
+      messages: [
+        mention("1786761000.000200"),
+        mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }),
+      ],
+    });
+
+    const starting = instance.start((event) => got.push(event));
+    await inLookup;
+    const live = socket.emit(mention("1786761000.000400"));
+    release!();
+    await Promise.all([starting, live]);
+
+    // The live message must not land between two replayed ones. If it does, the older
+    // replay that follows it is the last thing written to the reply target.
+    expect(got.map((event) => event.id.nativeId)).toEqual([
+      "GENG:1786761000.000100",
+      "GENG:1786761000.000200",
+      "GENG:1786761000.000400",
+    ]);
+    await instance.send({ surface: "slack", id: "GENG", isPublic: false }, { text: "ok" });
+    expect(api.posts[0].threadTs).toBe("1786761000.000400");
+  });
+
+  it("stops enumerating DMs once the run it belongs to has ended", async () => {
+    const { instance, api } = adapter({ since: 1786760000 });
+    const got: InboundEvent[] = [];
+    let release: () => void;
+    let entered: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inDms = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const requested: Array<string | undefined> = [];
+    api.openDirectChannels = async (cursor?: string) => {
+      requested.push(cursor);
+      if (cursor) return { ids: ["DLATE"] };
+      entered();
+      await held;
+      return { ids: ["DALICE"], nextCursor: "page2" };
+    };
+
+    const starting = instance.start((event) => got.push(event));
+    await inDms;
+    await instance.stop();
+    release!();
+    await starting;
+
+    // Enumerating DMs pages like everything else here, and paging for a run that has ended
+    // spends a rate limit the next run needs.
+    expect(requested).toEqual([undefined]);
+    expect(got).toEqual([]);
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -275,6 +275,29 @@ describe("SlackAdapter", () => {
     expect(await instance.readThread!(root!, 0)).toEqual([]);
   });
 
+  it("names mentions in a thread read the same way the inbound path does", async () => {
+    const { instance, api } = adapter();
+    api.names = { U0ALICE: "alice" };
+    await instance.start(() => {});
+    const channel = { surface: "slack", id: "GENG", isPublic: false } as const;
+    const root = await instance.post(channel, { text: "roll call" }, undefined, ["U0DRONE"]);
+
+    api.threads = [
+      {
+        messages: [
+          { type: "message", user: "UBOT", text: "roll call", ts: "1786761001.000200" },
+          { type: "message", user: "U0DRONE", text: "ask <@U0ALICE>", ts: "1786761003.000000" },
+        ],
+      },
+    ];
+
+    // A probe tallying replies must not read a mention differently from the channel it is
+    // reading — sharing the directory without filling it is what made the two disagree.
+    const replies = await instance.readThread!(root!);
+    expect(replies.map((reply) => reply.text)).toEqual(["ask @alice"]);
+    expect(api.nameCalls).toEqual(["U0ALICE"]);
+  });
+
   it("refuses a thread read it cannot answer, rather than reporting an empty thread", async () => {
     const { instance, api } = adapter();
     const root = { surface: "slack", nativeId: "GENG:1786761001.000200" } as const;

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -571,6 +571,79 @@ describe("SlackAdapter", () => {
     expect(second).toEqual([]);
   });
 
+  it("stops paging and starting reply walks once the run it belongs to has ended", async () => {
+    const { instance, api } = adapter({ since: 1786760000 });
+    const first: InboundEvent[] = [];
+    let release: () => void;
+    let entered: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inHistory = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const requested: Array<string | undefined> = [];
+    api.history = async (args) => {
+      requested.push(args.cursor);
+      if (args.cursor) return {};
+      entered();
+      await held;
+      // A page with more behind it, held until the run that asked for it has ended.
+      return {
+        messages: [
+          mention("1786761000.000100", {
+            text: "<@UBOT> ask <@U0ALICE>",
+            thread_ts: "1786761000.000100",
+            latest_reply: "1786761000.000300",
+          }),
+        ],
+        nextCursor: "page2",
+      };
+    };
+
+    const starting = instance.start((event) => first.push(event));
+    await inHistory;
+    await instance.stop();
+    release!();
+    await starting;
+
+    // Paging to the end of a gap on behalf of a run that has ended is work nobody asked
+    // for, against a rate limit the next run needs.
+    expect(requested).toEqual([undefined]);
+    // Nor is a reply walk started for a thread that moved: the page said so, but the run
+    // that would have read it is over.
+    expect(api.replyCalls).toEqual([]);
+    expect(first).toEqual([]);
+  });
+
+  it("spends no lookup on a message already stale when its turn comes", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    const looked: string[] = [];
+    let release: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    api.userName = async (id: string) => {
+      looked.push(id);
+      if (id === "U0ALICE") await held;
+      return id.toLowerCase();
+    };
+    await instance.start((event) => got.push(event));
+
+    // Same conversation, so the second waits behind the first. By the time its turn comes
+    // the run is over — and a chain is per conversation, so a lookup it spends is one the
+    // run actually serving that conversation waits behind.
+    const a = socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
+    const b = socket.emit(mention("1786761000.000200", { text: "<@UBOT> ask <@U0BOB>" }));
+    await instance.stop();
+    release!();
+    await Promise.all([a, b]);
+
+    expect(looked).toEqual(["U0ALICE"]);
+    expect(got).toEqual([]);
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -399,6 +399,82 @@ describe("SlackAdapter", () => {
     expect(got.map((event) => event.text)).toEqual(["ask @alice", "second"]);
   });
 
+  it("believes the directory over a label the sending client embedded", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    api.names = { U0ALICE: "alice" };
+    await instance.start((event) => got.push(event));
+
+    // The two disagree after a rename. On the reading that a label decides, the brain is
+    // told a different person was named than the one Slack will actually notify.
+    await socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE|bob>" }));
+    // With nothing in the directory the label is still better than the bare id.
+    await socket.emit(mention("1786761000.000200", { text: "<@UBOT> and <@U0CAROL|carol>" }));
+
+    expect(got.map((event) => event.text)).toEqual(["ask @alice", "and @carol"]);
+  });
+
+  it("does not let one conversation's lookups hold up another's", async () => {
+    const { instance, socket, api } = adapter({
+      channels: [
+        { id: "GENG", reply: "private" },
+        { id: "GOPS", reply: "private" },
+      ],
+    });
+    const got: InboundEvent[] = [];
+    await instance.start((event) => got.push(event));
+
+    let release: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    api.userName = async () => {
+      await held;
+      return "alice";
+    };
+    // GENG is stuck on a lookup. GOPS mentions nobody and must not wait behind it —
+    // ordering is what `ChannelQueue` needs per channel, and it runs channels in parallel.
+    const stuck = socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
+    await socket.emit({ ...mention("1786761000.000200"), channel: "GOPS" });
+
+    expect(got.map((event) => event.channel.id)).toEqual(["GOPS"]);
+    release!();
+    await stuck;
+    expect(got.map((event) => event.channel.id)).toEqual(["GOPS", "GENG"]);
+  });
+
+  it("drops a message still resolving when the adapter is stopped", async () => {
+    const { instance, socket, api } = adapter();
+    const first: InboundEvent[] = [];
+    await instance.start((event) => first.push(event));
+
+    let release: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    api.userName = async () => {
+      await held;
+      return "alice";
+    };
+    const inFlight = socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
+
+    // Stopped and restarted while that lookup is outstanding. The queued message belongs to
+    // the run that heard it: delivering it to the new session's callback would answer a
+    // question from before the restart, and leave its reply target behind in `lastByChannel`.
+    await instance.stop();
+    const second: InboundEvent[] = [];
+    await instance.start((event) => second.push(event));
+    release!();
+    await inFlight;
+
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+    // The new run still works, and threads onto its own message rather than the dropped one.
+    await socket.emit(mention("1786761000.000300"));
+    await instance.send({ surface: "slack", id: "GENG", isPublic: false }, { text: "ok" });
+    expect(api.posts[0].threadTs).toBe("1786761000.000300");
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -32,7 +32,11 @@ class FakeSocket implements SlackSocketClient {
 
   /** Answers when the adapter has finished with the envelope: delivery is not synchronous. */
   emit(event: Record<string, unknown>, ack = async () => {}): unknown {
-    return this.listener?.({ type: "events_api", body: { event }, ack });
+    // Not optional chaining. An emit with nobody subscribed answers `undefined`, and the
+    // lifecycle tests here assert on an empty result — so a subscription that quietly went
+    // missing would read as the adapter correctly declining to deliver.
+    if (!this.listener) throw new Error("emit with no socket listener installed");
+    return this.listener({ type: "events_api", body: { event }, ack });
   }
 }
 

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -12,6 +12,8 @@ import {
 class FakeSocket implements SlackSocketClient {
   listener?: (payload: unknown) => void;
   started = false;
+  /** Connect attempts, so a stale run opening a second one is visible. */
+  starts = 0;
   disconnected = false;
 
   on(_event: string, listener: (payload: unknown) => void): void {
@@ -24,6 +26,7 @@ class FakeSocket implements SlackSocketClient {
 
   async start(): Promise<void> {
     this.started = true;
+    this.starts += 1;
   }
 
   async disconnect(): Promise<void> {
@@ -563,6 +566,66 @@ describe("SlackAdapter", () => {
     await socket.emit(mention("1786761000.000200"));
     expect(second.map((event) => event.id.nativeId)).toEqual(["GENG:1786761000.000200"]);
   });
+
+  // `start` claims nothing until each of these answers, so a `stop` while one is in flight
+  // has to leave the call that made it unable to take the adapter over.
+  const heldStartCases: Array<[string, (api: FakeApi, gate: () => Promise<void>) => void]> = [
+    [
+      "authTest",
+      (api, gate) => {
+        const real = api.authTest.bind(api);
+        api.authTest = async () => {
+          await gate();
+          return real();
+        };
+      },
+    ],
+    [
+      "channelIsPrivate",
+      (api, gate) => {
+        const real = api.channelIsPrivate.bind(api);
+        api.channelIsPrivate = async (channel: string) => {
+          await gate();
+          return real(channel);
+        };
+      },
+    ],
+  ];
+
+  for (const [call, install] of heldStartCases) {
+    it(`does not let a start held in ${call} take over the run that replaced it`, async () => {
+      const { instance, socket, api } = adapter();
+      let release!: () => void;
+      let arrived!: () => void;
+      const blocked = new Promise<void>((resolve) => (release = resolve));
+      const inCall = new Promise<void>((resolve) => (arrived = resolve));
+      let held = false;
+      install(api, async () => {
+        if (held) return; // only the first run waits; the replacement runs through
+        held = true;
+        arrived();
+        await blocked;
+      });
+
+      const first: InboundEvent[] = [];
+      const starting = instance.start((event) => first.push(event));
+      await inCall;
+      await instance.stop();
+
+      const second: InboundEvent[] = [];
+      await instance.start((event) => second.push(event));
+      const connects = socket.starts;
+
+      release();
+      await starting;
+
+      // It must not have taken the callback, nor connected a socket of its own.
+      await socket.emit(mention());
+      expect(first).toEqual([]);
+      expect(second.map((event) => event.id.nativeId)).toEqual(["GENG:1786761000.000100"]);
+      expect(socket.starts).toBe(connects);
+    });
+  }
 
   it("does not let a stale start open the gate of the run that replaced it", async () => {
     const { instance, socket } = adapter();

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -564,6 +564,78 @@ describe("SlackAdapter", () => {
     expect(second.map((event) => event.id.nativeId)).toEqual(["GENG:1786761000.000200"]);
   });
 
+  it("does not let a stale start open the gate of the run that replaced it", async () => {
+    const { instance, socket } = adapter();
+    const gate = (signal: { at: () => void; release: Promise<void> }) => async () => {
+      signal.at();
+      await signal.release;
+    };
+    const make = () => {
+      let at!: () => void;
+      let go!: () => void;
+      const arrived = new Promise<void>((r) => (at = r));
+      const release = new Promise<void>((r) => (go = r));
+      return { at, go, arrived, release };
+    };
+
+    const one = make();
+    const two = make();
+    socket.start = gate(one);
+    const first: InboundEvent[] = [];
+    const starting = instance.start((event) => first.push(event));
+    await one.arrived;
+    await instance.stop();
+
+    socket.start = gate(two);
+    const second: InboundEvent[] = [];
+    const restarting = instance.start((event) => second.push(event));
+    await two.arrived;
+    const queued = socket.emit(mention("1786761000.000100"));
+
+    // The first run connects late. Its `releaseSocket` is the field the second run just
+    // overwrote, so without a check it opens a gate belonging to a connection that is
+    // still pending.
+    one.go();
+    await starting;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(second).toEqual([]);
+
+    two.go();
+    await restarting;
+    await queued;
+    expect(second.map((event) => event.id.nativeId)).toEqual(["GENG:1786761000.000100"]);
+  });
+
+  it("does not let a stale start tear down the run that replaced it", async () => {
+    const { instance, socket } = adapter();
+    let failFirst!: (error: Error) => void;
+    const firstConnect = new Promise<void>((_resolve, reject) => (failFirst = reject));
+    let arrived!: () => void;
+    const atFirstConnect = new Promise<void>((r) => (arrived = r));
+    socket.start = async () => {
+      arrived();
+      await firstConnect;
+    };
+
+    const first: InboundEvent[] = [];
+    const starting = instance.start((event) => first.push(event));
+    await atFirstConnect;
+    await instance.stop();
+
+    socket.start = async () => {};
+    const second: InboundEvent[] = [];
+    await instance.start((event) => second.push(event));
+
+    // The first run fails after the second is up. Its cleanup would otherwise unsubscribe
+    // the listener, clear the callback, invalidate the generation and disconnect — all of
+    // them the second run's.
+    failFirst(new Error("socket mode unavailable"));
+    await expect(starting).rejects.toThrow(/unavailable/);
+
+    await socket.emit(mention("1786761000.000200"));
+    expect(second.map((event) => event.id.nativeId)).toEqual(["GENG:1786761000.000200"]);
+  });
+
   it("abandons a replay when the adapter is stopped mid-backfill", async () => {
     const { instance, api } = adapter({ since: 1786760000 });
     const first: InboundEvent[] = [];

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -498,6 +498,79 @@ describe("SlackAdapter", () => {
     expect(api.posts[0].threadTs).toBe("1786761000.000300");
   });
 
+  it("drops a queued event when the start that heard it fails", async () => {
+    const { instance, socket, api } = adapter();
+    const first: InboundEvent[] = [];
+    let release: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // The lookup is what holds the message past the failure. Without one it settles while
+    // `onEvent` is still cleared, and nothing about the run it belongs to is ever tested.
+    api.userName = async () => {
+      await held;
+      return "alice";
+    };
+    // The listener is registered before the connection is up, so an envelope can already be
+    // queued when the start fails.
+    let queued: unknown;
+    socket.start = async () => {
+      queued = socket.emit(mention("1786761000.000100", { text: "<@UBOT> ask <@U0ALICE>" }));
+      throw new Error("socket mode unavailable");
+    };
+
+    await expect(instance.start((event) => first.push(event))).rejects.toThrow(/unavailable/);
+
+    const second: InboundEvent[] = [];
+    socket.start = async () => {};
+    await instance.start((event) => second.push(event));
+    release!();
+    await queued;
+
+    // It belongs to the run that heard it, and that run never came up.
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+  });
+
+  it("abandons a replay when the adapter is stopped mid-backfill", async () => {
+    const { instance, api } = adapter({ since: 1786760000 });
+    const first: InboundEvent[] = [];
+    let release: () => void;
+    let entered: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inHistory = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    api.histories.push({ messages: [mention("1786761000.000100")] });
+    const pages = api.history.bind(api);
+    // Held *before* the replay is queued, which is the window that matters: a stop landing
+    // here means the messages this page turns into were never queued by a live run.
+    api.history = async (args) => {
+      entered();
+      await held;
+      return pages(args);
+    };
+
+    const starting = instance.start((event) => first.push(event));
+    await inHistory;
+    await instance.stop();
+
+    // The restart backfills nothing of its own, so anything the second run hears came from
+    // the replay the first run abandoned.
+    const second: InboundEvent[] = [];
+    api.history = async () => ({});
+    await instance.start((event) => second.push(event));
+    release!();
+    await starting;
+
+    // The replay belongs to the run that asked for it. Delivering it into the next run
+    // would answer a message from before the restart, and thread onto it afterwards.
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a05f41-18b6-77a5-b31f-c3d37acd512e">Session</a>
<!-- /sageox:pr-header -->

Slack puts mentions in message text as `<@U0ALICE>`. `normalizeSlackText` stripped the
bot's own and left everyone else's as raw wire encoding, so a brain could see that somebody
had been addressed and **not who** — it answered about an id, and had no way to tell that
`<@U0ALICE>` twice was one person rather than two.

Member ids now resolve through `users.info` and render as `@alice`, preferring the label
Slack supplies when there is one.

## The consequence worth reviewing: inbound delivery is now asynchronous

Resolving a name is a network call, so `accept` has to be able to wait. Two messages waiting
concurrently would be delivered in whichever order Slack answered about their mentions — and
`ChannelQueue` preserves the order it is submitted in, so that scrambling reaches the brain:
the agent answers the second question first, and a reply with no inbound context threads onto
the wrong message.

Normalization therefore runs one message at a time through a promise chain. It idles once the
people in a conversation are cached. There is a test that fails without the chain.

`handleEnvelope` now answers when its envelope has been delivered. The ack is deliberately
*not* part of that promise — Slack retries an envelope that waits, so it still goes first and
alone. That is also what let the existing tests become `await socket.emit(...)` rather than
sleep on a timer.

**The alternative I rejected:** pull `users.list` at boot and keep delivery synchronous. It
spends a large workspace's entire member table to answer about the handful of people who
actually speak, and still misses anyone who joins later. Happy to switch if you'd rather have
synchronous delivery.

## Degradation

| Situation | Behaviour |
|---|---|
| No `users:read` | Every mention renders as its id — exactly what it did before |
| Slack won't name an id | Remembered, so it costs one call rather than one per message |
| Unnamed mention | Still reads as a mention; dropping it would lose that somebody was named |

## Security

The rendered form is text, not markup, so quoting it back addresses nobody. That is the
property `outboundText` already kept by escaping (#6) — it now holds one step earlier as
well, since the markup never reaches the brain at all.

The #6 test changed rather than disappeared, and now asserts **both** halves: the mention
reaches the brain as a name, *and* what the brain sends is escaped regardless.

## Verification

`pnpm typecheck` and `pnpm test` green — 1076 tests, 63 files.

Each new test was checked to fail without its change:

| Test | Fails without |
|---|---|
| names the members a message mentions, and asks Slack about each one once | the directory reaching normalization |
| keeps a mention Slack will not name, and stops asking about it | the negative cache |
| delivers in arrival order even when the first message waits on a lookup | the ordering chain |

## Not in this PR

Channel refs (`<#C0123|general>`) and links (`<https://x|label>`) still reach the brain as
Slack wire encoding. Same root cause, but they carry their own label so they need no lookup
and no async — a separate, much smaller change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a05f41-18b6-77a5-b31f-c3d37acd512e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790897205&installation_model_id=433550&pr_number=12&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F12&signature=f7aabc9100366f45c6b0058aa9629660f296e5d40413f10a0a65e3e66510b1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slack mentions now display readable member names when available, including in threads.
  - Messages are processed in arrival order within each conversation.
  - Member-name lookups are cached to improve consistency and reduce repeated requests.

- **Bug Fixes**
  - Added fallback handling and caching when member details cannot be retrieved.
  - Improved escaping for message text.
  - Prevented stale messages from being delivered after a restart or failed startup.

- **Documentation**
  - Updated Slack setup guidance to include the required `users:read` permission and explain behavior without it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->