### PR TITLE
Name run.jobSecrets in the launch a job-only credential refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `run.jobSecrets` exists to avoid, and that map is deliberately left out of this inventory.
   Each job-declared ref now carries it as the hint, in `run` and in `doctor`. A job that also
   arms `trigger.onRequest` is still refused at load, naming the three ways out it always has.
+  The remedy is withheld where the gateway itself also reads the ref — a job and a `private`
+  checkout sharing `GITHUB_TOKEN` would have to move a token the clone needs — so `mergeByRef`
+  now keeps a hint only where every declaration gives the same one, on the reasoning it
+  already applies to `degraded`. Which declaration was pushed first no longer decides which
+  advice an operator reads.
 
 - **A job a person asks for runs, even when its kill switch is parked.** `job_run` records
   the author of the message the agent is answering, so a request that arrives through a chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the brain reads as characters goes back out as characters, and `mentions` remains the only
   way a Slack message addresses anyone.
 
+- **The launch a job-only credential refuses now names the field that would let it start.**
+  `sageox-agent run` resolves every `jobs[].run.secrets` ref against the directory this
+  process was given, before it opens a socket, so a credential moved to a directory only
+  `job run` is given — but left spelled `secrets` — takes the whole surface down: no mentions
+  answered, no on-request runs, over a value nothing in that process would have read. The
+  refusal stays right, since nothing there can tell a moved credential from a typo, and a
+  scheduled job's unresolvable ref is otherwise a crashed 3am tick in a channel. What was
+  missing is the way out. The two remedies the message offered — mount the file here, add it
+  to `.env` — are both "put it back where the gateway reads it", which is the arrangement
+  `run.jobSecrets` exists to avoid, and that map is deliberately left out of this inventory.
+  Each job-declared ref now carries it as the hint, in `run` and in `doctor`. A job that also
+  arms `trigger.onRequest` is still refused at load, naming the three ways out it always has.
+
 - **A job a person asks for runs, even when its kill switch is parked.** `job_run` records
   the author of the message the agent is answering, so a request that arrives through a chat
   surface is the human on-request run the host has always described — it has refused with

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -421,7 +421,7 @@ Two consequences worth knowing before you split a credential out:
   `run.secrets` ref against its own mount before it opens a socket and refuses the launch on
   one that does not, so a credential that moved here but stayed spelled `secrets` is a
   crashlooping agent rather than a quietly weaker one. `run.jobSecrets` is left out of that
-  inventory.
+  inventory, and the refusal names it — so the Pod's log carries the fix, not only this page.
 - **The render refuses `jobSecrets` on an agent with no schedule**, because no Pod would then
   mount it and the field would read as though it had moved a credential it had not.
 

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -36,7 +36,8 @@ jobs:
       # environment, and refused at startup if it does not resolve.
       secrets: { GH_TOKEN: GH_TOKEN, ANTHROPIC_API_KEY: ANTHROPIC_API_KEY }
       # The same, for a credential the gateway's own process must not hold. Resolved
-      # identically; declaring one here refuses `trigger.onRequest` on this job.
+      # identically, but left out of the startup check — that is what lets the gateway
+      # start without it. Declaring one here refuses `trigger.onRequest` on this job.
       jobSecrets: { GH_APP_PEM: GH_APP_PEM }
       # Ambient variables this body inherits, by name. For values the platform injects at
       # runtime — EKS IRSA below; GKE and Azure workload identity present the same way.

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -331,11 +331,19 @@ export function declaredSecrets(manifest: AgentManifest, repos: RepoSpec[]): Dec
   // calling process was given, and a `jobSecrets` ref is the one a deployment keeps out of
   // the gateway's. Listing it would refuse the launch of every agent that split a credential
   // out. `job run` resolves it per run and fails by name.
