### PR TITLE
Lead a release with one line per CHANGELOG entry, not the whole section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,12 +175,18 @@ jobs:
           # 1.3.9 backfilled after 1.4.0 would list the pull requests between those two
           # instead of since 1.3.8, and a re-run would then replace a body the first run
           # published with a different one. Read from the same `released` list the alias
-          # arithmetic uses, so both agree on what precedes what. A prerelease matches no
-          # entry and falls out with the newest full release, which is the one it follows.
-          # Empty for the first release ever, and then the field is omitted and GitHub
-          # generates from the first commit.
-          previous=$(printf '%s\n' "$released" \
-            | awk -v v="$VERSION" '$0 == v { exit } { last = $0 } END { print last }')
+          # arithmetic uses, so both agree on what precedes what.
+          #
+          # Found by inserting this version into that list and taking its left neighbour,
+          # under the prerelease suffix rather than beside it: 1.3.10-rc.1 follows 1.3.9,
+          # the release below the line it is a candidate for, and not the newest release in
+          # the repository — which for a candidate on an older line is *ahead* of it, and an
+          # inverted range. `released` holds no suffixes, so that order is total. Empty for
+          # the first release ever, and the field is then omitted and GitHub generates from
+          # the first commit.
+          base="${VERSION%%-*}"
+          previous=$(printf '%s\n%s\n' "$released" "$base" | sort -V \
+            | awk -v v="$base" '$0 == v { exit } { last = $0 } END { print last }')
           echo "Comparing against: ${previous:-no earlier release}"
           echo "previous=${previous}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,20 @@ jobs:
           echo "Publishing: ${tags}"
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"
 
+          # The release this one follows, for the pull-request list GitHub generates below.
+          # Named rather than left to GitHub to infer, because it infers by tag date: a
+          # 1.3.9 backfilled after 1.4.0 would list the pull requests between those two
+          # instead of since 1.3.8, and a re-run would then replace a body the first run
+          # published with a different one. Read from the same `released` list the alias
+          # arithmetic uses, so both agree on what precedes what. A prerelease matches no
+          # entry and falls out with the newest full release, which is the one it follows.
+          # Empty for the first release ever, and then the field is omitted and GitHub
+          # generates from the first commit.
+          previous=$(printf '%s\n' "$released" \
+            | awk -v v="$VERSION" '$0 == v { exit } { last = $0 } END { print last }')
+          echo "Comparing against: ${previous:-no earlier release}"
+          echo "previous=${previous}" >> "$GITHUB_OUTPUT"
+
       # Checked before the build, not after: an hour of multi-arch build that ends with
       # nowhere to record its digest is an expensive way to learn the release notes are
       # missing.
@@ -333,6 +347,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
+          PREVIOUS: ${{ steps.tags.outputs.previous }}
           DIGEST: ${{ steps.image.outputs.digest }}
         run: |
           set -euo pipefail
@@ -344,11 +359,13 @@ jobs:
           # lines and stripped of `**` before the first sentence is cut, so one that opens
           # with a bold lead sentence reads here the same as one that does not.
           summary=$(awk -v heading="## [${VERSION}]" '
-            function flush(  cut, lead) {
+            function flush(  lead) {
               if (bullet == "") return
               gsub(/\*\*/, "", bullet)
-              cut = index(bullet, ". ")
-              lead = cut ? substr(bullet, 1, cut) : bullet
+              if (match(bullet, /[.!?] /))
+                lead = substr(bullet, 1, RSTART)
+              else
+                lead = bullet
               print "- " lead
               bullet = ""
             }
@@ -363,12 +380,13 @@ jobs:
           ' CHANGELOG.md)
 
           # What GitHub generates for a release on its own: every merged pull request with
-          # its author, and the compare link against the previous tag. Asked for through
-          # the API rather than `gh release create --generate-notes`, which `gh release
-          # edit` has no counterpart for — a re-run has to converge on the body the first
-          # run published, and this is the one spelling both paths can share.
+          # its author, and the compare link against the release resolved above. Asked for
+          # through the API rather than `gh release create --generate-notes`, which `gh
+          # release edit` has no counterpart for — a re-run has to converge on the body the
+          # first run published, and this is the one spelling both paths can share.
           generated=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f "tag_name=v${VERSION}" --jq .body)
+            -f "tag_name=v${VERSION}" ${PREVIOUS:+-f "previous_tag_name=v${PREVIOUS}"} \
+            --jq .body)
 
           body=$(printf '%s\n\nEach entry in full: [CHANGELOG.md](https://github.com/%s/blob/v%s/CHANGELOG.md).\n\n## Runtime image\n\n```\n%s@%s\n```\n\nPullable anonymously, `%s`. Pin the digest in production: the `%s` tag is immutable and is never republished.\n\n%s\n' \
             "$summary" "$GITHUB_REPOSITORY" "$VERSION" "$IMAGE" "$DIGEST" "$PLATFORMS" "$VERSION" "$generated")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,12 @@
 # has happened, which is the only thing that keeps the property true a year from now.
 #
 # THE DIGEST IS THE CONTRACT, NOT THE TAG. The deployment contract pins `imageRef` by
