### PR TITLE
Latch what a team lookup proved, so a dead credential is not silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   then the digest, then that generated list, with this file linked for the rest. Write an
   entry's first sentence to stand alone: it is what the release notes show.
 
+### Fixed
+
+- **A dead SageOx credential no longer degrades an agent in silence.** Every `team_search`
+  failed and the agent went on answering team-knowledge questions from the model alone —
+  the confident wrong answer, reached from a direction nothing was watching. The only trace
+  was one `ox_failed class=not-authenticated` line per turn in the gateway log. The team
+  brain now latches what each lookup proved as a capability reading, `brain.team` /
+  `cannot-reach`, so the turn prompt tells the agent not to answer as if team memory had
+  worked and the launch prints a `note:` line naming the credential to rotate. An answered
+  lookup clears the reading, so rotating the credential needs no restart.
+
+  `run` also takes one reading at startup. `doctor` was the only thing that ever checked
+  the credential and a deployment does not run `doctor`, so a credential already dead at
+  deploy time was exactly as silent as one revoked later. It is a capability and not a
+  precondition: an agent without team memory is less informed, not wrong, so it still comes
+  up, works, and discloses.
+
+  Two failure classes latch and only two — a rejected credential, and an `ox` that is not
+  on `PATH`. A lookup that merely fell over does not: the next one may well answer, and
+  announcing an outage a retry disproves is how people learn to skim announcements.
+
 ## [0.2.0] - 2026-09-02
 
 Everything below shipped after `v0.1.0`.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -32,6 +32,13 @@ from the gateway's `PATH`, `not-authenticated` is a credential to mount or rotat
 and will not fix itself by retrying, `unreadable` is output this gateway could not parse,
 and `failed` is everything else, where `detail` is the whole story.
 
