### PR TITLE
Bump the agent base image's pinned `ox` to 0.14.3

### DIFF
--- a/.claude/commands/ox-conversation.md
+++ b/.claude/commands/ox-conversation.md
@@ -1,0 +1,14 @@
+<!-- ox-hash: 6bdc2bd3da8e ver: 0.14.3 -->
+<!-- Keep this file thin. Behavioral guidance (disclosure ladder, id forms,
+     pinning, errors) belongs in the ox CLI JSON output (guidance field) and
+     `ox guide conversations`, not here.
+     Skills are agent-specific wrappers; ox serves all agents (Codex, etc.). -->
+Read recorded team conversations locally: list, summaries, distillation topics, and transcript slices.
+
+## Steps
+
+Run `ox conversation $ARGUMENTS` (or `ox conversation list` if no arguments
+are given), then present the results. Follow the JSON `guidance` field to
+descend the disclosure ladder (`show` → `topics` → `topic` → `transcript`);
+a full `sageox://` citation URI (quoted) works as an id and retrieves the
+cited transcript slice. Full workflow: `ox guide conversations`.

--- a/.claude/commands/ox.md
+++ b/.claude/commands/ox.md
@@ -1,4 +1,4 @@
-<!-- ox-hash: 31dd5815b853 ver: 0.12.0 -->
+<!-- ox-hash: 22568b2f4841 ver: 0.14.3 -->
 # SageOx Commands Reference
 
 Essential ox commands for team context:
