### PR TITLE
Say what a job body finds on disk, since one door has a workspace and the other does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The job body contract says what a body finds on disk.** A body must not read
+  `workspace/` — the repository checkouts and the `ox` index there are built by
+  `sageox-agent run`, in its own process, so what a body finds there depends on where it is
+  running: a run the brain starts is inside that process and, on an agent whose brain has
+  code tools, sees one — while every other run is a standalone `job run`, which builds no
+  workspace whatever its trigger. A body that reads a checkout works when someone asks for
+  it and fails on its tick. `docs/job-contract.md` has the rule, what to do instead, and
+  why a shared working tree is the wrong fix; `job run` is now held to it by a test that fails if
+  it ever starts warming a workspace of its own.
+
 ### Changed
 
 - **A GitHub Release leads with one line per entry here, not the whole section.** Quoting

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -106,6 +106,30 @@ still what most jobs should be.
 **If your body shells out to a coding harness, declare its key** — `ANTHROPIC_API_KEY` is
 not inherited any more than anything else is.
 
+## What a body finds on disk
+
+**The bundle, and nothing your body did not put there.** A run starts in the agent's
+directory — `./body.sh` resolves because of it. In a container deployment a scheduled run
+stages that directory for itself, fresh, and drops it when the run ends.
+
+**`workspace/` is not part of it, and a body must not read it.** The repository checkouts
+under `workspace/repos` and the `ox` index under `workspace/ox-data` belong to
+`sageox-agent run`: it builds them at startup, in its own process, for the brain's code
+tools. Nothing else builds them — not `job run`, whatever its trigger — so what a body finds
+there depends on where it is running. A run the brain starts is inside the gateway's own
+process, and on an agent whose brain has code tools it does see a workspace: a racing one,
+because startup creates each repository's directory before `git` fills it and waits for
+neither the clone nor the index. Every other run is a standalone `job run`, which builds
+none, and in a container deployment does not share a filesystem with the gateway at all. A
+body that reads a checkout is a body that works when someone asks for it and fails on its
+3am tick.
+
+**A body that wants a repository clones one** — shallow, and inside its budget. Durable state
+a body genuinely shares with the agent is a mount the deployment gives it
+([`sharedVolumes`](../deploy/helm/README.md#jobs) is the Kubernetes spelling), and a working
+tree is not that: the agent fast-forwards its checkout at every start, so a body writing
+there is a second writer on a tree it does not own.
+
 ## What the job writes back
 
 The artifact is gates you **ran**, never a verdict you reached — the host mints the verdict,

--- a/packages/cli/test/job-run.test.ts
+++ b/packages/cli/test/job-run.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -87,6 +87,19 @@ describe("sageox-agent job run", () => {
     const { stdout } = await job("shift", "--trigger", "webhook");
 
     expect(stdout).toContain(`envelope shift/webhook/3 in ${realpathSync(bundle)}`);
+  });
+
+  it("warms no repository workspace, so a body cannot come to depend on one", async () => {
+    // Declared and still not built. The clone, the fast-forward and `ox index code` belong
+    // to `run`, and a body that read what they leave behind would work on the chat door —
+    // which runs inside that process — and find nothing on the tick.
+    writeFileSync(join(bundle, "repos.conf"), "https://github.com/acme/service\n");
+    body('echo "workspace $([ -d workspace ] && echo present || echo absent)"');
+    const { stdout, code } = await job("shift");
+
+    expect(code).toBe(0);
+    expect(stdout).toContain("workspace absent");
+    expect(existsSync(join(bundle, "workspace"))).toBe(false);
   });
 
   it("passes a declared target through, converting the text a command line can only carry", async () => {


### PR DESCRIPTION
Closes #17.

## What #17 asked

Whether a job body that wants a repository checkout needs one staged for it, now that a job
Pod's `/agents` is a per-run `emptyDir`. Its own test was: does such a body exist, and what
does the clone cost it?

## What I found instead

Every factual claim in #17 holds at `58acb35` — `createRepoWorkspace` and `.warm()` still
have one call site each, both in `runCmd` (`packages/cli/src/cli.ts:1317`, `:1347`), and
`jobCmd` builds neither. But the framing understates the problem, and in a way that matters
more than the missing checkout:

**The same body sees a different disk depending on which door it came through.**

| door | process | `workspace/repos/<name>` |
|---|---|---|
| `trigger.onRequest`, from chat | the gateway (`cli.ts:364`) | present — warm, or still filling |
| `trigger.schedules`, a CronJob | `job run` (`cli.ts:1629`) | does not exist |
| `job run --trigger on-request`, a terminal | `job run` | whatever the directory it is pointed at has — none in a job container, the gateway's own on a single host |

`join(agent.dir, "workspace")` appears exactly once in the codebase, in `runCmd`. The
init container copies `/config` and nothing else, so in a job Pod there is no `workspace/`
at all — not an empty one, none. And the door that *does* have it is a race: `warm()` is
`void`-ed at `cli.ts:1347`, and `createRepoWorkspace` mkdirs each repository's directory
before `git` fills it, on purpose ("The brain can start in this directory while git fills
it"). A body probing with `existsSync` gets `true` and finds an empty tree.

So the failure mode is not "a body pays for its own clone." It is: **a body that reads a
checkout works when someone asks for it in chat and fails on its 3am tick.**

## Why documentation is the whole fix

All three options in #17 already work with no toolkit code, and #17's preferred one is worth
a warning it does not currently carry:

1. `sharedVolumes` with an RWX claim — renders into both pod specs today from the same
   helper (`deployment.yaml:77` / `cronjob.yaml:130`), so it works. **But it makes the body a
   second writer on a tree the agent rewrites at every launch** — `warm()` runs
   `git pull --ff-only` in it on every Deployment start. Right for read-mostly durable
   state; wrong for a tree a body works in.
2. A shallow clone in the body — seconds, and the body's own business.
3. Caching the `ox` index — the genuinely expensive part, and warming a capability a job
   body does not have: it runs with no brain in the loop.

Making the doors symmetric is not available. The body's cwd is the bundle by design, and
`workspace/` is a subdirectory of it — you cannot hide it from the gateway's door without
moving the workspace out of the agent directory, which would break the remedy paths
`repos.ts` prints. Warming on the job door is worse: `ox index code` carries a 30-minute
timeout, inside a budget measured in minutes.

That leaves stating the rule where the person who needs it will read it.

## The change

`docs/job-contract.md` — the document a body author reads — described env, params, the
verdict artifact and the report channel, and **said nothing about the filesystem at all**.
The `emptyDir` fact was documented twice, in `deploy/helm/README.md:349` and
`docs/deployment-contract.md:148`, both read by the operator rather than by the person
writing `runner/src/sweep.ts`.

A new "What a body finds on disk" section now carries the rule, the shallow clone as the
answer, and why a shared working tree is not one. The Kubernetes spelling stays behind a
link to the chart README, per `docs/naming.md`'s division.

The test pins the half that is behavior: `job run` builds no workspace even with a
`repos.conf` declared. Reverted against a `jobCmd` that calls `createRepoWorkspace`, it
fails with `workspace present`.

`pnpm test` (1103 passing) and `pnpm typecheck` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a06447-c232-77b8-939f-617cf484fc4f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790981922&installation_model_id=433550&pr_number=26&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F26&signature=810d4aa89d3d3ac076539b42da96a645bab0f71333187060131bb5c1b1bade8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified which files are available during job execution.
  - Documented that job bodies must not directly access `workspace/`.
  - Explained differences in repository and index visibility between chat-launched and standalone scheduled runs.
  - Added guidance for shallow repository clones and explicitly mounted durable volumes.

- **Bug Fixes**
  - Standalone job execution no longer creates a repository workspace when repositories are configured.
  - Added coverage confirming the workspace remains unavailable during these runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