+The first two also latch as the `brain.team` capability, because retrying cannot disprove
+either: `run` prints `note: brain.team — …` with what to do, and the agent is told to stop
+answering as if team memory had worked. The next lookup that gets an answer clears the
+reading, so a rotated credential needs no restart. `unreadable` and `failed` do not latch —
+the next lookup may well answer, and an announcement a retry disproves is one people learn
+to skim.
+
 **`ox_failed … class=failed detail="… permission denied"`.**
 `ox` needs a writable working directory. The gateway runs it from the home directory for
 this reason; if you have changed that, point it somewhere writable.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,6 +28,7 @@ import {
   makeOxTeam,
   serveTeamBrain,
   type HostedMcp,
+  type TeamBrain,
   resolveSecret,
   type AgentManifest,
   type Brain,
@@ -256,6 +257,12 @@ async function buildBrain(
   react: boolean;
   /** Present only when the job tool is served — see the shutdown path in `runCmd`. */
   jobs?: JobHost;
+  /**
+   * Present only when a team brain is configured. `runCmd` probes it once and hands its
+   * readings to the gateway, which is the only capability source here other than the code
+   * workspace.
+   */
+  team?: TeamBrain;
 }> {
   const nothingToClose = async () => {};
   if (manifest.brain.provider === "mock") {
@@ -397,6 +404,7 @@ async function buildBrain(
     addHosted(JOB_SERVER, server, `job tool (${requestable.map((l) => l.slug).join(", ")})`);
   }
 
+  let teamBrain: TeamBrain | undefined;
   for (const cfg of wiring.hosted) {
     let server: HostedMcp;
     if (cfg.preset === "vault") {
@@ -425,16 +433,16 @@ async function buildBrain(
         serveAt,
       );
     } else {
-      server = await serveTeamBrain(
-        makeOxTeam({
-          team: cfg.team,
-          repo: cfg.repo,
-          configHome: cfg.configHome,
-          // Resolved here, in the gateway. File-first: a mounted secret beats an env var.
-          token: resolveSecret(cfg.token, { dir: secretsDir }),
-        }),
-        serveAt,
-      );
+      // Held, not just served: this is the one brain that measures its own health, and
+      // `runCmd` puts those readings in the gateway's capability closure.
+      teamBrain = makeOxTeam({
+        team: cfg.team,
+        repo: cfg.repo,
+        configHome: cfg.configHome,
+        // Resolved here, in the gateway. File-first: a mounted secret beats an env var.
+        token: resolveSecret(cfg.token, { dir: secretsDir }),
+      });
+      server = await serveTeamBrain(teamBrain, serveAt);
     }
     addHosted(cfg.name, server, `${cfg.preset === "vault" ? cfg.brainPreset : cfg.preset} brain`);
   }
@@ -465,6 +473,7 @@ async function buildBrain(
     postMessage,
     react,
     jobs,
+    team: teamBrain,
   };
 }
 
@@ -1357,7 +1366,7 @@ async function runCmd(argv: string[]): Promise<void> {
   const state = loadState(statePath);
   const adapters = await buildAdapters(manifest, { secretsDir, since: state.since });
   const egress = new SurfaceEgress({ manifest, adapters });
-  const { brain, closeHosted, postMessage, react, jobs } = await buildBrain(
+  const { brain, closeHosted, postMessage, react, jobs, team } = await buildBrain(
     manifest,
     agent.dir,
     secretsDir,
@@ -1365,6 +1374,18 @@ async function runCmd(argv: string[]): Promise<void> {
     codeWorkspace,
     policy,
   );
+
+  // One lookup, so a credential that was already dead at deploy time is not first noticed
+  // by an agent answering a team-knowledge question from the model alone. Off the startup
+  // path for the same reason the code index is: an unusable team brain leaves this agent
+  // less informed, not wrong, so it comes up, works, and discloses.
+  if (team) {
+    void team.probe().then(() => {
+      for (const r of team.readings().filter(isActionable)) {
+        process.stdout.write(`  note: ${r.capability} — ${r.reason}; ${r.remedy}\n`);
+      }
+    });
+  }
 
   // Subscribe before the brain is ready — upstream's `--lazy-pool` exists for the same
   // reason. A brain that takes seconds to come up must not cost us the mentions that
@@ -1390,7 +1411,10 @@ async function runCmd(argv: string[]): Promise<void> {
           team: manifest.brains.some((b) => b.preset === "team"),
         }
       : undefined,
-    capabilities: codeWorkspace ? () => codeWorkspace.readings() : undefined,
+    // Re-read every turn, never captured: the team reading changes when a lookup fails or
+    // succeeds, and a latched one handed over as a value would outlive the credential that
+    // was rotated to clear it.
+    capabilities: () => [...(codeWorkspace?.readings() ?? []), ...(team?.readings() ?? [])],
   });
 
   // Persist the resume cursor periodically and on exit, so a restart does not reopen a

--- a/packages/core/src/health.ts
+++ b/packages/core/src/health.ts
@@ -48,6 +48,11 @@ const PROBE_FAILURES = [
   "clone-failed",
   "fetch-failed",
   "index-failed",
+  // The team brain's two, spelled the same as the `OxFailure` classes they are latched
+  // from, so `failure=not-authenticated` here and `class=not-authenticated` on the
+  // `ox_failed` line are one word to grep for rather than two.
+  "not-installed",
+  "not-authenticated",
 ] as const;
 export type ProbeFailure = (typeof PROBE_FAILURES)[number];
 

--- a/packages/core/src/team-server.ts
+++ b/packages/core/src/team-server.ts
@@ -160,8 +160,21 @@ export interface TeamBrain extends TeamOx {
  */
 export function makeOxTeam(scope: OxScope = {}): TeamBrain {
   let reading: ProbeResult | undefined;
+  // Which lookup's outcome `reading` currently holds. Completion order is not start order:
+  // the launch probe runs alongside the first turns, and `ChannelQueue` runs one turn per
+  // channel rather than one at a time, so two lookups can be in flight. A slow older `Ok`
+  // landing after a newer auth failure would restore exactly the silence this reading
+  // exists to break, so an outcome is dropped when something newer has already recorded.
+  let started = 0;
+  let recorded = 0;
 
   const search: TeamSearch = async (query, limit) => {
+    const lookup = ++started;
+    const record = (result: ProbeResult) => {
+      if (lookup < recorded) return;
+      recorded = lookup;
+      reading = result;
+    };
     const args = ["query", query, "--json", "--limit", String(limit)];
     if (scope.team) args.push("--team", scope.team);
     if (scope.repo) args.push("--repo", scope.repo);
@@ -176,11 +189,13 @@ export function makeOxTeam(scope: OxScope = {}): TeamBrain {
           // second wording of it: both reach a turn, and two spellings of one fact drift
           // into the agent hearing one thing per lookup and another from its capability
           // block.
-          reading = probeUnavailable(
-            TEAM_CAPABILITY,
-            latch.failure,
-            latch.remedy,
-            OX_FAILURE_TEXT[error.failure],
+          record(
+            probeUnavailable(
+              TEAM_CAPABILITY,
+              latch.failure,
+              latch.remedy,
+              OX_FAILURE_TEXT[error.failure],
+            ),
           );
         }
       }
@@ -190,7 +205,7 @@ export function makeOxTeam(scope: OxScope = {}): TeamBrain {
     // before is over. Zero passages is still `Ok` and never `Empty` — `ox query` reports no
     // corpus size, and one query matching nothing is also what a team with plenty written
     // down returns to unlucky wording.
-    reading = probeOk(TEAM_CAPABILITY, "team memory answered this gateway's last lookup");
+    record(probeOk(TEAM_CAPABILITY, "team memory answered this gateway's last lookup"));
     return (out as { team_context?: { results?: TeamPassage[] } }).team_context?.results ?? [];
   };
 

--- a/packages/core/src/team-server.ts
+++ b/packages/core/src/team-server.ts
@@ -9,6 +9,7 @@ import {
   type McpHandler,
   type ServeOptions,
 } from "./mcp-http.ts";
+import { probeOk, probeUnavailable, type ProbeFailure, type ProbeResult } from "./health.ts";
 
 const run = promisify(execFile);
 
@@ -127,20 +128,80 @@ export interface TeamOx {
 }
 
 /**
+ * The ox-backed surface, plus the capability health its own lookups measure.
+ *
+ * Health is not on {@link TeamOx} because {@link teamBrainHandler} never reads it. What
+ * the brain is told about a failed lookup is the per-turn sentence in
+ * {@link OX_FAILURE_TEXT}; the latched reading is for the gateway's capability closure and
+ * the operator's terminal, which are the two places that sentence never reaches.
+ */
+export interface TeamBrain extends TeamOx {
+  /**
+   * One lookup at launch, so a credential that is already dead at deploy time is no more
+   * silent than one revoked later. Nothing else in `run` checks: `oxStatus()` is called
+   * only by `init` and `doctor`, and a deployment runs neither.
+   *
+   * Never throws — the outcome is the reading.
+   */
+  probe(): Promise<void>;
+  /**
+   * This brain's capability health, live, as the closure handed to `Gateway` wants it.
+   * Empty until a lookup has happened: a reading before then would be a claim about a
+   * credential nothing has tried.
+   */
+  readings(): readonly ProbeResult[];
+}
+
+/**
  * Builds the ox-backed team surface, bound to one team.
  *
  * `configHome` points ox at its token file. This runs in the gateway, so the credential
  * stays on this side of the boundary; the brain never sees it.
  */
-export function makeOxTeam(scope: OxScope = {}): TeamOx {
+export function makeOxTeam(scope: OxScope = {}): TeamBrain {
+  let reading: ProbeResult | undefined;
+
+  const search: TeamSearch = async (query, limit) => {
+    const args = ["query", query, "--json", "--limit", String(limit)];
+    if (scope.team) args.push("--team", scope.team);
+    if (scope.repo) args.push("--repo", scope.repo);
+    let out: unknown;
+    try {
+      out = await runOx(args, scope, oxCwd(scope));
+    } catch (error) {
+      if (error instanceof OxCallError) {
+        const latch = LATCHED[error.failure];
+        if (latch) {
+          // `reason` is the same sentence the failed lookup itself hands the brain, not a
+          // second wording of it: both reach a turn, and two spellings of one fact drift
+          // into the agent hearing one thing per lookup and another from its capability
+          // block.
+          reading = probeUnavailable(
+            TEAM_CAPABILITY,
+            latch.failure,
+            latch.remedy,
+            OX_FAILURE_TEXT[error.failure],
+          );
+        }
+      }
+      throw error;
+    }
+    // An answer is the proof: ox ran, the credential was accepted, and whatever was latched
+    // before is over. Zero passages is still `Ok` and never `Empty` — `ox query` reports no
+    // corpus size, and one query matching nothing is also what a team with plenty written
+    // down returns to unlucky wording.
+    reading = probeOk(TEAM_CAPABILITY, "team memory answered this gateway's last lookup");
+    return (out as { team_context?: { results?: TeamPassage[] } }).team_context?.results ?? [];
+  };
+
   return {
-    search: async (query, limit) => {
-      const args = ["query", query, "--json", "--limit", String(limit)];
-      if (scope.team) args.push("--team", scope.team);
-      if (scope.repo) args.push("--repo", scope.repo);
-      const out = await runOx(args, scope, oxCwd(scope));
-      return (out as { team_context?: { results?: TeamPassage[] } }).team_context?.results ?? [];
+    search,
+    // The query is a fixed word and the passages are thrown away: what is being read here
+    // is whether ox answers at all.
+    probe: async () => {
+      await search("team", 1).catch(() => {});
     },
+    readings: () => (reading ? [reading] : []),
   };
 }
 
@@ -236,11 +297,54 @@ export function classifyOxFailure(e: { code?: string; stderr?: string }): OxFail
 }
 
 /**
+ * A failed `ox` call, carrying its class. The message is still the fixed per-class
+ * sentence: the class is a second field so a caller can act on it, never a second thing to
+ * parse back out of the text.
+ */
+export class OxCallError extends Error {
+  constructor(
+    readonly failure: OxFailure,
+    message: string,
+  ) {
+    super(message);
+    this.name = "OxCallError";
+  }
+}
+
+/** The capability id this brain's health is reported under. */
+const TEAM_CAPABILITY = "brain.team";
+
+/**
+ * The failure classes worth latching as capability health, and what a person does about
+ * each.
+ *
+ * `failed` and `unreadable` are absent, and that is the judgement here. Latching sends a
+ * human somewhere — `needsHuman` is what the operator note and the degraded turn block are
+ * built on — so it is for what retrying cannot disprove. A lookup that fell over once may
+ * well answer the next time; a missing binary and a rejected credential stay broken until
+ * somebody acts.
+ */
+const LATCHED: Partial<Record<OxFailure, { failure: ProbeFailure; remedy: string }>> = {
+  "not-installed": {
+    failure: "not-installed",
+    remedy:
+      "install the `ox` CLI in this agent's image, or drop the team brain from agent.yaml, " +
+      "then restart",
+  },
+  "not-authenticated": {
+    failure: "not-authenticated",
+    remedy:
+      "rotate this deployment's SageOx credential — the secret the team brain's `token` " +
+      "names, or the auth file under its `configHome` — then restart",
+  },
+};
+
+/**
  * The two halves of a failure, together so neither can be raised without the other: a
  * fixed string for the brain, and the detail on the gateway's own log, which the brain
  * never reads. Same split `GuardVerdict` makes between `reason` and the audit line.
  */
-function oxFailed(verb: string, failure: OxFailure, detail: string | undefined): Error {
+function oxFailed(verb: string, failure: OxFailure, detail: string | undefined): OxCallError {
   // Collapsed and bounded so the line stays readable, then quoted as JSON so it cannot
   // end early: a `"` in ox's output would otherwise close `detail` and let the rest of it
   // read as fields of its own — a forged `class=` sends an operator after the wrong cause,
@@ -248,7 +352,7 @@ function oxFailed(verb: string, failure: OxFailure, detail: string | undefined):
   // the only free text here.
   const one = (detail ?? "").replace(/\s+/g, " ").trim().slice(0, 500);
   console.warn(`ox_failed verb="${verb}" class=${failure} detail=${JSON.stringify(one || "none")}`);
-  return new Error(`ox ${verb}: ${OX_FAILURE_TEXT[failure]}`);
+  return new OxCallError(failure, `ox ${verb}: ${OX_FAILURE_TEXT[failure]}`);
 }
 
 async function runOx(args: string[], scope: OxScope, cwd: string): Promise<unknown> {

--- a/packages/core/test/team-server.test.ts
+++ b/packages/core/test/team-server.test.ts
@@ -260,8 +260,27 @@ describe("the team brain's own capability health", () => {
     `    while [ ! -f ./release ]; do sleep 0.02; done\n` +
     `    echo '{"team_context":{"results":[]}}'\n` +
     `    exit 0;;\n` +
+    `  *flaky*) echo "Error: the team context service is unavailable" >&2; exit 1;;\n` +
     `esac\n` +
     `echo "${REVOKED}" >&2\nexit 1`;
+
+  it("lets a success outlive a newer transient failure and clear the latch", async () => {
+    // The other half of the ordering rule, and it is deliberate: a `failed` lookup records
+    // nothing, so it does not make a newer-started success stale. Suppressing that success
+    // would hold `Unavailable` on evidence nobody has — and delay exactly the recovery a
+    // rotated credential is supposed to get without a restart.
+    const { value } = await withFakeOx(HELD_THEN_REVOKED, async (brain, bin) => {
+      await brain.search("revoked", 5).catch(() => {});
+      const latched = brain.readings()[0].health;
+      const held = brain.search("slow", 1).catch(() => {});
+      await until(() => existsSync(join(bin, "blocked")), "the held lookup to start");
+      await brain.search("flaky", 5).catch(() => {});
+      writeFileSync(join(bin, "release"), "");
+      await held;
+      return [latched, brain.readings()[0].health];
+    });
+    expect(value).toEqual(["Unavailable", "Ok"]);
+  });
 
   it("reports nothing until a lookup has been made", async () => {
     // Not `Ok`: nothing has tried the credential yet, and a reading is a claim about it.

--- a/packages/core/test/team-server.test.ts
+++ b/packages/core/test/team-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -32,6 +32,18 @@ function fakeOx(over: Partial<TeamOx> = {}): TeamOx {
     search,
     ...over,
   };
+}
+
+/**
+ * Waits for a condition rather than for a duration. A test that sleeps its way to an
+ * ordering asserts how loaded the machine was, and passes on either answer.
+ */
+async function until(condition: () => boolean, what: string): Promise<void> {
+  for (let attempt = 0; attempt < 500; attempt++) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${what}`);
 }
 
 /**
@@ -238,11 +250,16 @@ describe("the team brain's own capability health", () => {
     `if [ -f ./fail ]; then cat ./fail >&2; exit 1; fi\n` +
     `echo '{"team_context":{"results":[]}}'`;
   const REVOKED = "Error: team context query failed: not authenticated. Run 'ox login' first";
-  // A lookup whose query says `slow` answers a second late; every other one is refused now.
-  // That is enough to start one lookup before another and have it finish after.
-  const SLOW_THEN_REVOKED =
+  // A lookup whose query says `slow` announces itself in `blocked` and then waits for the
+  // test to create `release`; every other one is refused straight away. A barrier rather
+  // than a delay, so the interleaving is the test's to decide and not the machine's.
+  const HELD_THEN_REVOKED =
     `case "$*" in\n` +
-    `  *slow*) sleep 1; echo '{"team_context":{"results":[]}}'; exit 0;;\n` +
+    `  *slow*)\n` +
+    `    : > ./blocked\n` +
+    `    while [ ! -f ./release ]; do sleep 0.02; done\n` +
+    `    echo '{"team_context":{"results":[]}}'\n` +
+    `    exit 0;;\n` +
     `esac\n` +
     `echo "${REVOKED}" >&2\nexit 1`;
 
@@ -317,12 +334,16 @@ describe("the team brain's own capability health", () => {
     // Completion order is not start order once the launch probe overlaps a turn, and a
     // stale `Ok` landing on top of an auth failure is the silence this reading exists to
     // break, restored by a race.
-    const { value } = await withFakeOx(SLOW_THEN_REVOKED, async (brain) => {
+    const { value } = await withFakeOx(HELD_THEN_REVOKED, async (brain, bin) => {
+      // The older lookup is held inside the fake `ox` until this test lets it go, so the
+      // newer one demonstrably records first and the guard is what the assertion rests on.
       const older = brain.search("slow", 1).catch(() => {});
+      await until(() => existsSync(join(bin, "blocked")), "the older lookup to start");
       await brain.search("newer", 5).catch(() => {});
-      const beforeTheSlowOneLands = brain.readings()[0].health;
+      const whileTheOlderOneIsHeld = brain.readings()[0].health;
+      writeFileSync(join(bin, "release"), "");
       await older;
-      return [beforeTheSlowOneLands, brain.readings()[0].health];
+      return [whileTheOlderOneIsHeld, brain.readings()[0].health];
     });
     expect(value).toEqual(["Unavailable", "Unavailable"]);
   });

--- a/packages/core/test/team-server.test.ts
+++ b/packages/core/test/team-server.test.ts
@@ -11,11 +11,13 @@ import {
   TEAM_TOOLS,
   TEAM_TOOL_NAMES,
   type OxFailure,
+  type TeamBrain,
   type TeamOx,
   type TeamPassage,
   type TeamSearch,
   passageDate,
 } from "../src/team-server.ts";
+import { describeHealth, isActionable, isDegrading, needsHuman } from "../src/health.ts";
 
 const passages: TeamPassage[] = [
   { score: 0.94, text: "We chose Postgres over DynamoDB for the ledger.", doc_type: "adr", file_path: "docs/adr/012.md" },
@@ -30,6 +32,32 @@ function fakeOx(over: Partial<TeamOx> = {}): TeamOx {
     search,
     ...over,
   };
+}
+
+/**
+ * Puts a fake `ox` on PATH for the duration of `body`, with the audit lines it logs
+ * captured. The child runs with its cwd set to the same directory, so a script can gate on
+ * a marker file the body writes there — which is how one brain sees a credential die and
+ * come back. Pass no script to put nothing on PATH at all.
+ */
+async function withFakeOx<T>(
+  script: string | undefined,
+  body: (brain: TeamBrain, bin: string) => Promise<T>,
+): Promise<{ value: T; log: string }> {
+  const bin = mkdtempSync(join(tmpdir(), "ox-fake-"));
+  if (script !== undefined) writeFileSync(join(bin, "ox"), `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+  const previousPath = process.env.PATH;
+  process.env.PATH = script === undefined ? bin : `${bin}:${previousPath ?? ""}`;
+  const logged: string[] = [];
+  const warn = vi.spyOn(console, "warn").mockImplementation((line) => void logged.push(String(line)));
+  try {
+    const value = await body(makeOxTeam({ team: "team_x", cwd: bin }), bin);
+    return { value, log: logged.join("\n") };
+  } finally {
+    warn.mockRestore();
+    process.env.PATH = previousPath;
+    rmSync(bin, { recursive: true, force: true });
+  }
 }
 
 const call = (name: string, args: Record<string, unknown> = {}, ox: TeamOx = fakeOx()) =>
@@ -132,23 +160,11 @@ describe("what the brain is told when ox fails", () => {
 
   /** Runs `search` against a fake `ox` on PATH, and returns the error and the audit lines. */
   async function failingOx(script: string) {
-    const bin = mkdtempSync(join(tmpdir(), "ox-fake-"));
-    writeFileSync(join(bin, "ox"), `#!/bin/sh\n${script}\n`, { mode: 0o755 });
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${bin}:${previousPath ?? ""}`;
-    const logged: string[] = [];
-    const warn = vi.spyOn(console, "warn").mockImplementation((line) => void logged.push(String(line)));
-    try {
+    const { value, log } = await withFakeOx(script, (brain) =>
       // The query is the caller's own words: the thing that must not come back out.
-      const error = await makeOxTeam({ team: "team_x", cwd: bin })
-        .search(PLANTED, 5)
-        .then(() => undefined, (e: Error) => e);
-      return { message: error?.message ?? "", log: logged.join("\n") };
-    } finally {
-      warn.mockRestore();
-      process.env.PATH = previousPath;
-      rmSync(bin, { recursive: true, force: true });
-    }
+      brain.search(PLANTED, 5).then(() => undefined, (e: Error) => e),
+    );
+    return { message: value?.message ?? "", log };
   }
 
   it("keeps ox's stderr out of the brain and puts it in the audit log", async () => {
@@ -210,6 +226,94 @@ describe("what the brain is told when ox fails", () => {
     // four names, and the brain would act the same way on all of them.
     const classes: OxFailure[] = ["not-installed", "not-authenticated", "unreadable", "failed"];
     expect(new Set(classes.map((name) => OX_FAILURE_TEXT[name])).size).toBe(classes.length);
+  });
+});
+
+describe("the team brain's own capability health", () => {
+  // Answers with no passages, and fails with whatever the body has written into `fail`
+  // beside it. ox runs with its cwd set to that directory, so `./fail` is the marker.
+  const SCRIPTED = `if [ -f ./fail ]; then cat ./fail >&2; exit 1; fi\necho '{"team_context":{"results":[]}}'`;
+  const REVOKED = "Error: team context query failed: not authenticated. Run 'ox login' first";
+
+  it("reports nothing until a lookup has been made", async () => {
+    // Not `Ok`: nothing has tried the credential yet, and a reading is a claim about it.
+    const { value } = await withFakeOx(SCRIPTED, async (brain) => brain.readings());
+    expect(value).toEqual([]);
+  });
+
+  it("latches a revoked credential, so the turn and the operator both learn of it", async () => {
+    const { value, log } = await withFakeOx(SCRIPTED, async (brain, bin) => {
+      writeFileSync(join(bin, "fail"), REVOKED);
+      await brain.search("how do we deploy", 5).catch(() => {});
+      return brain.readings();
+    });
+
+    expect(value).toHaveLength(1);
+    const [reading] = value;
+    expect(reading.capability).toBe("brain.team");
+    expect(reading.health).toBe("Unavailable");
+    // The same word on both lines, so one grep finds the classification and the reading.
+    expect(log).toContain("class=not-authenticated");
+    expect(describeHealth(reading)).toContain("failure=not-authenticated");
+    // Disclosed to the agent, and announced to a human — the two are separate decisions.
+    expect(isDegrading(reading.health)).toBe(true);
+    expect(needsHuman(reading.health)).toBe(true);
+    // What the agent is told is the fixed sentence, and the remedy is only for the operator.
+    expect(reading.reason).toBe(OX_FAILURE_TEXT["not-authenticated"]);
+    expect(isActionable(reading) && reading.remedy).toMatch(/rotate/);
+  });
+
+  it("clears itself on the next answer, so a rotated credential needs no restart", async () => {
+    const { value } = await withFakeOx(SCRIPTED, async (brain, bin) => {
+      const path = join(bin, "fail");
+      writeFileSync(path, REVOKED);
+      await brain.search("x", 5).catch(() => {});
+      const dead = brain.readings()[0].health;
+      rmSync(path);
+      await brain.search("x", 5);
+      return [dead, brain.readings()[0].health];
+    });
+    expect(value).toEqual(["Unavailable", "Ok"]);
+  });
+
+  it("reads an answer with no passages as Ok, never as an empty corpus", async () => {
+    // One query that matched nothing says nothing about how much the team has written
+    // down, and `ox query` reports no corpus size. `Empty` here would be a guess.
+    const { value } = await withFakeOx(SCRIPTED, async (brain) => {
+      expect(await brain.search("nothing matches this", 5)).toEqual([]);
+      return brain.readings()[0].health;
+    });
+    expect(value).toBe("Ok");
+  });
+
+  it("leaves the reading standing when one lookup merely fell over", async () => {
+    // `failed` is the class retrying can disprove. Latching it would announce an outage to
+    // a human on every flaky lookup, which is how people learn to skim announcements.
+    const { value } = await withFakeOx(SCRIPTED, async (brain, bin) => {
+      await brain.search("x", 5);
+      writeFileSync(join(bin, "fail"), "Error: the team context service is unavailable");
+      await brain.search("x", 5).catch(() => {});
+      return brain.readings()[0].health;
+    });
+    expect(value).toBe("Ok");
+  });
+
+  it("takes the first reading at launch, without throwing", async () => {
+    const { value } = await withFakeOx(SCRIPTED, async (brain) => {
+      await brain.probe();
+      return brain.readings()[0].health;
+    });
+    expect(value).toBe("Ok");
+  });
+
+  it("latches a missing `ox` at launch too — an image built without it stays broken", async () => {
+    const { value } = await withFakeOx(undefined, async (brain) => {
+      await brain.probe();
+      return brain.readings()[0];
+    });
+    expect(value.health).toBe("Unavailable");
+    expect(describeHealth(value)).toContain("failure=not-installed");
+    expect(value.reason).toBe(OX_FAILURE_TEXT["not-installed"]);
   });
 });
 

--- a/packages/core/test/team-server.test.ts
+++ b/packages/core/test/team-server.test.ts
@@ -274,7 +274,10 @@ describe("the team brain's own capability health", () => {
       const latched = brain.readings()[0].health;
       const held = brain.search("slow", 1).catch(() => {});
       await until(() => existsSync(join(bin, "blocked")), "the held lookup to start");
-      await brain.search("flaky", 5).catch(() => {});
+      // Asserted rather than swallowed: a `flaky` lookup that answered would leave the
+      // held success to produce `Ok` on its own, and the test would pass having exercised
+      // nothing.
+      await expect(brain.search("flaky", 5)).rejects.toMatchObject({ failure: "failed" });
       writeFileSync(join(bin, "release"), "");
       await held;
       return [latched, brain.readings()[0].health];

--- a/packages/core/test/team-server.test.ts
+++ b/packages/core/test/team-server.test.ts
@@ -230,10 +230,21 @@ describe("what the brain is told when ox fails", () => {
 });
 
 describe("the team brain's own capability health", () => {
-  // Answers with no passages, and fails with whatever the body has written into `fail`
-  // beside it. ox runs with its cwd set to that directory, so `./fail` is the marker.
-  const SCRIPTED = `if [ -f ./fail ]; then cat ./fail >&2; exit 1; fi\necho '{"team_context":{"results":[]}}'`;
+  // Answers with no passages; fails with whatever the body has written into `fail` beside
+  // it, and answers unreadably if `garbage` is there. ox runs with its cwd set to that
+  // directory, so the markers are `./fail` and `./garbage`.
+  const SCRIPTED =
+    `if [ -f ./garbage ]; then echo "not json at all"; exit 0; fi\n` +
+    `if [ -f ./fail ]; then cat ./fail >&2; exit 1; fi\n` +
+    `echo '{"team_context":{"results":[]}}'`;
   const REVOKED = "Error: team context query failed: not authenticated. Run 'ox login' first";
+  // A lookup whose query says `slow` answers a second late; every other one is refused now.
+  // That is enough to start one lookup before another and have it finish after.
+  const SLOW_THEN_REVOKED =
+    `case "$*" in\n` +
+    `  *slow*) sleep 1; echo '{"team_context":{"results":[]}}'; exit 0;;\n` +
+    `esac\n` +
+    `echo "${REVOKED}" >&2\nexit 1`;
 
   it("reports nothing until a lookup has been made", async () => {
     // Not `Ok`: nothing has tried the credential yet, and a reading is a claim about it.
@@ -286,16 +297,34 @@ describe("the team brain's own capability health", () => {
     expect(value).toBe("Ok");
   });
 
-  it("leaves the reading standing when one lookup merely fell over", async () => {
-    // `failed` is the class retrying can disprove. Latching it would announce an outage to
-    // a human on every flaky lookup, which is how people learn to skim announcements.
+  it("leaves the reading standing when a lookup falls over or answers unreadably", async () => {
+    // The two classes retrying can disprove. Latching either would announce an outage to a
+    // human on every flaky lookup, which is how people learn to skim announcements.
     const { value } = await withFakeOx(SCRIPTED, async (brain, bin) => {
       await brain.search("x", 5);
       writeFileSync(join(bin, "fail"), "Error: the team context service is unavailable");
       await brain.search("x", 5).catch(() => {});
-      return brain.readings()[0].health;
+      const afterFailed = brain.readings()[0].health;
+      rmSync(join(bin, "fail"));
+      writeFileSync(join(bin, "garbage"), "");
+      await brain.search("x", 5).catch(() => {});
+      return [afterFailed, brain.readings()[0].health];
     });
-    expect(value).toBe("Ok");
+    expect(value).toEqual(["Ok", "Ok"]);
+  });
+
+  it("does not let a slower older lookup bury what a newer one proved", async () => {
+    // Completion order is not start order once the launch probe overlaps a turn, and a
+    // stale `Ok` landing on top of an auth failure is the silence this reading exists to
+    // break, restored by a race.
+    const { value } = await withFakeOx(SLOW_THEN_REVOKED, async (brain) => {
+      const older = brain.search("slow", 1).catch(() => {});
+      await brain.search("newer", 5).catch(() => {});
+      const beforeTheSlowOneLands = brain.readings()[0].health;
+      await older;
+      return [beforeTheSlowOneLands, brain.readings()[0].health];
+    });
+    expect(value).toEqual(["Unavailable", "Unavailable"]);
   });
 
   it("takes the first reading at launch, without throwing", async () => {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0644a-6377-765c-ac56-86d021b98e12">Session</a>
<!-- /sageox:pr-header -->

Closes #22.

## What was needed

An agent whose SageOx credential is revoked keeps answering. Every `team_search` fails, nothing discloses it, nothing announces it, and the only trace is one `ox_failed class=not-authenticated` line per turn in the gateway log — so the agent goes on answering team-knowledge questions from the model alone. That is the confident wrong answer [`docs/startup-and-readiness.md`](docs/startup-and-readiness.md) exists to prevent, reached from a direction nothing was watching: capability health was wired to the code index and to no brain.

The runtime already classified this correctly and then dropped it. `classifyOxFailure()` names the auth case from ox's own phrasing, and `OX_FAILURE_TEXT` already holds the sentence for the brain. Both were per-turn text plus a `console.warn`; nothing latched.

```mermaid
flowchart LR
  A["ox lookup fails<br/>classifyOxFailure()"] --> B["fixed sentence<br/>to the brain"]
  A --> C["ox_failed line<br/>in the gateway log"]
  A -.->|new| D["brain.team<br/>capability reading"]
  D --> E["turn prompt:<br/>the agent discloses"]
  D --> F["run: note naming<br/>the credential to rotate"]
```

## What this ships

- **`packages/core/src/team-server.ts`** — `oxFailed()` returns an `OxCallError` carrying the class it already computed, so a caller acts on the classification instead of parsing it back out of the message. `makeOxTeam()` returns a `TeamBrain`: `search` unchanged, plus `readings()` and `probe()`. A failed lookup latches `probeUnavailable("brain.team", …)`; an answered one latches `probeOk`, so a rotated credential clears the state with no restart.
- **`packages/core/src/health.ts`** — two new `ProbeFailure` members, spelled the same as the `OxFailure` classes they are latched from, so `failure=not-authenticated` and `class=not-authenticated` are one word to grep for rather than two.
- **`packages/cli/src/cli.ts`** — `buildBrain` hands the team brain back; `runCmd` fires one launch probe and prints `note: brain.team — …` for anything actionable, then `capabilities: () => [...codeWorkspace.readings(), ...team.readings()]`.
- CHANGELOG entry, and a paragraph in [`docs/guide/troubleshooting.md`](docs/guide/troubleshooting.md) under the existing team-brain entry, where an operator reading `class=not-authenticated` will already be.

Everything downstream was already built: the degraded turn block, the `needsHuman` announce path, and the reading being re-read per turn rather than captured.

## Three judgement calls

**Only two failure classes latch.** `not-authenticated` and `not-installed` stay broken until somebody acts. `failed` and `unreadable` do not latch — the next lookup may well answer, and latching is what sends a human somewhere. Announcing an outage a retry disproves is how people learn to skim announcements.

**`not-installed` is included, which #22 did not ask for.** An image built without `ox` is silently degraded in exactly the same way, `OX_FAILURE_TEXT` already had the words, and stating the rule while applying it to one of the two members it covers seemed worse than the extra map entry. Straightforward to drop if you would rather keep this to the reported symptom.

**`run` takes one reading at launch**, per the second comment on the issue. `oxStatus()` has two call sites — `init` and `doctor` — and a deployment executes neither, so a credential already dead at deploy time was exactly as silent as one revoked later. It uses `ox query`, the verb already on the allowlist, not the `ox status` poll the issue rules out. It is off the startup path and not a precondition: an agent without team memory is *less informed*, not *wrong*, so it comes up, works, and discloses.

One smaller call: a lookup that answers with **no passages reads as `Ok`, never `Empty`**. One query matching nothing is also what a team with plenty written down returns to unlucky wording, and `ox query` reports no corpus size — `Empty` would be a guess.

## How I verified

`pnpm typecheck` and `pnpm test` (1109 tests, 63 files) green.

Seven new cases in `packages/core/test/team-server.test.ts`, against a fake `ox` whose behaviour a test flips mid-run through a marker file, so one brain watches a credential die and come back: nothing reported before a lookup; a revoked credential latched, disclosed, and announced with the failure word matching the `ox_failed` line; the reading cleared by the next answer; a zero-passage answer read as `Ok`; a lookup that merely fell over leaving the reading standing; `probe()` taking the first reading without throwing; and a missing `ox` latched at launch.

I checked the negative case by hand: adding `failed` to the latch set fails `leaves the reading standing when one lookup merely fell over`, and the other six exercise API that does not exist before this change. The existing `failingOx` helper was folded into the shared fake-`ox` harness rather than duplicated.

SageOx-Session: https://sageox.ai/c/ses_01a0644a-6377-765c-ac56-86d021b98e12

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790982105&installation_model_id=433550&pr_number=27&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F27&signature=0cdbed4fbb9c964cae19427e522e35c3bc01b17178f3de90e4bdc1670f53498e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added team capability health tracking for credential and tool availability.
  - Startup now checks team access and provides actionable guidance when unavailable.
  - Prompts and startup notes disclose when team information cannot be reached.
  - Team capability status automatically recovers after access is restored.

- **Bug Fixes**
  - Prevented misleading team responses when authentication or required tools are unavailable.
  - Transient lookup failures no longer permanently mark team access as unavailable.

- **Documentation**
  - Added troubleshooting guidance for team access and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->