-# digest, so each release records its manifest-list digest in its GitHub Release, which
-# quotes that version's CHANGELOG.md section beside it. The workflow writes it because
-# nobody — not the tagger, not the reviewer — knows the digest before the build runs; it
-# writes it to the release rather than onto `main` because that is not a branch write, and
-# because the registry already answers `:VERSION` authoritatively.
+# digest, so each release records its manifest-list digest in its GitHub Release, beside a
+# one-line summary of each of that version's CHANGELOG.md entries and the pull-request list
+# GitHub generates on its own. The workflow writes the digest because nobody — not the
+# tagger, not the reviewer — knows it before the build runs; it writes it to the release
+# rather than onto `main` because that is not a branch write, and because the registry
+# already answers `:VERSION` authoritatively.
 name: Release
 
 on:
@@ -92,7 +93,7 @@ jobs:
 
           # A tag can be pushed at any commit, including one that was never merged. Without
           # this, the official image is built from code nobody reviewed and published under
-          # release notes quoted from main's CHANGELOG — describing an image main's own
+          # release notes drawn from main's CHANGELOG — describing an image main's own
           # source never produced.
           if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
             echo "::error::${GITHUB_REF_NAME} points at a commit that is not on main."
@@ -326,7 +327,7 @@ jobs:
 
       # The release, not `main`: a digest is derived, and the registry already answers
       # `:VERSION` authoritatively, so a tracked copy is a second source that drifts — it
-      # did, on the first release. `CHANGELOG.md` keeps what humans write and is quoted
+      # did, on the first release. `CHANGELOG.md` keeps what humans write and is summarized
       # here. Creating a release is not a branch write, so no ruleset applies.
       - name: Publish the GitHub Release
         env:
@@ -336,15 +337,41 @@ jobs:
         run: |
           set -euo pipefail
 
