### PR TITLE
Give every declaration of a shared secretRef its own remedy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `secretRef` two features share now carries both their remedies, each under the line it
+  belongs to.** `mergeByRef` collapses every declaration of one ref into a single entry — a
+  bundle's GitHub MCP server and a `private` `repos.conf` checkout both reading `GITHUB_TOKEN`
+  is the ordinary shape — but that entry could hold only one `hint`. So advice about one
+  feature either read as advice about the ref, which is wrong for the other feature sharing
+  it, or was dropped. Dropping was the safe half of that choice and is what shipped: it cost
+  every agent with this shape the `GITHUB_TOKEN` guidance it used to print. Declarations are
+  plural all the way through now — `DeclaredSecret.declaredBy` is a list of `{ where, hint }`,
+  and each place states its own answer, which is strictly more than either surviving-hint rule
+  could offer. A ref declared once keeps the one-line message it has always had. Two or more
+  get a line each, with the declarations that share a remedy listed together above it, so one
+  instruction is stated once rather than repeated per line. `doctor` appends every distinct
+  hint instead of the first. The hint-equality rule is gone, having been a workaround for the
+  singular field rather than a rule about credentials.
+
 - **A broadcast in a Slack message is escaped and logged instead of throwing, so the turn
   ends in an answer.** `SlackAdapter.outboundText` refused `<!channel>` by throwing, and
   `SurfaceEgress.reply` does not catch around `send` — so the throw left `drive`, ended the

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -90,6 +90,8 @@ import {
   GITHUB_TOKEN_SPEC,
   SAGEOX_TOKEN_SPEC,
   declaredSecrets,
+  declaredHints,
+  declaredWhere,
   spawnedSecretSpec,
   requireCredential,
   requireDeclaredSecrets,
@@ -1305,7 +1307,7 @@ async function runCmd(argv: string[]): Promise<void> {
   const declared = declaredSecrets(manifest, repos);
   for (const secret of requireDeclaredSecrets(declared, { dir: secretsDir })) {
     process.stdout.write(
-      `  note: ${secret.where}: ${secret.name} does not resolve — ${secret.degraded}\n`,
+      `  note: ${declaredWhere(secret)}: ${secret.name} does not resolve — ${secret.degraded}\n`,
     );
   }
 
@@ -1978,15 +1980,15 @@ async function doctorCmd(argv: string[]): Promise<boolean> {
     // a launch that dies on a missing secret.
     for (const secret of declaredSecrets(manifest, repos)) {
       if (resolveSecret(secret.name, { dir: secretsDir })) {
-        ok.push(`${secret.where}: secretRef ${secret.name} resolves`);
+        ok.push(`${declaredWhere(secret)}: secretRef ${secret.name} resolves`);
       } else if (secret.degraded) {
         warnings.push(
-          `${secret.where}: secretRef ${secret.name} does not resolve — ${secret.degraded}`,
+          `${declaredWhere(secret)}: secretRef ${secret.name} does not resolve — ${secret.degraded}`,
         );
       } else {
         problems.push(
-          `${secret.where}: secretRef ${secret.name} does not resolve` +
-            (secret.hint ? ` — ${secret.hint}` : ""),
+          `${declaredWhere(secret)}: secretRef ${secret.name} does not resolve` +
+            (declaredHints(secret).length ? ` — ${declaredHints(secret).join("; ")}` : ""),
         );
       }
     }

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -219,10 +219,26 @@ export async function requireCredential(
   return value;
 }
 
-/** A `secretRef` the bundle declares, with the line that declares it. */
-export interface DeclaredSecret extends CredentialSpec {
+/** One place a bundle asks for a ref, and the advice that belongs to *that* place. */
+export interface Declaration {
   /** Where the bundle asks for it, so an operator knows which line to fix. */
   where: string;
+  /**
+   * What to do about it here.
+   *
+   * Per declaration and not per ref, because advice is about one feature: a job's
+   * `run.jobSecrets` remedy is wrong for the `private` checkout reading the same
+   * `GITHUB_TOKEN`, and the checkout's fine-grained-token advice says nothing about the job.
+   * A ref two features share has two answers, and an operator needs the one beside the line
+   * it belongs to.
+   */
+  hint?: string;
+}
+
+/** A `secretRef` the bundle declares, with every line that declares it. */
+export interface DeclaredSecret extends Omit<CredentialSpec, "hint"> {
+  /** Never empty. More than one means several features read the same file. */
+  declaredBy: Declaration[];
   /**
    * What still works without it.
    *
@@ -234,6 +250,29 @@ export interface DeclaredSecret extends CredentialSpec {
   degraded?: string;
 }
 
+/** One declaration, taking the spec's own advice as that declaration's. */
+function declaredAt(spec: CredentialSpec, where: string, degraded?: string): DeclaredSecret {
+  const { hint, ...rest } = spec;
+  return { ...rest, declaredBy: [{ where, hint }], degraded };
+}
+
+/** Every place a ref is declared, as one phrase. */
+export function declaredWhere(secret: DeclaredSecret): string {
+  return secret.declaredBy.map((decl) => decl.where).join(" and ");
+}
+
+/**
+ * The advice across every declaration, each stated once.
+ *
+ * Two jobs sharing a ref share a remedy, and saying it twice reads as two instructions.
+ */
+export function declaredHints(secret: DeclaredSecret): string[] {
+  const hints = secret.declaredBy
+    .map((decl) => decl.hint)
+    .filter((hint): hint is string => hint !== undefined);
+  return [...new Set(hints)];
+}
+
 /**
  * One entry per `secretRef`, however many features read it.
  *
@@ -243,17 +282,13 @@ export interface DeclaredSecret extends CredentialSpec {
  * as "2 declared secret(s) did not resolve" and prompted for twice, which reads as two
  * problems and is one.
  *
- * The merged entry names every place, and is **fatal if any declaration is fatal**: a
+ * The merged entry keeps every declaration, and is **fatal if any declaration is fatal**: a
  * feature that degrades gracefully without the credential does not make the one that cannot
  * start without it any less broken.
  *
- * It keeps a hint only where every declaration gives the same one, under the same reasoning:
- * a remedy is advice about one feature, and the other feature sharing the ref may be the one
- * it is wrong for. Moving a `GITHUB_TOKEN` that a job and a `private` checkout both read into
- * `run.jobSecrets` leaves the clone's declaration unresolved and the launch still refused —
- * so that hint must not survive the merge that proves the gateway needs the value. Two jobs
- * sharing a ref do give the same hint, which is why it does not name their indices: `where`
- * already names every line, and a remedy true of both should read as one remedy.
+ * Keeping them all is what lets each carry its own advice. A single `hint` on the merged
+ * entry could only be one declaration's, so it was either wrong for the others or dropped;
+ * neither states what an operator facing two features and one file actually needs.
  */
 function mergeByRef(declared: DeclaredSecret[]): DeclaredSecret[] {
   const byRef = new Map<string, DeclaredSecret>();
@@ -265,9 +300,8 @@ function mergeByRef(declared: DeclaredSecret[]): DeclaredSecret[] {
     }
     byRef.set(secret.name, {
       ...seen,
-      where: `${seen.where} and ${secret.where}`,
+      declaredBy: [...seen.declaredBy, ...secret.declaredBy],
       degraded: seen.degraded && secret.degraded ? seen.degraded : undefined,
-      hint: seen.hint === secret.hint ? seen.hint : undefined,
     });
   }
   return [...byRef.values()];
@@ -285,50 +319,53 @@ export function declaredSecrets(manifest: AgentManifest, repos: RepoSpec[]): Dec
   manifest.surfaces.forEach((surface, index) => {
     const at = `surfaces[${index}]`;
     if (surface.kind === "buzz" && typeof surface.identity === "string") {
-      declared.push({ ...buzzNsecSpec(surface.identity), where: `${at}.identity (buzz)` });
+      declared.push(declaredAt(buzzNsecSpec(surface.identity), `${at}.identity (buzz)`));
     }
     if (surface.kind === "slack") {
       if (typeof surface.identity === "string") {
-        declared.push({ ...slackBotTokenSpec(surface.identity), where: `${at}.identity (slack)` });
+        declared.push(declaredAt(slackBotTokenSpec(surface.identity), `${at}.identity (slack)`));
       }
       if (typeof surface.appToken === "string") {
-        declared.push({ ...slackAppTokenSpec(surface.appToken), where: `${at}.appToken (slack)` });
+        declared.push(declaredAt(slackAppTokenSpec(surface.appToken), `${at}.appToken (slack)`));
       }
     }
   });
 
   manifest.brains.forEach((brain, index) => {
     if ((brain.preset === "local" || brain.preset === "shared") && brain.age) {
-      declared.push({
-        ...ageIdentitySpec(brain.age.identitySecret, brain.age.recipient),
-        where: `brains[${index}].age.identitySecret`,
-        degraded:
+      declared.push(
+        declaredAt(
+          ageIdentitySpec(brain.age.identitySecret, brain.age.recipient),
+          `brains[${index}].age.identitySecret`,
           "plaintext vault files stay readable; every `*.md.age` slice is denied on read and on write",
-      });
+        ),
+      );
     }
     if (brain.preset === "team") {
       const ref = brain.token ?? DEFAULT_OX_TOKEN_SECRET;
-      declared.push({
-        ...SAGEOX_TOKEN_SPEC,
-        name: ref,
-        where: `brains[${index}].token${brain.token ? "" : ` (defaulted to ${ref})`}`,
-        // The one credential with a second source: `ox login` writes an auth.json that
-        // authenticates just as well, which is why a workstation legitimately has no
-        // token. A deployment mounts neither, and every team_search fails.
-        degraded:
+      declared.push(
+        declaredAt(
+          { ...SAGEOX_TOKEN_SPEC, name: ref },
+          `brains[${index}].token${brain.token ? "" : ` (defaulted to ${ref})`}`,
+          // The one credential with a second source: `ox login` writes an auth.json that
+          // authenticates just as well, which is why a workstation legitimately has no
+          // token. A deployment mounts neither, and every team_search fails.
           "an `ox login` auth.json authenticates instead where one exists; a deployment " +
           "with neither fails every team_search",
-      });
+        ),
+      );
     }
   });
 
   manifest.mcpServers.forEach((decl, index) => {
     const server = resolveMcpServer(decl);
     for (const [envVar, ref] of Object.entries(server.secrets)) {
-      declared.push({
-        ...spawnedSecretSpec(ref, envVar, "the server"),
-        where: `mcpServers[${index}].secrets.${envVar} (server "${server.name}")`,
-      });
+      declared.push(
+        declaredAt(
+          spawnedSecretSpec(ref, envVar, "the server"),
+          `mcpServers[${index}].secrets.${envVar} (server "${server.name}")`,
+        ),
+      );
     }
   });
 
@@ -346,14 +383,18 @@ export function declaredSecrets(manifest: AgentManifest, repos: RepoSpec[]): Dec
   // arrangement the split was for.
   manifest.jobs.forEach((job, index) => {
     for (const [envVar, ref] of Object.entries(job.run.secrets)) {
-      declared.push({
-        ...spawnedSecretSpec(ref, envVar, "the job body"),
-        where: `jobs[${index}].run.secrets.${envVar} (job "${job.slug}")`,
-        hint:
-          `if ${ref} is mounted only in a directory this process is not given, it belongs ` +
-          "in run.jobSecrets rather than run.secrets — this check leaves that map out, and " +
-          "`sageox-agent job run` resolves it per run and fails by name",
-      });
+      declared.push(
+        declaredAt(
+          {
+            ...spawnedSecretSpec(ref, envVar, "the job body"),
+            hint:
+              `if ${ref} is mounted only in a directory this process is not given, it ` +
+              "belongs in run.jobSecrets rather than run.secrets — this check leaves that " +
+              "map out, and `sageox-agent job run` resolves it per run and fails by name",
+          },
+          `jobs[${index}].run.secrets.${envVar} (job "${job.slug}")`,
+        ),
+      );
     }
   });
 
@@ -361,13 +402,43 @@ export function declaredSecrets(manifest: AgentManifest, repos: RepoSpec[]): Dec
   // after warmup has already started, which is late and on a background path.
   const priv = repos.filter((repo) => repo.private);
   if (priv.length) {
-    declared.push({
-      ...GITHUB_TOKEN_SPEC,
-      where: `repos.conf (private: ${priv.map((repo) => repo.name).join(", ")})`,
-    });
+    declared.push(
+      declaredAt(
+        GITHUB_TOKEN_SPEC,
+        `repos.conf (private: ${priv.map((repo) => repo.name).join(", ")})`,
+      ),
+    );
   }
 
   return mergeByRef(declared);
+}
+
+/**
+ * One entry of the "did not resolve" list: the ref, where it is declared, and what to do.
+ *
+ * A ref declared once keeps the one-line form it has always had. Several declarations get a
+ * line each, because they are separate lines in separate files to go and fix — and each
+ * carries the advice belonging to it, since a remedy for one feature can be the wrong move
+ * for the other reading the same file. Declarations that share a remedy are listed together
+ * above it, so it is stated once.
+ */
+function describeDeclared(secret: DeclaredSecret): string {
+  const [only] = secret.declaredBy;
+  if (secret.declaredBy.length === 1) {
+    return `  ${secret.name} — declared by ${only.where}` + (only.hint ? `\n      ${only.hint}` : "");
+  }
+  const groups = declaredHints(secret).map((hint) => ({
+    hint,
+    wheres: secret.declaredBy.filter((decl) => decl.hint === hint).map((decl) => decl.where),
+  }));
+  const unadvised = secret.declaredBy.filter((decl) => !decl.hint).map((decl) => decl.where);
+  const blocks = [
+    ...unadvised.map((where) => `      ${where}`),
+    ...groups.map(
+      (group) => group.wheres.map((where) => `      ${where}`).join("\n") + `\n          ${group.hint}`,
+    ),
+  ];
+  return `  ${secret.name} — declared by:\n${blocks.join("\n")}`;
 }
 
 /**
@@ -391,13 +462,7 @@ export function requireDeclaredSecrets(
   const degraded = missing.filter((secret) => secret.degraded);
 
   if (fatal.length) {
-    const list = fatal
-      .map(
-        (secret) =>
-          `  ${secret.name} — declared by ${secret.where}` +
-          (secret.hint ? `\n      ${secret.hint}` : ""),
-      )
-      .join("\n\n");
+    const list = fatal.map(describeDeclared).join("\n\n");
     throw new Error(
       `${fatal.length} declared secret(s) did not resolve, so this agent cannot do what it ` +
         `is configured to do. Each is read from ${dir}/<name>, then from the environment:\n\n` +

--- a/packages/cli/test/credentials.test.ts
+++ b/packages/cli/test/credentials.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { loadManifest } from "@sageox/agent-toolkit-core";
 import {
   declaredSecrets,
+  declaredWhere,
   spawnedSecretSpec,
   requireCredential,
   requireDeclaredSecrets,
@@ -312,11 +313,11 @@ describe("declared secretRefs", () => {
       "GITHUB_TOKEN", // repos.conf's private clone
     ]);
     // Every one names the line that declares it, not just the ref.
-    expect(declared.map((secret) => secret.where)).toContain("surfaces[1].appToken (slack)");
-    expect(declared.map((secret) => secret.where)).toContain(
+    expect(declared.map(declaredWhere)).toContain("surfaces[1].appToken (slack)");
+    expect(declared.map(declaredWhere)).toContain(
       'mcpServers[0].secrets.TRACKER_API_KEY (server "tracker")',
     );
-    expect(declared.map((secret) => secret.where)).toContain(
+    expect(declared.map(declaredWhere)).toContain(
       'jobs[0].run.secrets.GH_TOKEN (job "nightly")',
     );
   });
@@ -383,20 +384,25 @@ jobs:
     const declared = declaredSecrets(shared, parseReposConf(PRIVATE_REPO));
 
     expect(declared).toHaveLength(1);
-    expect(declared[0].where).toBe(
+    expect(declaredWhere(declared[0])).toBe(
       'jobs[0].run.secrets.GH_TOKEN (job "nightly") and repos.conf (private: service)',
     );
-    expect(declared[0].hint).toBeUndefined();
-    expect(() => requireDeclaredSecrets(declared, { dir: secretsDir })).toThrow(
-      /GITHUB_TOKEN/,
-    );
+
     let message = "";
     try {
       requireDeclaredSecrets(declared, { dir: secretsDir });
     } catch (error) {
       message = (error as Error).message;
     }
-    expect(message).not.toContain("jobSecrets");
+    // Both remedies, each under the line it is true of. The job's is still stated — it is
+    // correct advice about the job — but it can no longer read as advice about the ref,
+    // because the checkout is named right beside it with its own answer.
+    expect(message).toContain(
+      '      jobs[0].run.secrets.GH_TOKEN (job "nightly")\n          if GITHUB_TOKEN is mounted only',
+    );
+    expect(message).toContain(
+      "      repos.conf (private: service)\n          Use a fine-grained token",
+    );
   });
 
   it("keeps that remedy for a ref two jobs share, since it is true of both", () => {
@@ -425,7 +431,7 @@ jobs:
     const declared = declaredSecrets(twoJobs, []);
 
     expect(declared).toHaveLength(1);
-    expect(declared[0].where).toBe(
+    expect(declaredWhere(declared[0])).toBe(
       'jobs[0].run.secrets.GH_TOKEN (job "nightly") and jobs[1].run.secrets.GH_TOKEN (job "weekly")',
     );
     let message = "";
@@ -434,7 +440,14 @@ jobs:
     } catch (error) {
       message = (error as Error).message;
     }
-    expect(message).toContain("run.jobSecrets rather than run.secrets");
+    // Both lines listed, then the remedy once beneath them: it is one instruction, and
+    // repeating it under each would read as two different things to go and do.
+    expect(message).toContain(
+      '      jobs[0].run.secrets.GH_TOKEN (job "nightly")\n' +
+        '      jobs[1].run.secrets.GH_TOKEN (job "weekly")\n' +
+        "          if DEMO_JOB_TOKEN is mounted only",
+    );
+    expect(message.match(/run\.jobSecrets rather than run\.secrets/g)).toHaveLength(1);
     // No index, or it would be advice about one of the two lines it names.
     expect(message).not.toContain("jobs[0].run.jobSecrets");
   });
@@ -504,7 +517,7 @@ mcpServers:
 
     expect(both).toHaveLength(1);
     expect(both[0].name).toBe("GITHUB_TOKEN");
-    expect(both[0].where).toBe(
+    expect(declaredWhere(both[0])).toBe(
       'mcpServers[0].secrets.GITHUB_TOKEN (server "github") and ' +
         "repos.conf (private: service)",
     );
@@ -558,12 +571,12 @@ brains:
   - { preset: team, team: team_jihjpfkt8b${token} }
 `;
     const defaulted = declaredSecrets(loadManifest(team("")), []);
-    expect(defaulted.map((s) => [s.name, s.where])).toEqual([
+    expect(defaulted.map((s) => [s.name, declaredWhere(s)])).toEqual([
       ["SAGEOX_TOKEN", "brains[0].token (defaulted to SAGEOX_TOKEN)"],
     ]);
 
     const named = declaredSecrets(loadManifest(team(", token: DROVER_OX_TOKEN")), []);
-    expect(named.map((s) => [s.name, s.where])).toEqual([
+    expect(named.map((s) => [s.name, declaredWhere(s)])).toEqual([
       ["DROVER_OX_TOKEN", "brains[0].token"],
     ]);
 


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a05f61-120c-78f1-9c02-6bbbd8ae5111">Session</a>
<!-- /sageox:pr-header -->

Closes #18.

## What was needed

`mergeByRef` collapses every declaration of one `secretRef` into a single entry. That is
right — a bundle's GitHub MCP server and a `private` `repos.conf` checkout both reading
`GITHUB_TOKEN` is the ordinary shape, and reporting one missing file as *"2 declared
secret(s) did not resolve"* reads as two problems when it is one.

But the merged entry carried a **singular `hint`** beside an already-**plural `where`**, and
that asymmetry was the bug. Advice is about a feature, not about a ref: a job's
`run.jobSecrets` remedy is the wrong move for the checkout reading the same token, and the
checkout's fine-grained-token advice says nothing about the job.

So there were only two options, and both lose:

- **Keep one** — #16's review caught this. Jobs are pushed before `repos.conf`, so a shared
  `GITHUB_TOKEN` advised *"move it to `run.jobSecrets`"*, which moves a token the gateway's
  own clone needs. Which advice you read was decided by list order.
- **Drop it when they disagree** — what shipped. Correct, and it cost every agent of that
  shape the guidance it used to print.

## What ships

`hint` becomes plural alongside `where`. `DeclaredSecret.declaredBy` is a list of
`{ where, hint }`, and each place states its own answer.

**A ref declared once is byte-identical to before** — the common case did not need changing:

```
  DEPLOY_KEY — declared by jobs[0].run.secrets.GH (job "nightly")
      if DEPLOY_KEY is mounted only in a directory this process is not given, it belongs in
      run.jobSecrets rather than run.secrets — …
```

**Two or more get a line each, with the advice belonging to it:**

```
  GITHUB_TOKEN — declared by:
      jobs[0].run.secrets.GH (job "nightly")
          if GITHUB_TOKEN is mounted only in a directory this process is not given, it
          belongs in run.jobSecrets rather than run.secrets — …
      repos.conf (private: service)
          Use a fine-grained token limited to the repositories this agent may touch — …
```

The job's remedy is stated again, and it is safe to state: it can no longer read as advice
about the *ref*, because the checkout is named right beside it with its own answer. That is
strictly more than either surviving-hint rule could offer.

**Declarations sharing a remedy are grouped above it**, so two jobs needing the same move
read as one instruction rather than two:

```
  DEMO_JOB_TOKEN — declared by:
      jobs[0].run.secrets.GH_TOKEN (job "nightly")
      jobs[1].run.secrets.GH_TOKEN (job "weekly")
          if DEMO_JOB_TOKEN is mounted only in a directory this process is not given, …
```

The hint-equality rule is gone. It was a workaround for the singular field, not a rule about
credentials — this removes the need for it rather than refining it.

Other notes:

- `declaredWhere` and `declaredHints` are what both `run` and `doctor` read, so the two
  cannot drift — the property `declaredSecrets` already states for the inventory itself.
- `doctor` appends every distinct hint rather than the first; with one hint its line is
  unchanged.
- `declaredAt` replaces seven repetitions of `{ ...spec, where }`, and takes the spec's own
  `hint` as that declaration's. `DeclaredSecret` is `Omit<CredentialSpec, "hint">`, so there
  is no second place a hint could hide.
- No behaviour outside the message: the same refs are validated, with the same
  fatal-vs-degraded classification.

## How it was verified

`pnpm test` — 1102 passing. `pnpm typecheck` — clean, root and every package.

Tests cover the single-declaration form, a job sharing a ref with a private checkout (both
remedies present, each under its own line), and two jobs sharing one (grouped, remedy
asserted to appear exactly once).

One thing worth flagging: the first full run after editing the tests reported 2 failures,
and I could not reproduce it in four subsequent full runs or three repeats of the shell-out
suites. Recording it rather than calling it nothing.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a05f61-120c-78f1-9c02-6bbbd8ae5111

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790964819&installation_model_id=433550&pr_number=20&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F20&signature=f53c963267f3ca86c8889f076a63f99a5760390544c6aa9c92e28a1ae79a50f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved secret diagnostics when a secret is declared in multiple locations.
  - Error messages now show all relevant declaration locations and provide location-specific remediation guidance.
  - Duplicate instructions are consolidated for shared declarations.
  - Doctor checks and startup notices now report distinct hints more clearly.
- **Documentation**
  - Added changelog documentation covering improved multi-declaration secret handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->