### PR TITLE
Give a job Pod its own `/agents`, since the agent's claim is ReadWriteOnce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A scheduled job runs wherever the cluster puts it, instead of only on the agent's node.**
+  The chart mounted the agent's `ReadWriteOnce` claim in every job Pod as well as the
+  Deployment's, and RWO binds a volume to one node — so a job Pod the scheduler placed
+  anywhere else could never attach it. It sat in `Init:0/1` behind a `Multi-Attach error for
+  volume` until `activeDeadlineSeconds` killed it, with nothing in the job's own logs,
+  because the body never started; the same job then completed in seconds on the ticks that
+  landed beside the agent, and hung for the whole deadline on the ones that did not, which is
+  what made it hard to recognise as a placement problem at all. Once the scheduler settled on
+  another node, every tick hung. `/agents` in a job Pod is now an `emptyDir`, staged for that
+  run by the same init container the agent Pod runs and gone with it — a run needed nothing
+  that was on the claim: it stages its own bundle from `/config`, reads its kill switch
+  through the relay, and writes its verdict under the container's own tmpdir. Two Pods
+  writing one EBS volume was never safe on the ticks that *did* co-locate, either.
+  **A job body that genuinely shares durable state with the agent now has to say so** — one
+  `sharedVolumes` entry, on a claim whose access mode allows a second node, which is the same
+  thing shared brains already ask for. One that silently relied on the agent's warm
+  checkouts, index, or local vault gets an empty directory instead; on a claim it could only
+  reach from one node, and only after the Deployment had gone first, it was already relying
+  on luck. The deployment contract's job clause says this too: a target owes a run a writable
+  bundle directory, not a durable one.
+
 - **A job a person asks for runs, even when its kill switch is parked.** `job_run` records
   the author of the message the agent is answering, so a request that arrives through a chat
   surface is the human on-request run the host has always described — it has refused with

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -91,7 +91,15 @@ your behalf. An `image:` source is one more pull from a registry the node alread
 `imageRef` from, with the same node credential — pin it by digest for the same reason
 `imageRef` is pinned by digest, and note that a failed pull on a CronJob loses that run
 under `backoffLimit: 0`, the same class of failure as an `imageRef` pull failure. A
-`persistentVolumeClaim:` or `csi:` source costs whatever that driver costs at attach.
+`persistentVolumeClaim:` or `csi:` source costs whatever that driver costs at attach — and
+on an agent that declares a schedule it has to be mountable from more than one node,
+normally `ReadWriteMany`. A job Pod mounts the bundle source too, and `ReadWriteOnce` binds
+a volume to whichever node holds it: the job Pod then sits in `Init:0/1` behind a
+`Multi-Attach` event until its deadline kills it, unless it happened to land beside the
+Deployment. `readOnly: true` does not help — the limit is on nodes, not on writers. The
+chart cannot check this for you: values carry a `claimName`, the access mode lives on the
+claim, and the chart tooling deliberately does not contact the cluster. This is the one
+volume both Pods still mount; the agent's own claim is [no longer one of them](#jobs).
 
 Nothing here caps what a bundle may carry. On an uncapped source a runner can ship
 `node_modules`, a compiled binary, or a model file; whether it *should* is a policy you set,

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -98,8 +98,9 @@ a volume to whichever node holds it: the job Pod then sits in `Init:0/1` behind 
 `Multi-Attach` event until its deadline kills it, unless it happened to land beside the
 Deployment. `readOnly: true` does not help — the limit is on nodes, not on writers. The
 chart cannot check this for you: values carry a `claimName`, the access mode lives on the
