### PR TITLE
Cut the CHANGELOG section for 0.2.0 and move the chart to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-02
+
+Everything below shipped after `v0.1.0`.
+
+Published as `ghcr.io/sageox/agent-base:0.2.0`, which takes `:latest` and `:0.2`. `:0.1`
+stays on 0.1.0, and `:0` is not published at all — before 1.0.0 a minor bump may break
+you. Pin the digest recorded on the GitHub Release in production; the tags are for
+humans.
+
+Still pre-1.0: configuration format and CLI flags may move between minor versions. Two
+things a deployment already running 0.1.0 has to act on. **Slack needs the `users:read`
+scope** before an agent reads a mention as a name; a workspace that withholds it keeps
+rendering every mention as its id, which is what it did before. And **a job Pod's
+`/agents` no longer outlives the run** — a body that kept durable state beside its bundle
+needs a `sharedVolumes` claim whose access mode allows the placement.
+
+**The Helm chart moves to 0.10.0**, for the one entry here that is templates rather than
+code: `/agents` in a job Pod is an `emptyDir` instead of the agent's `ReadWriteOnce`
+claim. It renders on 0.1.0's image, and it is the only entry that does not need the new
+one.
+
+Two of the rest are keys an older binary will not honour, so roll the image before
+setting either: `jobs[].run.jobSecrets` is refused under `.strict()`, and `mentions` on
+`post_message` is dropped as an undeclared argument, leaving a roll call that addresses
+nobody — the silence that field exists to prevent.
+
 ### Added
 
 - **A Slack agent reads a mention as a name, not an id.** Slack's addressing primitive is

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Run one or more SageOx Agent Toolkit identities on Kubernetes
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "0.0.0"
 home: https://github.com/sageox/agent-toolkit
 sources:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -51,7 +51,7 @@ Or depend on it, and nest this chart's values under its name. Helm hands every s
 # Chart.yaml
 dependencies:
   - name: agent
-    version: 0.9.0
+    version: 0.10.0
     repository: "file://../agent-toolkit/deploy/helm"
 ```
 


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06338-88a4-7d04-802f-d74e4bba8a22">Session</a>
<!-- /sageox:pr-header -->

## Summary

Step 1 of the release process in [`CONTRIBUTING.md`](CONTRIBUTING.md): renames
`## [Unreleased]` to `## [0.2.0] - 2026-09-02`, opens a fresh one above it, and moves the
Helm chart to 0.10.0. `release.yml` refuses to publish `v0.2.0` until a heading by that name
exists, and quotes the section beneath it as the GitHub Release notes.

**A minor and not a patch.** Four of the eleven entries add something an operator sets or a
job body calls: `jobs[].run.jobSecrets`, `mentions` on `post_message`, `readThread` on the
Slack surface, and a mention that reaches the brain as a name — which needs the `users:read`
scope a 0.1.0 workspace was never asked for. The section leads with that scope and with
`/agents`, because those are what a deployment already running 0.1.0 has to act on, and a
reader of the GitHub Release notes has only that section.

**The chart moves for the first time since 0.9.0**, because this is the first release whose
entries reach the templates: `/agents` in a job Pod renders as an `emptyDir` rather than the
agent's `ReadWriteOnce` claim. Minor there too — [`docs/deployment-contract.md`](docs/deployment-contract.md)
now says durable between runs is not owed, so a job body that kept state beside its bundle
has to move it to a `sharedVolumes` claim. `values.yaml` is unchanged, so there is nothing
new to set; the dependency pin in the chart's README moves with the version.

The two "roll the image first" claims in the section were checked rather than assumed:
`run` is `.strict()` (`packages/core/src/manifest.ts:808`), so an older binary **refuses** a
manifest carrying `run.jobSecrets`; `PostArgs` is a plain `z.object`
(`packages/core/src/job-channel.ts:150`), so an older binary silently **drops** `mentions`
and the roll call addresses nobody. Different failures, and the section names them
separately.

`appVersion` stays the inert `"0.0.0"` placeholder — nothing reads it, and deployments pin
`imageRef` by digest.

## Test Plan

```
helm lint --strict deploy/helm --values deploy/helm/examples/two-agents.values.yaml   # 0 failed
helm template agents deploy/helm --values deploy/helm/examples/two-agents.values.yaml # renders
deploy/helm/tests/{jobs,consume,bundle,networkpolicy}.sh                              # 4× ok
pnpm typecheck                                                                        # clean
pnpm test                                                                             # 63 files, 1102 passed
```

No behavior changes to test — the diff is a CHANGELOG heading, a chart version, and the
README pin that tracks it. The chart suite is what proves the bump did not disturb what the
templates render.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added, or N/A documented — N/A, no code changes; existing chart suite re-run
- [x] `pnpm typecheck && pnpm test` green
- [x] Deployment checks run if `deploy/` changed
- [x] CHANGELOG entry added if user-facing — this PR *is* the CHANGELOG cut
- [x] Breaking change documented — `/agents` durability and the `users:read` scope lead the section
- [x] Docs updated if behavior or configuration changed — chart README dependency pin

</details>

SageOx-Session: https://sageox.ai/c/ses_01a06338-88a4-7d04-802f-d74e4bba8a22

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790964048&installation_model_id=433550&pr_number=19&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F19&signature=b5a33f52f305ac9df08549af5f565f909de7497f8f91f388d5320345f3e4e802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 0.2.0, including image tags, compatibility status, required Slack scope, job storage changes, Helm chart version, and updated configuration requirements.
  - Updated Helm chart documentation to reference version 0.10.0.

- **Release**
  - Updated the Helm chart version from 0.9.0 to 0.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->