### PR TITLE
Escape a Slack broadcast and log it, instead of killing the turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A broadcast in a Slack message is escaped and logged instead of throwing, so the turn
+  ends in an answer.** `SlackAdapter.outboundText` refused `<!channel>` by throwing, and
+  `SurfaceEgress.reply` does not catch around `send` — so the throw left `drive`, ended the
+  turn, and the withdrawn acknowledgement left the channel watching the glyph appear and
+  vanish with no reply. The brain was never told what happened. That refusal predates the
+  outbound escaping this release also ships and was the only thing keeping a broadcast off
+  the wire; `&lt;!channel&gt;` now renders as those characters and notifies nobody, so the
+  refusal bought no reach and cost the turn. Every attempt still gets one line an operator
+  can act on — `egress_escaped surface=slack channel=… rule=slackBroadcast`, the shape
+  `egress_blocked` already logs. The sharper half was that `normalizeSlackText` un-escapes
+  inbound text, so somebody *typing* the characters `<!channel>` reached the brain as
+  markup: quoting a message that merely discussed Slack broadcasts killed the turn over one
+  nobody sent. The un-escape is unchanged, because the round trip is symmetric now — what
+  the brain reads as characters goes back out as characters, and `mentions` remains the only
+  way a Slack message addresses anyone.
+
 - **A job a person asks for runs, even when its kill switch is parked.** `job_run` records
   the author of the message the agent is answering, so a request that arrives through a chat
   surface is the human on-request run the host has always described — it has refused with
@@ -101,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent enough to page whoever it named: through none of the id validation `mentions` gets,
   and recorded on the audit line as `mentions=0`. The recipients the adapter builds from
   `mentions` are still markup — the one part of an outbound message it constructs itself.
-  The bulk-mention refusal is unchanged: `<!channel>` is refused, not rendered.
+  Escaping also takes the reach of `<!channel>`, which is what let its refusal go.
 
 ## [0.1.0] - 2026-08-31
 

--- a/docs/guide/chat-surfaces.md
+++ b/docs/guide/chat-surfaces.md
@@ -490,9 +490,11 @@ not a guess worth making on your behalf.
 
 The requested message is posted top-level in the destination, and the agent's ordinary
 response confirms the result back in the conversation where the request originated.