+  //
+  // The hint names that field here, where the refusal is read, because the two remedies
+  // this error otherwise offers — mount the file here, add it to `.env` — are both the
+  // arrangement the split was for.
   manifest.jobs.forEach((job, index) => {
     for (const [envVar, ref] of Object.entries(job.run.secrets)) {
       declared.push({
         ...spawnedSecretSpec(ref, envVar, "the job body"),
         where: `jobs[${index}].run.secrets.${envVar} (job "${job.slug}")`,
+        hint:
+          `if ${ref} is mounted only in a directory this process is not given, it belongs ` +
+          `in jobs[${index}].run.jobSecrets — this check leaves that map out, and ` +
+          "`sageox-agent job run` resolves it per run and fails by name",
       });
     }
   });

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -246,6 +246,14 @@ export interface DeclaredSecret extends CredentialSpec {
  * The merged entry names every place, and is **fatal if any declaration is fatal**: a
  * feature that degrades gracefully without the credential does not make the one that cannot
  * start without it any less broken.
+ *
+ * It keeps a hint only where every declaration gives the same one, under the same reasoning:
+ * a remedy is advice about one feature, and the other feature sharing the ref may be the one
+ * it is wrong for. Moving a `GITHUB_TOKEN` that a job and a `private` checkout both read into
+ * `run.jobSecrets` leaves the clone's declaration unresolved and the launch still refused —
+ * so that hint must not survive the merge that proves the gateway needs the value. Two jobs
+ * sharing a ref do give the same hint, which is why it does not name their indices: `where`
+ * already names every line, and a remedy true of both should read as one remedy.
  */
 function mergeByRef(declared: DeclaredSecret[]): DeclaredSecret[] {
   const byRef = new Map<string, DeclaredSecret>();
@@ -259,6 +267,7 @@ function mergeByRef(declared: DeclaredSecret[]): DeclaredSecret[] {
       ...seen,
       where: `${seen.where} and ${secret.where}`,
       degraded: seen.degraded && secret.degraded ? seen.degraded : undefined,
+      hint: seen.hint === secret.hint ? seen.hint : undefined,
     });
   }
   return [...byRef.values()];
@@ -342,7 +351,7 @@ export function declaredSecrets(manifest: AgentManifest, repos: RepoSpec[]): Dec
         where: `jobs[${index}].run.secrets.${envVar} (job "${job.slug}")`,
         hint:
           `if ${ref} is mounted only in a directory this process is not given, it belongs ` +
-          `in jobs[${index}].run.jobSecrets — this check leaves that map out, and ` +
+          "in run.jobSecrets rather than run.secrets — this check leaves that map out, and " +
           "`sageox-agent job run` resolves it per run and fails by name",
       });
     }

--- a/packages/cli/test/credentials.test.ts
+++ b/packages/cli/test/credentials.test.ts
@@ -338,6 +338,29 @@ describe("declared secretRefs", () => {
     expect(requireDeclaredSecrets(declared, { dir: secretsDir })).toEqual([]);
   });
 