-claim, and the chart tooling deliberately does not contact the cluster. This is the one
-volume both Pods still mount; the agent's own claim is [no longer one of them](#jobs).
+claim, and the chart tooling deliberately does not contact the cluster. The agent's own
+claim is [not mounted in a job Pod](#jobs) for this reason; a bundle claim still is, on
+every scheduled run.
 
 Nothing here caps what a bundle may carry. On an uncapped source a runner can ship
 `node_modules`, a compiled binary, or a model file; whether it *should* is a policy you set,

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -142,10 +142,9 @@ Two limits of the copy onto the claim, both from the bundle sharing one director
 agent's mutable state — cursors, checkouts, and indexes cannot be replaced wholesale, so the
 bundle cannot either. A file dropped from the bundle is not removed from the claim; only
 `repos.conf` is, because it is the one name whose absence changes behaviour. And a bundle is
-staged file by file rather than all at once, so a Pod staging a *different* generation beside
-another — a same-name ConfigMap mid-refresh, or a job's `Job` that outlived a release change
-— can leave two generations mixed until the next stage. Immutable sources keep that to the
-one apply that changes them.
+staged file by file rather than all at once, so a stage that reads a source mid-change — a
+same-name ConfigMap being refreshed under it — can leave two generations mixed until the
+next stage. Immutable sources keep that to the one apply that changes them.
 
 `podAnnotations`, `nodeSelector`, `tolerations`, `priorityClassName`, and
 [`networkPolicy`](#network-policy) are release-wide.
@@ -199,7 +198,7 @@ Three, and they are fixed:
 |---|---|---|
 | `agent` | Deployment Pod | the gateway, and the brain as its subprocess |
 | `job` | CronJob Pod | `sageox-agent job run <slug>` |
-| `stage-config` | init container of both | the bundle copy onto the claim |
+| `stage-config` | init container of both | the bundle copy into `/agents` |
 
 They are listed because a cluster add-on that acts on *some* containers needs their names,
 and nothing else here would tell you them. EKS's IRSA webhook is the case worth spelling
@@ -333,13 +332,20 @@ Deployment runs, so the envelope is the host's: admission past both switches, si
 the budget's bow-out, the run record, and the verdict. The trigger is stamped by the door it
 came through, which is why a scheduled object can only ever claim `schedule`.
 
-A job run is the same identity, not a second workload: it runs on the agent's own claim,
-with that agent's ServiceAccount, secret mount, shared volumes, and resource numbers. It
-stages that bundle itself, with the same init container the agent Pod runs — a job that
-waited on the Deployment to have gone first would lose its run on a fresh install, and
-nothing retries it. With a `ReadWriteOnce` claim, that means a job Pod can
-only start where the agent Pod already runs; if your storage class is zonal, the placement
-values (`nodeSelector`, `tolerations`) are where you say so.
+A job run is the same identity, not a second workload: it runs with that agent's
+ServiceAccount, secret mount, shared volumes, and resource numbers. It stages that bundle
+itself, with the same init container the agent Pod runs — a job that waited on the
+Deployment to have gone first would lose its run on a fresh install, and nothing retries it.
+
+What it does not get is the agent's claim. `/agents` in a job Pod is an `emptyDir`, fresh
+for the run and gone with it, because the claim is `ReadWriteOnce` and a job Pod mounting it
+could only attach where the Deployment Pod already ran — anywhere else the Pod sat in
+`Init:0/1` behind a `Multi-Attach error for volume` until `activeDeadlineSeconds` killed it,
+with empty logs, because the body never started. Nothing a run needs is on that claim: it
+stages its own bundle, reads its kill switch through the relay, and writes its verdict
+under the container's own tmpdir. A job body that genuinely shares durable state with the
+agent gets a `sharedVolumes` entry, on a claim you back with an access mode that allows two
+Pods to mount it — `ReadWriteMany` for anything that may land on a second node.
 
 ### A job that reads the Kubernetes API
 

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -63,11 +63,10 @@ scheduled run is lost.
   command: ["/bin/sh", "-ceu"]
   args:
     - |
-      # Staged so that a stage running beside it cannot be observed half-done. One claim
-      # carries the agent and every job of that agent, so two Pods can stage the same
-      # bundle at once — a nightly tick beside a rollout, or two jobs on one cron. Copy
-      # aside, then land each file by rename, which is atomic: a reader sees the whole old
-      # file or the whole new one, and the two are the same bytes from the same source.
+      # Staged so that a stage running beside it cannot be observed half-done. Copy aside,
+      # then land each file by rename, which is atomic: a reader sees the whole old file or
+      # the whole new one. `persistence.existingClaim` is the operator's own volume, so this
+      # stage cannot assume it is the only thing writing where it lands.
       install -d -m 0700 /agents/{{ .name }}
       stage=$(mktemp -d /agents/.stage.XXXXXX)
       cp -LR /config/. "$stage/"
@@ -164,6 +163,15 @@ from under the `Read(//mnt/secrets-store/**)` deny rule's sibling without the re
 {{- define "agent.jobSecretsMountPath" -}}/mnt/job-secrets-store{{- end -}}
 
 {{/*
+`/agents` is the agent's claim in the Deployment Pod and an `emptyDir` in a job Pod. The
+claim is `ReadWriteOnce`, which binds it to one node: a job Pod the scheduler placed on any
+other node could not attach it, and sat in `Init:0/1` behind a `Multi-Attach` event until
+`activeDeadlineSeconds` killed it — with nothing in the job's own logs, because the body
+never started. A scheduled run needs nothing that is on the claim: it stages its own bundle
+from `/config`, reads its kill switch through the relay, and writes its verdict under the
+container's own tmpdir. Durable state a job body does share with the agent goes on a
+`sharedVolumes` claim, which the operator backs with an access mode that allows it.
+
 The bundle arrives on whatever volume the consumer named, passed through verbatim: a
 ConfigMap, an image, a claim, a CSI volume. The chart's contract is the directory at
 `/config`, never the object behind it, so nothing here branches on which source it is.
@@ -172,8 +180,12 @@ No volume at all is the case where the bundle rides inside `bundle.stageImage` i
 */}}
 {{- define "agent.podVolumes" -}}
 - name: agent-data
+{{- if .job }}
+  emptyDir: {}
+{{- else }}
   persistentVolumeClaim:
     claimName: {{ include "agent.claimName" . }}
+{{- end }}
 {{- with .agent.bundle.volume }}
 - name: config
   {{- toYaml . | nindent 2 }}

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -84,13 +84,28 @@ counted 2 "- /mnt/secrets-store"
 # Nothing in the rendered object names the job body — that stays in the manifest.
 absent "runner/"
 
-present "claimName: agents-harry"
 present "mountPath: /mnt/secrets-store"
 
-# Every scheduled Pod stages its own bundle. One that waited on the Deployment to have gone
-# first would lose its run on a fresh install, and nothing retries it. It stages by rename
-# rather than in place, because that same claim is being staged by the agent Pod and by
-# every other job of this agent.
+# `/agents` is this Pod's own, never the agent's `ReadWriteOnce` claim. A job Pod that
+# mounted the claim could only attach where the Deployment Pod already ran; on any other
+# node it sat in `Init:0/1` behind a `Multi-Attach` event until its deadline killed it, and
+# its logs were empty because the body never started.
+counted 2 "emptyDir: {}"
+absent "claimName: agents-harry"
+absent "claimName: agents-ida"
+
+# The Deployment keeps the claim. Its `/agents` holds the cursors, local memory, checkouts
+# and indexes the contract calls durable, so gating the mount on the wrong side of `.job`
+# would lose every one of them on the next rollout and render just as cleanly.
+rendered=$(helm template agents "$chart" --values "$values" --show-only templates/deployment.yaml)
+present "claimName: agents-harry"
+present "claimName: agents-ida"
+absent "emptyDir"
+
+# Every scheduled Pod stages its own bundle, into the `emptyDir` above. One that waited on
+# the Deployment to have gone first would lose its run on a fresh install, and nothing
+# retries it.
+render
 counted 2 "name: stage-config"
 present 'dest="/agents/harry/${file#$stage/}"'
 present 'dest="/agents/ida/${file#$stage/}"'

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -43,7 +43,7 @@ A target that supports jobs owes each declared job:
 | A platform deadline of `wallClockMs + deadlineHeadroomMs`, rounded up where the target's unit is coarser | `budget` |
 | Single-flight — a run that would overlap a running one is refused, never queued | — |
 | No platform retry — a failed run is a failed run | — |
-| Writable, durable state, and somewhere the verdict artifact lands | `Mutable state`, above |
+| A writable bundle directory and somewhere the verdict artifact lands — durable between runs is not owed | `Agent definition`, above |
 
 `run.command` and `run.args` are a list, and the list is the whole interface: no shell
 string, so nothing can be word-split or interpolated into one.
@@ -84,7 +84,12 @@ environment — and a job that needs the pod's cloud identity says so by name in
 wrote down.
 
 A job run is the same agent — the same bundle directory and the same `secretRef` mounts the
-rows above already require, not a second deployment carrying configuration of its own. A
+rows above already require, not a second deployment carrying configuration of its own. The
+same bundle, though, is not necessarily the same *copy*: a target may stage a run one of its
+own, and [the chart](#kubernetes-chart) does, because a job Pod sharing the agent's
+`ReadWriteOnce` claim could not start off the node the agent runs on. A job body's files are
+therefore its run's, and anything it needs to outlive the run belongs in a store it reaches
+over the network rather than beside the bundle. A
 target **may** add a second mount that a scheduled run gets and the agent's own workload does
 not, and one that does closes a gap policy cannot: a credential absent from the agent's mount
 is not a file in the process that runs the brain. Added, never substituted — a job run
@@ -109,7 +114,8 @@ the bundle's own source as a Kubernetes VolumeSource, so Helm, Kustomize, Terraf
 Argo CD, and Flux can own those objects without a toolkit-specific translation step.
 
 A short init container copies non-secret files from that volume, mounted read-only at
-`/config`, into a persistent volume; the long-running container then uses the same paths and
+`/config`, into the agent directory — the agent's persistent claim in the Deployment Pod, a
+per-run `emptyDir` in a job Pod; the long-running container then uses the same paths and
 command as Compose. Which volume carries the bundle is the operator's choice — a ConfigMap,
 an image, a claim, a CSI volume — and nothing below `/config` depends on the answer.
 Repository checkouts and `ox` indexes stay on that PVC, while clone, fast-forward fetch,
@@ -137,9 +143,11 @@ the budget, and mints the verdict. The declaration reaches the chart as a mirror
 in that agent's values, because Helm cannot read an operator-supplied bundle at render
 time; the mirror carries the clock and the bound only — not the argv, not the switch —
 so it cannot become a second place a job is decided.
-[The chart's README](../deploy/helm/README.md#jobs) has the rendered shape and the one
-placement consequence — a job Pod shares the agent's claim, so a `ReadWriteOnce` volume ties
-it to the node the agent runs on.
+[The chart's README](../deploy/helm/README.md#jobs) has the rendered shape and the one thing
+a job Pod does not share — the agent's `ReadWriteOnce` claim, which would tie its placement
+to the agent's node. It stages its bundle onto an `emptyDir` of its own instead, and a body
+that does share durable state with the agent gets a `sharedVolumes` claim whose access mode
+says so.
 
 A job Pod is the one pod spec that may hold a cluster token, opted into per agent with
 `serviceAccount.automountJobToken` and off by default. It runs the argv its `agent.yaml`


### PR DESCRIPTION
Closes #10.

## What was needed

An agent with both a chat surface and a scheduled job intermittently stopped running the
job. `agent.podVolumes` is shared by the Deployment and the CronJob and mounted the agent's
claim unconditionally, and that claim is created `ReadWriteOnce` — which binds a volume to
one **node**. So a job Pod was runnable only where the Deployment Pod already ran:

| job Pod node | outcome |
|---|---|
| same node as the Deployment | attaches, runs normally (seconds) |
| any other node | `Multi-Attach error for volume`, `Init:0/1` until `activeDeadlineSeconds` |

Scheduling-dependent rather than deterministic, which is what made it hard to recognise:
identical ticks finishing in ~8 seconds or dying after 15 minutes, with **nothing in the
job's own logs**, because the body never started. Once the scheduler settled on a different
node, every subsequent tick hung. Nothing asked for co-location, and the chart exposes no
`affinity` with which to ask.

## What ships

The helper already knew whether it was rendering a job — the job secret volume a few lines
below reads exactly that context — so the workspace mount is now gated on it too.

```mermaid
flowchart LR
  S["/config (bundle source)"] --> A["Deployment Pod: /agents = agent-data PVC (RWO)"]
  S --> B["CronJob Pod: /agents = emptyDir, per run"]
```

- **`_helpers.tpl`** renders `emptyDir: {}` for `agent-data` when `.job` is set, and the
  claim otherwise. An `emptyDir` rather than no volume at all, because `stage-config` and
  `job` are separate containers: the staged bundle has to pass between them, and
  `--bundle /agents/<name>` has to keep resolving. Every Pod already stages for itself, so
  the only thing that changes is which volume it stages onto.
- Secret mounts, `sharedVolumes`, the ServiceAccount and the resource numbers are untouched:
  a job run is still the same identity.

A run needs nothing that was on that claim. It stages its own bundle from `/config`; its
kill switch is read through the relay (`jobSwitchSource` builds an engram source from the
private brain, never a file); and the verdict artifact lands in `JobHost.workDir`, under the
container's own tmpdir. The Buzz resume cursor is not affected either — `loadState` and
`saveState` have exactly two call sites, both in `runCmd`, which is the Deployment's
process.

## What a job Pod loses

Visibility of the agent's warm checkouts, `ox` index, and local vault directory, and the
ability to leave files behind for its own next tick. `job run` never cloned or indexed —
`createRepoWorkspace` and `.warm()` are called only from `runCmd` — so this is about a body
that reached into the agent's workspace itself. It could only ever do that on a tick that
co-located *and* landed after the Deployment had warmed, so nothing could depend on it
reliably, but it is a real behaviour change and the CHANGELOG says so.

A body that genuinely shares durable state with the agent now has to declare it: one
`sharedVolumes` entry, on a claim whose access mode allows a second node — the same
mechanism shared brains already use. No new values key, because the one that would be
needed already exists.

## The contract change this required

`docs/deployment-contract.md` owed each declared job *"writable, durable state"*. An
`emptyDir` is writable and not durable, so the canonical target could not have satisfied
that row. The row now owes **a writable bundle directory and somewhere the verdict artifact
lands — durable between runs is not owed**, and the Jobs clause says why: a target may stage
a run a copy of its own. That is the one decision here worth arguing with; the alternative
that keeps the promise is `jobs[].workspace: shared | none` from the issue, at the cost of a
values knob with one user.

Comments that asserted the old arrangement went with it — the staging script's claim that
"one claim carries the agent and every job of that agent", the README's mixed-generations
paragraph, and the contract's placement note.

## How it was verified

`deploy/helm/tests/jobs.sh` asserts `emptyDir: {}` twice and no `claimName: agents-*` in the
CronJob render, plus a paired check that the **Deployment** still mounts the claim — gating
on the wrong side of `.job` renders just as cleanly and would drop the agent's cursors,
memory, checkouts and indexes on the next rollout. It fails without the template change:

```
jobs.sh: expected 2 × 'emptyDir: {}', found 0
```

- `deploy/helm/tests/{jobs,consume,bundle,networkpolicy}.sh` — ok
- `helm lint --strict` with the example values — 0 failed
- `pnpm test` — 1078 passed; `pnpm typecheck` — clean

SageOx-Session: https://sageox.ai/c/ses_01a05f60-d890-7403-a396-81678308dd77

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790900547&installation_model_id=433550&pr_number=15&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F15&signature=29620d99d4be4f6cc6f5d8e2421154218b1b38698f7bc89bdd35e7a153d0d80b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled jobs now run on any Kubernetes node using isolated per-run storage.
  * Jobs can opt into durable shared state through explicitly configured, multi-node shared volumes.

* **Documentation**
  * Clarified bundle staging behavior, storage durability, and volume configuration requirements.
  * Documented that agent deployments retain persistent storage while scheduled jobs use temporary storage.

* **Bug Fixes**
  * Scheduled jobs no longer depend on the agent’s single-node persistent volume claim, preventing volume attachment and scheduling issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->