-          # This version's own section, ended by the next heading.
-          notes=$(awk -v heading="## [${VERSION}]" '
+          # The lead sentence of each entry in this version's CHANGELOG section, under its
+          # own heading. The section itself is the reasoning — 0.2.0's ran to 200 lines —
+          # which pushed the digest and the pull-request list below the fold; it stays in
+          # CHANGELOG.md, linked under the summary. An entry is joined across its wrapped
+          # lines and stripped of `**` before the first sentence is cut, so one that opens
+          # with a bold lead sentence reads here the same as one that does not.
+          summary=$(awk -v heading="## [${VERSION}]" '
+            function flush(  cut, lead) {
+              if (bullet == "") return
+              gsub(/\*\*/, "", bullet)
+              cut = index(bullet, ". ")
+              lead = cut ? substr(bullet, 1, cut) : bullet
+              print "- " lead
+              bullet = ""
+            }
             index($0, heading) == 1 { inside = 1; next }
-            inside && /^## / { exit }
-            inside { print }
+            !inside { next }
+            /^## / { flush(); exit }
+            /^### / { flush(); sub(/^### /, "## "); if (seen++) print ""; print; print ""; next }
+            /^- / { flush(); bullet = substr($0, 3); next }
+            /^ / && bullet != "" { sub(/^ +/, ""); bullet = bullet " " $0; next }
+            /^$/ { flush() }
+            END { flush() }
           ' CHANGELOG.md)
 
-          body=$(printf '%s\n\n## Runtime image\n\n```\n%s@%s\n```\n\nPullable anonymously, `%s`. Pin the digest in production: the `%s` tag is immutable and is never republished.\n' \
-            "$notes" "$IMAGE" "$DIGEST" "$PLATFORMS" "$VERSION")
+          # What GitHub generates for a release on its own: every merged pull request with
+          # its author, and the compare link against the previous tag. Asked for through
+          # the API rather than `gh release create --generate-notes`, which `gh release
+          # edit` has no counterpart for — a re-run has to converge on the body the first
+          # run published, and this is the one spelling both paths can share.
+          generated=$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f "tag_name=v${VERSION}" --jq .body)
+
+          body=$(printf '%s\n\nEach entry in full: [CHANGELOG.md](https://github.com/%s/blob/v%s/CHANGELOG.md).\n\n## Runtime image\n\n```\n%s@%s\n```\n\nPullable anonymously, `%s`. Pin the digest in production: the `%s` tag is immutable and is never republished.\n\n%s\n' \
+            "$summary" "$GITHUB_REPOSITORY" "$VERSION" "$IMAGE" "$DIGEST" "$PLATFORMS" "$VERSION" "$generated")
 
           # GitHub hands its own "Latest release" badge to the newest release not marked
           # prerelease — a second `latest`, which the image tags above do not govern. An rc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A GitHub Release leads with one line per entry here, not the whole section.** Quoting
+  the section put a screen of *why* above the image digest — the one thing a deployment
+  needs from the release — and above the pull-request list GitHub generates for the tag.
+  The body is now each entry's lead sentence under its Added / Changed / Fixed heading,
+  then the digest, then that generated list, with this file linked for the rest. Write an
+  entry's first sentence to stand alone: it is what the release notes show.
+
 ## [0.2.0] - 2026-09-02
 
 Everything below shipped after `v0.1.0`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,10 @@ Maintainers cut a release from `main` in two steps:
 [`release.yml`](.github/workflows/release.yml) does the rest: it builds the
 runtime image for `linux/amd64` and `linux/arm64`, pushes it to
 `ghcr.io/sageox/agent-base`, checks that it is pullable with no credentials, and
-publishes a GitHub Release quoting that version's CHANGELOG section with the
-published digest under it. Production pins that digest; the tags are for humans.
+publishes a GitHub Release: the lead sentence of each of that version's CHANGELOG
+entries, the published digest, and the pull requests GitHub lists for the tag.
+Production pins that digest; the tags are for humans. Write each CHANGELOG entry
+so its first sentence stands alone — that sentence is the release note.
 
 A re-run reuses the digest already published under that version rather than
 building a second one, so a release that failed *after* its push is repaired by


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06364-031d-7474-b4de-453297a39266">Session</a>
<!-- /sageox:pr-header -->

## Summary

A release page tells you what changed and what to pull. Ours buried both: the body was
this version's CHANGELOG section quoted verbatim — **215 lines** of prose for 0.2.0 — so
the image digest, the one thing a deployment needs from a release, sat below a screen of
reasoning, and the pull-request list GitHub generates for a tag was never there at all.

The body is now **36 lines**: each entry's lead sentence under its `Added` / `Changed` /
`Fixed` heading, the digest, and GitHub's own `What's Changed` list with the compare link.
`CHANGELOG.md` is linked for the rest, so nothing is lost — it moves to where a reader
goes when a one-liner is not enough.

<details>
<summary>What v0.2.0's release body becomes</summary>

```markdown
## Added

- A Slack agent reads a mention as a name, not an id.
- A probing job can read its thread back on Slack, so a roll call there has an answer.
- A probing job body can address its post, so the agents it names actually wake.
- A bundle can say which of a job's credentials the gateway's own process must not hold.

## Changed

- The agent base image ships `ox` 0.14.3.

## Fixed

- A broadcast in a Slack message is escaped and logged instead of throwing, so the turn ends in an answer.
- A scheduled job runs wherever the cluster puts it, instead of only on the agent's node.
- The launch a job-only credential refuses now names the field that would let it start.
- A job a person asks for runs, even when its kill switch is parked.
- A DM sent to a Slack agent while it was down is answered when it comes back.
- A Slack message says what the brain wrote, and addresses only whom `mentions` names.

Each entry in full: [CHANGELOG.md](https://github.com/sageox/agent-toolkit/blob/v0.2.0/CHANGELOG.md).

## Runtime image

ghcr.io/sageox/agent-base@sha256:…

Pullable anonymously, `linux/amd64,linux/arm64`. Pin the digest in production: the `0.2.0` tag is immutable and is never republished.

## What's Changed
* … every merged pull request, its author, and the compare link — generated by GitHub
```

</details>

Three details worth review:

- **The summary is derived, not authored.** `awk` takes each entry's first sentence —
  cut at `.`, `!`, or `?` followed by a space — joining wrapped lines and dropping `**`
  first, so an entry that opens with a bold lead and one that does not read the same. No
  new convention to maintain — CONTRIBUTING now says the consequence: write an entry's
  first sentence to stand alone, because it is the release note.
- **`releases/generate-notes`, not `gh release create --generate-notes`.** `gh release
  edit` has no counterpart flag, and this step must be idempotent — a re-run repairs a
  release that failed after its push, so both paths have to compose the same body.
- **The comparison base is named, not inferred.** GitHub infers it by tag date, so a
  1.3.9 backfilled after 1.4.0 would list the pull requests between those two instead of
  since 1.3.8, and a re-run would replace a published body with a different one.
  `previous_tag_name` is resolved from the same `released` list the floating-alias
  arithmetic uses, matched on the base version so a candidate follows the release below
  its own line (`1.3.10-rc.1` → `1.3.9`) rather than the newest release in the repository,
  which would be an inverted range.

## Test Plan

The step's shell was extracted from the workflow and run against the real `CHANGELOG.md`
with a stubbed `gh`, for every version section the file holds:

```
$ VERSION=0.2.0 … bash -c 'source ./step.sh; printf "%s\n" "$body"'
36 lines — the body quoted above
```

- `0.1.0` and `0.1.0-rc.1` were run too. Their older entries have plain, non-bold bullets;
  the first-sentence cut handles both shapes, so a backfill of the existing releases reads
  the same as a new one.
- `python3 -c "import yaml; yaml.safe_load(...)"` — the workflow still parses.
- `pnpm test` — 1102 passed (63 files). `pnpm typecheck` — clean.

The predecessor arithmetic was run against the tag step as it executes, for every shape
it has to handle:

| version | `released` | `previous` |
|---|---|---|
| 0.2.0 | 0.1.0, 0.2.0 | 0.1.0 |
| 0.1.0, first release ever | — | empty, field omitted |
| 1.3.9 backfilled after 1.4.0 | 1.3.8, 1.3.9, 1.4.0 | 1.3.8 |
| 1.3.10-rc.1, candidate on an older line | 1.3.8, 1.3.9, 1.4.0 | 1.3.9 |
| 1.5.0-rc.1 | 1.3.8, 1.3.9, 1.4.0 | 1.4.0 |

The alias arithmetic in that same step is unchanged: 0.2.0 still resolves
`:0.2.0,:0.2,:latest`, and a candidate still resolves its own `:VERSION` and nothing else.

No unit test accompanies this: the change is a GitHub Actions shell step, which this
repository has no harness for. It was verified by running the step itself, as above.

**Already applied to the two published releases.** [v0.2.0](https://github.com/sageox/agent-toolkit/releases/tag/v0.2.0)
went from 219 lines to 46 and [v0.1.0](https://github.com/sageox/agent-toolkit/releases/tag/v0.1.0)
from 56 to 24, using this same step so they read identically to future ones. Each recorded
digest was checked byte-for-byte after the edit — `sha256:fd0dfa8b…` and `sha256:e84c494f…`
are unchanged, and the Latest badge still sits on v0.2.0.

<details>
<summary>Checklist</summary>

- [x] Tests added, or N/A documented — N/A, documented above
- [x] `pnpm typecheck && pnpm test` green
- [x] Deployment checks run if `deploy/` changed — `deploy/` untouched
- [x] CHANGELOG entry added if user-facing
- [x] Breaking change documented — none; the published digest and tags are unchanged
- [x] Docs updated if behavior or configuration changed — `CONTRIBUTING.md` releasing section

</details>

SageOx-Session: https://sageox.ai/c/ses_01a06364-031d-7474-b4de-453297a39266