+  it("names run.jobSecrets when the ref that did not resolve is a job's own", () => {
+    // The arrangement above, spelled wrong: a credential moved to the mount only the job's
+    // Pods take, but left in `run.secrets`. The launch is refused — nothing here can tell
+    // that from a typo, and the whole surface goes down for a credential nothing read — so
+    // the message has to name the field that both isolates it and lets the agent start.
+    // The other two remedies it offers are "put it back on the gateway's mount".
+    for (const name of ["DEMO_NSEC", "DEMO_SLACK_BOT", "DEMO_SLACK_APP", "DEMO_TRACKER_KEY"]) {
+      writeFileSync(join(secretsDir, name), "value");
+    }
+    writeFileSync(join(secretsDir, "GITHUB_TOKEN"), "ghp_x");
+    const declared = declaredSecrets(loadManifest(FLEET), parseReposConf(PRIVATE_REPO));
+
+    let message = "";
+    try {
+      requireDeclaredSecrets(declared, { dir: secretsDir });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toMatch(/1 declared secret\(s\) did not resolve/);
+    expect(message).toContain('jobs[0].run.secrets.GH_TOKEN (job "nightly")');
+    expect(message).toContain("jobs[0].run.jobSecrets");
+  });
+
   it("names every missing ref at once, with where it is declared and how to get one", () => {
     const declared = declaredSecrets(loadManifest(FLEET), parseReposConf(PRIVATE_REPO));
     let message = "";

--- a/packages/cli/test/credentials.test.ts
+++ b/packages/cli/test/credentials.test.ts
@@ -339,11 +339,11 @@ describe("declared secretRefs", () => {
   });
 
   it("names run.jobSecrets when the ref that did not resolve is a job's own", () => {
-    // The arrangement above, spelled wrong: a credential moved to the mount only the job's
-    // Pods take, but left in `run.secrets`. The launch is refused — nothing here can tell
-    // that from a typo, and the whole surface goes down for a credential nothing read — so
-    // the message has to name the field that both isolates it and lets the agent start.
-    // The other two remedies it offers are "put it back on the gateway's mount".
+    // The arrangement above, spelled wrong: a credential moved to the directory only
+    // `job run` is given, but left in `run.secrets`. The launch is refused — nothing here
+    // can tell that from a typo, and the whole surface goes down for a credential nothing
+    // read — so the message has to name the field that both isolates it and lets the agent
+    // start. The other two remedies it offers are "put it back where the gateway reads it".
     for (const name of ["DEMO_NSEC", "DEMO_SLACK_BOT", "DEMO_SLACK_APP", "DEMO_TRACKER_KEY"]) {
       writeFileSync(join(secretsDir, name), "value");
     }
@@ -358,7 +358,85 @@ describe("declared secretRefs", () => {
     }
     expect(message).toMatch(/1 declared secret\(s\) did not resolve/);
     expect(message).toContain('jobs[0].run.secrets.GH_TOKEN (job "nightly")');
-    expect(message).toContain("jobs[0].run.jobSecrets");
+    expect(message).toContain("run.jobSecrets");
+  });
+
+  it("withholds that remedy from a ref the gateway itself also reads", () => {
+    // The hint is advice about one feature, and the feature sharing the ref is the one it
+    // is wrong for: a `private` checkout clones inside the gateway, so moving GITHUB_TOKEN
+    // to `run.jobSecrets` would leave repos.conf's declaration unresolved and the launch
+    // still refused. Which declaration was pushed first must not decide that — jobs are
+    // pushed before repos.conf, so first-wins would have sent the operator the wrong way.
+    const shared = loadManifest(`
+name: shared-demo
+brain: { provider: claude-acp }
+respondTo: anyone
+surfaces: [{ kind: console }]
+jobs:
+  - slug: nightly
+    archetype: sweep
+    description: A bounded pass over the repository.
+    trigger: { onRequest: true }
+    budget: { wallClockMs: 3600000 }
+    run: { command: node, args: ["nightly.ts"], secrets: { GH_TOKEN: GITHUB_TOKEN } }
+`);
+    const declared = declaredSecrets(shared, parseReposConf(PRIVATE_REPO));
+
+    expect(declared).toHaveLength(1);
+    expect(declared[0].where).toBe(
+      'jobs[0].run.secrets.GH_TOKEN (job "nightly") and repos.conf (private: service)',
+    );
+    expect(declared[0].hint).toBeUndefined();
+    expect(() => requireDeclaredSecrets(declared, { dir: secretsDir })).toThrow(
+      /GITHUB_TOKEN/,
+    );
+    let message = "";
+    try {
+      requireDeclaredSecrets(declared, { dir: secretsDir });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).not.toContain("jobSecrets");
+  });
+
+  it("keeps that remedy for a ref two jobs share, since it is true of both", () => {
+    // Two jobs that both need the credential can both move it, so the remedy survives —
+    // which is why the hint names no job index. `where` already names every line, and a
+    // remedy true of both has to read as one remedy rather than as advice about jobs[0].
+    const twoJobs = loadManifest(`
+name: two-job-demo
+brain: { provider: claude-acp }
+respondTo: anyone
+surfaces: [{ kind: console }]
+jobs:
+  - slug: nightly
+    archetype: sweep
+    description: A bounded pass over the repository.
+    trigger: { onRequest: true }
+    budget: { wallClockMs: 3600000 }
+    run: { command: node, args: ["nightly.ts"], secrets: { GH_TOKEN: DEMO_JOB_TOKEN } }
+  - slug: weekly
+    archetype: sweep
+    description: A wider pass over the repository.
+    trigger: { onRequest: true }
+    budget: { wallClockMs: 3600000 }
+    run: { command: node, args: ["weekly.ts"], secrets: { GH_TOKEN: DEMO_JOB_TOKEN } }
+`);
+    const declared = declaredSecrets(twoJobs, []);
+
+    expect(declared).toHaveLength(1);
+    expect(declared[0].where).toBe(
+      'jobs[0].run.secrets.GH_TOKEN (job "nightly") and jobs[1].run.secrets.GH_TOKEN (job "weekly")',
+    );
+    let message = "";
+    try {
+      requireDeclaredSecrets(declared, { dir: secretsDir });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("run.jobSecrets rather than run.secrets");
+    // No index, or it would be advice about one of the two lines it names.
+    expect(message).not.toContain("jobs[0].run.jobSecrets");
   });
 
   it("names every missing ref at once, with where it is declared and how to get one", () => {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a05f61-120c-78f1-9c02-6bbbd8ae5111">Session</a>
<!-- /sageox:pr-header -->

Closes #9.

## What was needed

An agent whose job declares a credential mounted only where jobs run does not start its chat
surface. The whole surface, not one code path: no mentions answered, no on-request runs,
over a value nothing in that process would have read.

`sageox-agent run` resolves every `jobs[].run.secrets` ref against the directory it was
given, before it opens a socket, and refuses the launch on one that does not resolve. That
refusal is right and stays. Nothing there can tell a moved credential from a typo, and a
scheduled job's unresolvable ref is otherwise a crashed 3am tick in a channel.

What was missing is the way out. The toolkit already has the field that both isolates the
credential and lets the agent start — `jobs[].run.jobSecrets`, from #2 — and that map is
deliberately left out of this inventory. Nothing in the failure said so. The two remedies
the message offered are *mount the file here* and *add it to `.env`*, and both mean **put it
back where the gateway reads it**, which is the arrangement the split exists to avoid. The
field was named in the chart's README, which is not what an operator reads in a
crashlooping Pod's log.

## What ships

Each `jobs[].run.secrets` entry carries the pointer as its hint, so it appears in `run` and
in `doctor`:

```
  DEPLOY_KEY — declared by jobs[0].run.secrets.DEPLOY_KEY (job "sweep")
      if DEPLOY_KEY is mounted only in a directory this process is not given, it belongs in
      jobs[0].run.jobSecrets — this check leaves that map out, and `sageox-agent job run`
      resolves it per run and fails by name
```

No behaviour moves. The check covers the same refs it always did, and a job that declares
`run.jobSecrets` while arming `trigger.onRequest` is still refused at load, naming the three
ways out it always has.

The message is written in the register the manifest's own `jobSecrets` refusal uses — *the
gateway's own process*, *that directory* — rather than in Kubernetes nouns. The toolkit
runs under Compose and launchd too, and no other operator-facing message here says "Pod".

### What the issue suggested, and why not

#9 proposes validating a secret on a surface only if that surface can use it. Two things
stop that here:

- The gateway cannot distinguish *moved to the job mount* from *typo*. Only the bundle
  knows, which is why the bundle declares it. Dropping the check trades a loud crashloop for
  the 3am tick — the failure this inventory exists to prevent.
- *Per surface* does not map onto this process. One gateway serves every surface, and
  `sageox-agent job run` — what a CronJob execs — already runs no startup inventory at all.

### Two docs went with it

- **`docs/job-contract.md`** described `jobSecrets` as "resolved identically" directly under
  a line reading "refused at startup if it does not resolve", which reads as though it were
  checked at startup too. That is the confusion this PR is about, sitting in the contract.
- **`deploy/helm/README.md`**'s account of this crashloop now says the refusal names the
  field, so the fix is in the log and not only on that page.

`docs/deployment-contract.md`, `docs/guide/reference.md` and the bring-up skill's
`operations.md` describe the mount split and the `onRequest` refusal, and are unchanged —
nothing they claim moved.

## How it was verified

`pnpm test` — 1080 passing. `pnpm typecheck` — clean, root and every package.

One test, `names run.jobSecrets when the ref that did not resolve is a job's own`, confirmed
failing without the source change: it stages every other declared ref, leaves the job's
absent, and asserts the thrown message names both the line that declares it and the field
that would let the launch through.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a05f61-120c-78f1-9c02-6bbbd8ae5111

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790900691&installation_model_id=433550&pr_number=16&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F16&signature=2fd1670ad7e291b63e2cbefe99a5c92432c999642df27e09e0735c38814330a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for unresolved job-only credentials in `run` and `doctor`, identifying the specific credential field and appropriate source.
  * Suppressed misleading guidance when a credential is also required by the gateway.
  * Added clearer guidance for credentials that should be provided per job run.

* **Documentation**
  * Clarified how job-only credentials resolve, bypass startup checks, and affect request-triggered jobs.
  * Documented handling of unresolved credential references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->