-Unknown channels, unconsented public channels, and Slack bulk mentions are refused. Slack
-mention markup written into the text is neither refused nor honoured: it renders as the
-characters the agent typed, so a cross-post notifies nobody it names.
+Unknown channels and unconsented public channels are refused. Slack markup written into the
+text is neither refused nor honoured: `<@U0ALICE>` and `<!channel>` alike render as the
+characters the agent typed, so a cross-post notifies nobody it names. A broadcast shape in
+the text is logged as `egress_escaped … rule=slackBroadcast` rather than refused — escaping
+already takes its reach, and refusing cost the turn.
 Cross-posts never reuse an unrelated message as a fake thread parent.
 
 ### Let the agent react with an emoji

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -235,7 +235,7 @@ export class SlackAdapter implements SurfaceAdapter {
     const target = inReplyTo ? contextOf(inReplyTo) : this.lastByChannel.get(channel.id);
     if (!target) throw new Error(`no inbound context for Slack channel ${channel.id}`);
 
-    const text = this.outboundText(msg);
+    const text = this.outboundText(msg, channel.id);
 
     // In a channel, threading the answer onto the question is what keeps the channel
     // readable. A 1:1 DM has nothing to keep tidy, and a threaded answer there hides
@@ -263,7 +263,7 @@ export class SlackAdapter implements SurfaceAdapter {
   ): Promise<EventRef | undefined> {
     if (!this.started) throw new Error("SlackAdapter.start() must be called before post()");
     this.assertChannel(channel);
-    const text = this.outboundText(msg);
+    const text = this.outboundText(msg, channel.id);
 
     // A Slack `ts` is unique only within a conversation, so an anchor from a different
     // channel names a real message somewhere else — and `thread_ts` pointing at one starts
@@ -551,26 +551,33 @@ export class SlackAdapter implements SurfaceAdapter {
   }
 
   /**
-   * The brain's text, screened and then written as Slack's encoding of those same
-   * characters. Both outbound paths go through it, so neither can screen without encoding.
+   * The brain's text, written as Slack's encoding of those same characters. Both outbound
+   * paths go through it, so neither can send without encoding.
    *
-   * A broadcast is refused rather than encoded. `GuardedMessage` cannot represent one, and
-   * `<!channel>` in text is the way back through that boundary; waking every member of the
-   * channel is worth failing the turn over rather than delivering as literal text.
+   * Escaping is the half of `normalizeSlackText` that was missing. That function un-escapes
+   * `&lt;`, `&gt;` and `&amp;` on the way in, so the brain reads characters and never
+   * Slack's encoding — but with no encoder on the way out the round trip is not symmetric,
+   * and text that reached the brain carrying `<@U0ALICE>` went back out as live markup and
+   * notified that member. Quoting the message that woke the agent is ordinary and must not
+   * be an act of addressing. Addressing is `mentions`, whose ids {@link address} validates
+   * and whose count the `post_message` audit line carries.
    *
-   * The rest is escaped, which is the half of `normalizeSlackText` that was missing. That
-   * function un-escapes `&lt;`, `&gt;` and `&amp;` on the way in, so the brain reads
-   * characters and never Slack's encoding — but with no encoder on the way out the round
-   * trip is not symmetric, and text that reached the brain carrying `<@U0ALICE>` went back
-   * out as live markup and notified that member. Quoting the message that woke the agent is
-   * ordinary and must not be an act of addressing. Addressing is `mentions`, whose ids
-   * {@link address} validates and whose count the `post_message` audit line carries.
+   * A broadcast is escaped by those same replacements and logged rather than refused.
+   * `&lt;!channel&gt;` renders as characters and notifies nobody, so the throw that stood
+   * here bought no reach and cost the whole turn: `SurfaceEgress.reply` does not catch
+   * around `send`, so it left `drive` and the channel saw the acknowledgement appear and
+   * vanish with no answer. The brain also reads `<!channel>` from somebody who merely typed
+   * those characters — `normalizeSlackText` un-escapes the `&lt;!channel&gt;` Slack sent —
+   * so quoting either form is an answer and one `egress_escaped` line, not a dead turn.
    *
    * `&` is replaced first, or it escapes the ampersands the other two introduce.
    */
-  private outboundText(msg: GuardedMessage): string {
+  private outboundText(msg: GuardedMessage, channel: string): string {
     if (/<!\s*(?:channel|here|everyone)(?:\^[^>]*)?>/i.test(msg.text)) {
-      throw new Error("Slack bulk mentions are not supported");
+      console.warn(
+        `egress_escaped surface=${SLACK_SURFACE} channel=${channel} rule=slackBroadcast ` +
+          `reason="the text carried a broadcast, escaped to characters that notify nobody"`,
+      );
     }
     return msg.text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
   }
@@ -720,10 +727,10 @@ const SLACK_EMOJI_NAME = /^[a-z0-9_+'-]+$/;
  * Anchored and closed over the alphabet Slack actually issues, which is what makes the
  * mention below safe to build by concatenation: a value carrying `>` would otherwise close
  * the `<@…>` it was put inside and let the rest of it read as markup — `<!channel>` among
- * the things it could then be, which is the broadcast `outboundText` refuses in `text` and
- * which must not have a second way in. This prefix is the one part of an outbound message
- * the adapter builds itself, so it is the one part that is not escaped. The bound is
- * generous; Slack ids are 9–11 characters.
+ * the things it could then be, which `outboundText` escapes in `text`. This prefix is the
+ * one part of an outbound message the adapter builds itself, so it is the one part that is
+ * not escaped — which makes this check the only thing keeping a live broadcast off the
+ * wire. The bound is generous; Slack ids are 9–11 characters.
  */
 const SLACK_MEMBER_ID = /^[UWB][A-Z0-9]{1,31}$/;
 

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -331,6 +331,42 @@ describe("SlackAdapter", () => {
     expect(api.posts[1].text).toBe("<@U0DRONE> who is &lt;@U0ALICE&gt;?");
   });
 
+  it("escapes a broadcast in the brain's text and logs it, rather than killing the turn", async () => {
+    const logged: string[] = [];
+    const warn = vi.spyOn(console, "warn").mockImplementation((line) => void logged.push(String(line)));
+    try {
+      const { instance, socket, api } = adapter();
+      const got: InboundEvent[] = [];
+      await instance.start((event) => got.push(event));
+      // Somebody used `@channel`, which Slack delivers as live markup.
+      socket.emit(mention("1786761000.000100", { text: "<@UBOT> <!channel> deploy now" }));
+      // Somebody typed those characters, which Slack escapes on the wire and
+      // `normalizeSlackText` un-escapes — so the brain reads a broadcast nobody sent.
+      socket.emit(mention("1786761000.000200", { text: "<@UBOT> what does &lt;!channel&gt; do?" }));
+      expect(got.map((event) => event.text)).toEqual([
+        "<!channel> deploy now",
+        "what does <!channel> do?",
+      ]);
+
+      // Quoting either one answers. Refusing threw out of `SurfaceEgress.reply`, which does
+      // not catch around `send`, so the turn ended and the channel saw the acknowledgement
+      // appear and vanish with no reply.
+      for (const event of got) await instance.send(event.channel, { text: event.text }, event);
+      expect(api.posts.map((post) => post.text)).toEqual([
+        "&lt;!channel&gt; deploy now",
+        "what does &lt;!channel&gt; do?",
+      ]);
+
+      // Still one line per attempt, naming a rule, which is what an operator acts on.
+      expect(logged).toEqual([
+        expect.stringContaining("egress_escaped surface=slack channel=GENG rule=slackBroadcast"),
+        expect.stringContaining("egress_escaped surface=slack channel=GENG rule=slackBroadcast"),
+      ]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("refuses a top-level post to an unconfigured channel", async () => {
     const { instance, api } = adapter();
     await instance.start(() => {});
@@ -338,12 +374,6 @@ describe("SlackAdapter", () => {
     await expect(
       instance.post({ surface: "slack", id: "GOTHER", isPublic: false }, { text: "no" }),
     ).rejects.toThrow(/not configured/i);
-    await expect(
-      instance.post(
-        { surface: "slack", id: "GENG", isPublic: false },
-        { text: "hello <!channel>" },
-      ),
-    ).rejects.toThrow(/bulk mentions/i);
     expect(api.posts).toHaveLength(0);
   });
 
@@ -671,11 +701,9 @@ describe("SlackAdapter", () => {
     }
   });
 
-  it("refuses unconfigured channels and Slack-native bulk mentions", async () => {
-    const { instance, socket } = adapter();
-    const got: InboundEvent[] = [];
-    await instance.start((event) => got.push(event));
-    socket.emit(mention());
+  it("refuses unconfigured channels", async () => {
+    const { instance } = adapter();
+    await instance.start(() => {});
 
     await expect(
       instance.send({ surface: "slack", id: "GOTHER", isPublic: false }, { text: "hi" }),
@@ -684,9 +712,6 @@ describe("SlackAdapter", () => {
     await expect(
       instance.send({ surface: "slack", id: "D404", isPublic: false }, { text: "hi" }),
     ).rejects.toThrow(/not configured/);
-    await expect(instance.send(got[0].channel, { text: "hello <!channel>" })).rejects.toThrow(
-      /bulk mentions/,
-    );
   });
 
   it("disconnects cleanly", async () => {

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -357,11 +357,18 @@ describe("SlackAdapter", () => {
         "what does &lt;!channel&gt; do?",
       ]);
 
+      // `post` lost the same throw, and it is the path where the recipients the adapter
+      // builds sit unescaped beside the brain's text — so the broadcast has to stay escaped
+      // next to live markup, and reach exactly the one member `mentions` names.
+      await instance.post(got[0].channel, { text: "shipped <!channel>" }, undefined, ["U0DRONE"]);
+      expect(api.posts[2].text).toBe("<@U0DRONE> shipped &lt;!channel&gt;");
+
       // Still one line per attempt, naming a rule, which is what an operator acts on.
-      expect(logged).toEqual([
-        expect.stringContaining("egress_escaped surface=slack channel=GENG rule=slackBroadcast"),
-        expect.stringContaining("egress_escaped surface=slack channel=GENG rule=slackBroadcast"),
-      ]);
+      expect(logged).toEqual(
+        Array(3).fill(
+          expect.stringContaining("egress_escaped surface=slack channel=GENG rule=slackBroadcast"),
+        ),
+      );
     } finally {
       warn.mockRestore();
     }

--- a/packages/core/src/guard.ts
+++ b/packages/core/src/guard.ts
@@ -62,9 +62,9 @@ export function strings(value: unknown): string[] {
  * Attachments and broadcasts need no rule here: `GuardedMessage` cannot represent
  * either, so the type refuses them structurally. Where a surface encodes them in the
  * message text instead of in a field of its own, keeping that refusal true is the
- * adapter's job and not this function's: `SlackAdapter.outboundText` refuses `<!channel>`
- * and escapes the rest, so `<@U0ALICE>` in text renders as those characters rather than
- * notifying that member.
+ * adapter's job and not this function's: `SlackAdapter.outboundText` escapes `&`, `<` and
+ * `>`, so `<@U0ALICE>` and `<!channel>` in text render as those characters rather than
+ * notifying anyone.
  */
 export function evaluateEgress(
   msg: GuardedMessage,


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a05f61-5b9f-7d23-a1f6-2edf560e4fc6">Session</a>
<!-- /sageox:pr-header -->

Closes #5.

## What was wrong

`SlackAdapter.outboundText` refused `<!channel>` by throwing. `SurfaceEgress.reply` does not
catch around `adapter.send`, so that throw left `drive`, left `runTurn`, and landed in
`handle`'s catch — the turn was over. `stopSignalling()` in the `finally` withdrew the
acknowledgement emoji, so the channel saw the glyph appear, then vanish, and no answer
arrived. The brain was never told what happened, and never got the chance to rephrase that
the same refusal would have given it one layer up through `GuardFeedback`.

The sharp part is what reaches the refusal. `normalizeSlackText` un-escapes inbound text, so
somebody *typing* the characters `<!channel>` — discussing Slack markup, pasting a snippet —
arrives at the brain as `<!channel>` that was never a broadcast on the wire. Quoting it ended
the turn over punctuation nobody wrote.

## What this does

Takes option 2 from the issue: escape it like everything else, and log.

```
egress_escaped surface=slack channel=GENG rule=slackBroadcast reason="…"
```

The reasoning, against the three design questions the issue asks:

**Why not feed it back into the guard loop (Q1).** There is nothing to tell the brain. Its
message goes out whole and renders exactly the characters it wrote. Feedback would be a
refusal notice for something that was not refused, and it would need a new typed-error seam
through `SurfaceEgress.reply` to distinguish "the adapter refuses this" from "the transport
failed" — more machinery than the problem has.

**Why escaping is enough on reach (Q2).** Escaping *is* the enforcement, and it predates
nothing: it landed in #4. `&lt;!channel&gt;` renders as those seven characters and notifies
nobody. The throw was the enforcement only before that, when unescaped text went out live.
What was left was a signal delivered by destroying the turn — and `egress_blocked` already
proves a loud one-line signal does not have to cost the turn. So: same shape of line, same
place an operator already looks, no failure.

**Why the un-escape is left alone (Q3).** Once the throw is gone, path 2 is harmless: the
brain reads characters, and those characters go back out as characters. The round trip is
symmetric. Narrowing `normalizeSlackText` would make the brain read Slack's encoding for one
special case, which is the thing that function exists to spare it.

One knock-on worth naming: the `mentions` prefix `address()` builds is the only unescaped
part of an outbound message, so `SLACK_MEMBER_ID` is now the *only* thing keeping a live
`<!channel>` off the wire. Its comment says so.

## Against the acceptance criteria

- **Answers or is told why, never loses the turn.** New test drives both forms — live
  `<!channel>` markup and a typed `&lt;!channel&gt;` Slack escaped on the wire — through
  normalization and back out via `send`. Both answer.
- **One line, with a rule name.** `egress_escaped … rule=slackBroadcast`, asserted per
  attempt in the same test.
- **Nothing notifies more people than `mentions` names.** The posted text is asserted as
  `&lt;!channel&gt; deploy now`. #4's line holds.

The test fails on `Error: Slack bulk mentions are not supported` without the change.

`pnpm test` (1079 passed) and `pnpm typecheck` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a05f61-5b9f-7d23-a1f6-2edf560e4fc6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790899020&installation_model_id=433550&pr_number=13&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F13&signature=0b169745122ec68b8d9a6dae7e248fedfce1ac86bfe99db162d34b3a428b5978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Slack messages containing broadcast markup such as `<!channel>` are now safely escaped instead of causing delivery failures.
  - Broadcast-style text no longer notifies recipients, allowing affected turns to complete normally.
  - Ordinary special characters continue to render safely.

- **Documentation**
  - Clarified Slack mention behavior, cross-posting, and outbound message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->