@@ -45,6 +45,37 @@ Record agent sessions to the project ledger for team visibility.
 ox doctor
 ```
 Run diagnostic checks on SageOx configuration and integrations.
+
+## Search Code, History, PRs
+
+`ox code` queries the local CodeDB index. Reach for it before grep/ripgrep on this repo.
+
+Verb-mode (preferred):
+
+```bash
+ox code defs <name>                       # where is <name> defined?
+ox code callers <name>                    # who calls <name>? (resolved call graph)
+ox code callees <name> --depth 2          # what <name> calls (transitive)
+ox code refs <name> [--lang go]           # text references
+ox code log <path> [--author X --after YYYY-MM-DD]  # commits touching path
+ox code prs --sort stalled                # PR triage
+ox code activity --since 7d               # recent GitHub events
+ox code insights                          # hotspots, contention, open PRs/issues
+ox code status                            # index health
+```
+
+DSL-mode (when verbs don't fit):
+
+```bash
+ox code search "<text>" type:pr                   # indexed PR titles/bodies/comments
+ox code search "<text>" type:comment ckind:todo   # source comments by kind
+ox code search "<text>" author:<n> after:<date>   # git history + content together
+ox code search "/<regex>/"                        # forced regex
+```
+
+DSL: `type:{code,symbol,diff,commit,comment,pr,issue}`, `repo:`, `file:`, `lang:`, `author:`, `before:`/`after:`, `message:`, `calls:`/`calledby:`, `depth:`, `confidence:{extracted,inferred,ambiguous}`, `ckind:`, `state:`, `OR`, `/regex/`. Negate any filter with `-` prefix.
+
+Fall back to grep only for exact-string matches in a known file or when `ox code` returns 0 results.
 
 ---
 Run `ox --help` for full command list.

--- a/.sageox/README.md
+++ b/.sageox/README.md
@@ -4,12 +4,6 @@
 
 ---
 
-
-## SageOx Links
-
-- **Repository Dashboard:** https://sageox.ai/repo/repo_01a04040-8e6b-7714-8bea-56318bec434c
-- **Team Dashboard:** https://sageox.ai/team/team_jihjpfkt8b
-
 ## For AI Coworkers
 
 If you are an AI coworker (Claude Code, Cursor, Windsurf, OpenCode, etc.), run this command at the start of each session:
@@ -23,6 +17,11 @@ This injects minimal, relevant team context into your session. As you work on sp
 When users ask if you're using SageOx: if you have an agent ID from running `ox agent prime`, confirm with your agent ID; otherwise run it first.
 
 ---
+
+## SageOx Links
+
+- **Repository Dashboard:** https://sageox.ai/repo/repo_01a04040-8e6b-7714-8bea-56318bec434c
+- **Team Dashboard:** https://sageox.ai/team/team_jihjpfkt8b
 
 ## The Problem
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that moved but stayed spelled `secrets` refuses the launch, not just the run. Nothing that
   loads today stops loading — the key is new, and `run` was already `.strict()`.
 
+### Changed
+
+- **The agent base image ships `ox` 0.14.3.** `OX_VERSION` and both architecture
+  checksums in `deploy/docker/Dockerfile` move up from 0.13.0. The six ox calls the
+  toolkit makes — `query`, `status`, `team list`, `index code`, `code status`, and
+  `code search` — take the same flags and return the same fields on 0.14.3 that they
+  did on 0.13.0, so nothing that reads them changes.
+
 ### Fixed
 
 - **A job a person asks for runs, even when its kill switch is parked.** `job_run` records

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -42,12 +42,12 @@ RUN apt-get update \
 # The gateway runs ox itself — the credential stays on this side of the brain boundary.
 # Pin the release and verify it so rebuilding this image cannot silently install a newer
 # binary. Debian's architecture names match the SageOx release names we support.
-ARG OX_VERSION=0.13.0
+ARG OX_VERSION=0.14.3
 RUN set -eu; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-      amd64) checksum="9922cdf6cfb5008f340300c4efad82b6d1042bedac60853c26477a11e8957b51" ;; \
-      arm64) checksum="700356e66f44b26aab7451792799511535c9d7dd79ac0aeb2912fb852e38d794" ;; \
+      amd64) checksum="57a3da98394bc34f0ac72855cf8a88b86d11fdb87b4e82fff881e8801f4b1f27" ;; \
+      arm64) checksum="626a2ae15b32dc227558b472597e7092a3f324b6977967ad4cd40e06d7a96fdd" ;; \
       *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
     archive="ox_${OX_VERSION}_linux_${arch}.tar.gz"; \


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a05f59-5126-7422-accd-3b70b6d79d51">Session</a>
<!-- /sageox:pr-header -->

`deploy/docker/Dockerfile` pinned `ox` 0.13.0, so a rebuild installed a binary three releases behind the one a workstation gets from the tap. This moves the pin to 0.14.3 and both per-architecture checksums with it — they *are* the pin, and `ci.yml` builds amd64 and arm64 deliberately so a stale arm64 checksum cannot stay green.

That `ARG` is the only `OX_VERSION` reference in the repo.

## Why this is safe

The pin is all that changes, so the risk lives entirely in what `ox` returns — the gateway shells to it and parses the JSON. Every call the toolkit makes was run against 0.14.3 and returns the same fields:

| Call | Site | Field the code reads |
|---|---|---|
| `query … --json --limit --team --repo` | `packages/core/src/team-server.ts:138` | `team_context.results[]` |
| `status --json` | `packages/cli/src/ox.ts:41` | `auth.{authenticated,expires_at,user,git_pat_valid}`, `config.auth_file` |
| `team list --json` | `packages/cli/src/ox.ts:126` | `primary_team`, `teams[].{team_id,name,slug,primary}` |
| `code status --json` | `packages/cli/src/repos.ts:313` | `index_exists` |
| `index code --json` | `packages/cli/src/repos.ts:307` | — (`--json` is a global flag) |
| `code search … --json --limit` | `packages/cli/src/repos.ts:370` | — (both flags present) |

The 0.14.3 tarball still carries `ox` at its root, so the `tar -xzf … -C /usr/local/bin ox` extraction is unchanged. It also ships `ox-adapter-*` binaries, as 0.13.0 did; the image extracts only `ox`, which is unchanged behaviour.

## Verification

- `docker build --target runtime` — arm64 leg end to end: `sha256sum -c` reports `ox_0.14.3_linux_arm64.tar.gz: OK`, and the layer's own `ox version` prints `ox 0.14.3`. Running `ox version` in the built image confirms `0.14.3 / linux/arm64`.
- The amd64 tarball was downloaded and hashed independently against the release's `checksums.txt`; CI's amd64 leg exercises that path for real.
- `pnpm typecheck` clean; `pnpm test` 1078/1078 across 63 files.

## Also included

The `.claude/commands/*` and `.sageox/README.md` files that `ox agent prime` regenerated at 0.14.3 — the same upgrade seen from the workstation side, carried here rather than left dirty in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a05f59-5126-7422-accd-3b70b6d79d51

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790899089&installation_model_id=433550&pr_number=14&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F14&signature=cf3bd522c5844ef80430ecdaedb33f54a3cff84dc974e596eb563ac7cdf849c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guidance for reading locally recorded conversations, including result formatting and citation support.
  - Expanded command-line usage documentation with code search modes, filters, and fallback guidance.

- **Documentation**
  - Reorganized SageOx links for improved discoverability.
  - Added unreleased changelog notes covering the updated command-line tool version.

- **Chores**
  - Updated the bundled command-line tool to version 0.14.3 for supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->