### PR TITLE
Read the team brain's token per lookup, so a rotated secret self-heals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A rotated SageOx credential recovers without a Deployment restart.** The team brain's
+  token was resolved once, when the gateway started, and stamped onto every `ox` child for
+  the life of the process — so a secrets-store CSI driver that refreshed the mounted file
+  in place changed nothing, and the agent went on sending a revoked value until somebody
+  restarted it. The gateway now reads the secret per `ox` child, which is a file read next
+  to a process spawn, and the reading that a lookup latches clears itself the moment the
+  new value is accepted. Rotation stops needing a human; a genuine revoke is still the case
+  that does, which is the honest split. Every other credential still resolves at startup —
+  each is held by a connection or a subprocess a rotation would have to re-establish
+  anyway — and refreshing the mount remains opt-in: the bootstrap module leaves the CSI
+  driver's rotation reconciler off. `docs/deployment-contract.md` has the split.
+
 - **A GitHub Release leads with one line per entry here, not the whole section.** Quoting
   the section put a screen of *why* above the image digest — the one thing a deployment
   needs from the release — and above the pull-request list GitHub generates for the tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that does, which is the honest split. Every other credential still resolves at startup —
   each is held by a connection or a subprocess a rotation would have to re-establish
   anyway — and refreshing the mount remains opt-in: the bootstrap module leaves the CSI
-  driver's rotation reconciler off. `docs/deployment-contract.md` has the split.
+  driver's rotation reconciler off, so on that path a restart is still the rotation step for
+  this credential too. A configured token ref now also speaks for the agent when it reads as
+  nothing: the `ox` child carries no credential and falls back to its auth file, rather than
+  inheriting a `SAGEOX_TOKEN` from the gateway's own environment — which on a host running
+  several agents is another agent's. `docs/deployment-contract.md` has the split.
 
 - **A GitHub Release leads with one line per entry here, not the whole section.** Quoting
   the section put a screen of *why* above the image digest — the one thing a deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **A rotated SageOx credential recovers without a Deployment restart.** The team brain's
-  token was resolved once, when the gateway started, and stamped onto every `ox` child for
-  the life of the process — so a secrets-store CSI driver that refreshed the mounted file
-  in place changed nothing, and the agent went on sending a revoked value until somebody
-  restarted it. The gateway now reads the secret per `ox` child, which is a file read next
-  to a process spawn, and the reading that a lookup latches clears itself the moment the
-  new value is accepted. Rotation stops needing a human; a genuine revoke is still the case
+- **A SageOx credential refreshed under the agent's secrets mount is picked up without a
+  Deployment restart.** The team brain's token was resolved once, when the gateway started,
+  and stamped onto every `ox` child for the life of the process — so a secrets-store CSI
+  driver that refreshed the mounted file in place changed nothing, and the agent went on
+  sending a revoked value until somebody restarted it. The gateway now reads the secret per
+  `ox` child, which is a file read next to a process spawn, and the reading that a lookup
+  latches clears itself the moment the new value is accepted. Rotation stops needing a human; a genuine revoke is still the case
   that does, which is the honest split. Every other credential still resolves at startup —
   each is held by a connection or a subprocess a rotation would have to re-establish
   anyway — and refreshing the mount remains opt-in: the bootstrap module leaves the CSI

--- a/deploy/terraform/aws-eks-agent/README.md
+++ b/deploy/terraform/aws-eks-agent/README.md
@@ -38,4 +38,6 @@ separate clusters cannot collide inside one AWS account. The Pod Identity role t
 policy also requires the exact EKS cluster, namespace, and ServiceAccount session tags.
 
 To rotate a credential, put a new Secrets Manager version and restart the Deployment; the
-new pod mounts the current values.
+new pod mounts the current values. The team brain's SageOx token is read per `ox` child
+rather than at startup, so it recovers without the restart wherever the mount is refreshed
+— which needs the CSI driver's rotation reconciler, off by default in the bootstrap module.

--- a/deploy/terraform/aws-eks-bootstrap/main.tf
+++ b/deploy/terraform/aws-eks-bootstrap/main.tf
@@ -36,8 +36,11 @@ resource "helm_release" "secrets_store_csi_provider_aws" {
     tolerations = [{ operator = "Exists" }]
     secrets-store-csi-driver = {
       install = true
-      # No rotation reconciler: the runtime resolves credentials at process startup, so
-      # rotation is "seed the new value, restart the Deployment" either way.
+      # No mirror into a Kubernetes Secret: the workload mounts Secrets Manager values
+      # directly, and a second copy in the API is a second thing to authorize. Rotation is
+      # unaffected — the reconciler that refreshes a mount is `enableSecretRotation`, left
+      # at its default of off, so rotation here is "seed the new value, restart the
+      # Deployment" for every credential but the team brain's token.
       syncSecret = {
         enabled = false
       }

--- a/deploy/terraform/aws-eks-bootstrap/main.tf
+++ b/deploy/terraform/aws-eks-bootstrap/main.tf
@@ -37,10 +37,12 @@ resource "helm_release" "secrets_store_csi_provider_aws" {
     secrets-store-csi-driver = {
       install = true
       # No mirror into a Kubernetes Secret: the workload mounts Secrets Manager values
-      # directly, and a second copy in the API is a second thing to authorize. Rotation is
-      # unaffected — the reconciler that refreshes a mount is `enableSecretRotation`, left
-      # at its default of off, so rotation here is "seed the new value, restart the
-      # Deployment" for every credential but the team brain's token.
+      # directly, and a second copy in the API is a second thing to authorize. A separate
+      # setting refreshes a mount in place — `enableSecretRotation`, left at its default of
+      # off — so rotation here is "seed the new value, restart the Deployment" for every
+      # credential, the team brain's token included. That token is the one the runtime
+      # re-reads per `ox` child, so enabling the reconciler is what would let it recover
+      # without the restart.
       syncSecret = {
         enabled = false
       }

--- a/docs/aws-eks-deployment.md
+++ b/docs/aws-eks-deployment.md
@@ -161,6 +161,12 @@ Put a new Secrets Manager version, then restart the Deployment. The new pod moun
 current values; the runtime resolves credentials at process startup, so a restart is the
 rotation step either way.
 
+The team brain's SageOx token is the one credential that does not need the restart — the
+gateway reads it from the mount for every `ox` child. That only helps if the mount is
+refreshed, which the bootstrap module leaves off: set the CSI driver's
+`enableSecretRotation` if you want that credential to recover from a rotation on its own.
+See [the deployment contract](deployment-contract.md) for why it is the only one.
+
 Managed secret deletion uses a 7-day recovery window. The chart-managed PVC is
 retained on Helm uninstall. Confirm both retained data sets before permanently deleting them.
 

--- a/docs/aws-eks-deployment.md
+++ b/docs/aws-eks-deployment.md
@@ -161,11 +161,12 @@ Put a new Secrets Manager version, then restart the Deployment. The new pod moun
 current values; the runtime resolves credentials at process startup, so a restart is the
 rotation step either way.
 
-The team brain's SageOx token is the one credential that does not need the restart — the
-gateway reads it from the mount for every `ox` child. That only helps if the mount is
-refreshed, which the bootstrap module leaves off: set the CSI driver's
-`enableSecretRotation` if you want that credential to recover from a rotation on its own.
-See [the deployment contract](deployment-contract.md) for why it is the only one.
+The team brain's SageOx token is the one credential that can skip the restart, and only
+where the mount is refreshed under it: the gateway reads it for every `ox` child, but the
+bootstrap module leaves the CSI driver's `enableSecretRotation` at its default of off, so
+on this path the file never changes and the restart is still the rotation step. Enable that
+setting if you want the credential to recover from a rotation on its own, and see
+[the deployment contract](deployment-contract.md) for why it is the only one that could.
 
 Managed secret deletion uses a 7-day recovery window. The chart-managed PVC is
 retained on Helm uninstall. Confirm both retained data sets before permanently deleting them.

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -168,9 +168,18 @@ never contains external credentials. See the [ground-up AWS guide](aws-eks-deplo
 
 To rotate a credential, put the new value in the external store and restart the
 Deployment — the new pod mounts current values, and the runtime resolves credentials at
-process startup. The current single-container tier also
-shares a filesystem between the gateway and its brain subprocess. Kubernetes secret sourcing
-does not create a filesystem boundary; a future hardened tier must isolate those processes.
+process startup. The team brain's SageOx token is the one exception: it is read from the
+mount for every `ox` child, so a file the CSI driver refreshes in place is what the next
+lookup carries, and the capability recovers with nobody involved. Nothing else here can
+work that way — the surface tokens, the Buzz identity and the model key are each held at
+startup by a connection or a subprocess that a rotation would have to re-establish
+regardless. Refreshing the mount is opt-in: the bootstrap module leaves the CSI driver's
+rotation reconciler at its default of off, and without it a restart is the rotation step
+for this credential too.
+
+The current single-container tier also shares a filesystem between the gateway and its
+brain subprocess. Kubernetes secret sourcing does not create a filesystem boundary; a
+future hardened tier must isolate those processes.
 
 The runtime runs `ox index code` and verifies `ox code status`; it does not run `ox daemon`.
 The daemon synchronizes SageOx ledger state and is not the repository-index readiness

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -159,8 +159,10 @@ retention and no shipping: it goes to the gateway's stream beside `turn_start` a
 Create one at **https://sageox.ai/settings/tokens**; it is prefixed `oxp_` and shown once.
 
 One thing to know: `doctor` checks the token with SageOx and reports its current rolling
-expiry. If SageOx rejects it, rotate the value through the deployment's secret manager and restart
-only the affected agent workload.
+expiry. If SageOx rejects it, rotate the value through the deployment's secret manager. The
+gateway reads that secret for each `ox` call rather than once at boot, so a mount refreshed in
+place is picked up by the next lookup; where nothing refreshes the file, restart only the
+affected agent workload.
 
 Do not reuse the access token from your own `ox login`: it expires within hours and has no
 refresh credential once out of ox's hands.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -35,9 +35,10 @@ and `failed` is everything else, where `detail` is the whole story.
 The first two also latch as the `brain.team` capability, because retrying cannot disprove
 either: `run` prints `note: brain.team — …` with what to do, and the agent is told to stop
 answering as if team memory had worked. The next lookup that gets an answer clears the
-reading, so a rotated credential needs no restart. `unreadable` and `failed` do not latch —
-the next lookup may well answer, and an announcement a retry disproves is one people learn
-to skim.
+reading, and it reads the credential from its mount rather than from anything captured at
+boot — so a rotation that reaches the file needs no restart. `unreadable` and `failed` do
+not latch — the next lookup may well answer, and an announcement a retry disproves is one
+people learn to skim.
 
 **`ox_failed … class=failed detail="… permission denied"`.**
 `ox` needs a writable working directory. The gateway runs it from the home directory for

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -439,8 +439,10 @@ async function buildBrain(
         team: cfg.team,
         repo: cfg.repo,
         configHome: cfg.configHome,
-        // Resolved here, in the gateway. File-first: a mounted secret beats an env var.
-        token: resolveSecret(cfg.token, { dir: secretsDir }),
+        // Resolved here, in the gateway, and per lookup rather than once: file-first, so a
+        // mounted secret beats an env var, and a mount rewritten under this process is what
+        // the next `ox` child carries.
+        token: () => resolveSecret(cfg.token, { dir: secretsDir }),
       });
       server = await serveTeamBrain(teamBrain, serveAt);
     }
@@ -2092,7 +2094,7 @@ async function doctorCmd(argv: string[]): Promise<boolean> {
     if (teamBrain?.preset === "team") {
       const tokenRef = teamBrain.token ?? DEFAULT_OX_TOKEN_SECRET;
       const ox = await oxStatus({
-        token: resolveSecret(tokenRef, { dir: secretsDir }),
+        token: () => resolveSecret(tokenRef, { dir: secretsDir }),
         configHome: teamBrain.configHome,
       });
       if (!ox.installed) {

--- a/packages/cli/src/ox.ts
+++ b/packages/cli/src/ox.ts
@@ -75,7 +75,7 @@ export async function oxStatus(scope: OxScope = {}): Promise<OxStatus> {
  * so supplying one means it is what did the work.
  */
 export function credentialSource(scope: OxScope): "SAGEOX_TOKEN" | "auth file" {
-  return scope.token ? "SAGEOX_TOKEN" : "auth file";
+  return scope.token?.() ? "SAGEOX_TOKEN" : "auth file";
 }
 
 /** True when the token is gone or expires within the hour. */

--- a/packages/cli/src/ox.ts
+++ b/packages/cli/src/ox.ts
@@ -35,10 +35,14 @@ export interface OxStatus {
  * nothing down. So the check happens before the agent runs, not at the first question.
  */
 export async function oxStatus(scope: OxScope = {}): Promise<OxStatus> {
+  // Built once and reported from, never resolved a second time: `OxScope.token` reads a
+  // file that may be rewritten under this process, so a second reading could name a
+  // credential this child never carried.
+  const env = oxEnv(scope);
   try {
     // Same credential the team brain will use, or the check answers a different question
     // than the one asked: a container has no ambient login for ox to fall back on.
-    const { stdout } = await run("ox", ["status", "--json"], { timeout: 30_000, env: oxEnv(scope), cwd: oxCwd(scope) });
+    const { stdout } = await run("ox", ["status", "--json"], { timeout: 30_000, env, cwd: oxCwd(scope) });
     const parsed = JSON.parse(stdout) as {
       auth?: {
         authenticated?: boolean;
@@ -57,7 +61,7 @@ export async function oxStatus(scope: OxScope = {}): Promise<OxStatus> {
       authFile: parsed.config?.auth_file,
       // An env token takes precedence over anything on disk, so if we supplied one and
       // the call authenticated, that is what authenticated it.
-      source: credentialSource(scope),
+      source: credentialSource(env),
     };
   } catch (error) {
     const e = error as { code?: string; message?: string };
@@ -71,11 +75,17 @@ export async function oxStatus(scope: OxScope = {}): Promise<OxStatus> {
 }
 
 /**
- * Which credential authenticated. An env token takes precedence over anything on disk,
- * so supplying one means it is what did the work.
+ * Which credential authenticated, read off the env a child was given. An env token takes
+ * precedence over anything on disk, so a child that carried one is a child it did the work
+ * for.
+ *
+ * The env and not the scope: the scope's token is a reading of a file, and taking it a
+ * second time after the child has exited can answer differently from the one that built
+ * its env — which is the whole premise of resolving per child. `doctor` would then name a
+ * credential the run never used.
  */
-export function credentialSource(scope: OxScope): "SAGEOX_TOKEN" | "auth file" {
-  return scope.token?.() ? "SAGEOX_TOKEN" : "auth file";
+export function credentialSource(env: NodeJS.ProcessEnv): "SAGEOX_TOKEN" | "auth file" {
+  return env.SAGEOX_TOKEN ? "SAGEOX_TOKEN" : "auth file";
 }
 
 /** True when the token is gone or expires within the hour. */

--- a/packages/cli/src/ox.ts
+++ b/packages/cli/src/ox.ts
@@ -14,7 +14,12 @@ export interface OxStatus {
   gitPatValid?: boolean;
   authFile?: string;
   /**
-   * Which credential actually authenticated.
+   * Which credential this check handed the `ox` child.
+   *
+   * Not a claim about what ox then did with it: a token is bound to one endpoint, and
+   * against any other ox ignores it and falls back to the auth file without saying so —
+   * see `OxScope.token`. Nothing here can tell the two apart, because the endpoint a token
+   * was issued for is not derivable from the token.
    *
    * ox reports `config.auth_file` unconditionally — the path it *would* read for a disk
    * login, whether or not anything is there. Reporting that as the source is wrong in a

--- a/packages/cli/test/ox.test.ts
+++ b/packages/cli/test/ox.test.ts
@@ -27,15 +27,18 @@ describe("expiringSoon", () => {
 
 describe("credential source reporting", () => {
   it("names the token when one was supplied, since a PAT carries no user claims", () => {
-    expect(credentialSource({ token: "oxp_x" })).toBe("SAGEOX_TOKEN");
+    expect(credentialSource({ token: () => "oxp_x" })).toBe("SAGEOX_TOKEN");
   });
 
   it("reports the auth file when no token was supplied", () => {
     expect(credentialSource({})).toBe("auth file");
+    // The ref is declared but nothing is mounted under it: what `resolveSecret` returns
+    // then is `undefined`, and the auth file is what will have done the work.
+    expect(credentialSource({ token: () => undefined })).toBe("auth file");
   });
 
   it("prefers the token even when an auth file is also configured, as ox does", () => {
-    expect(credentialSource({ token: "oxp_x", configHome: "/mnt/secrets-store/ox" })).toBe("SAGEOX_TOKEN");
+    expect(credentialSource({ token: () => "oxp_x", configHome: "/mnt/secrets-store/ox" })).toBe("SAGEOX_TOKEN");
   });
 });
 

--- a/packages/cli/test/ox.test.ts
+++ b/packages/cli/test/ox.test.ts
@@ -2,7 +2,21 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { expiringSoon, credentialSource, oxTeams } from "../src/ox.ts";
+import { expiringSoon, credentialSource, oxStatus, oxTeams } from "../src/ox.ts";
+
+/** Puts an `ox` on PATH that prints `stdout` whatever it is asked. */
+const withFakeOx = async <T>(stdout: string, run: () => Promise<T>): Promise<T> => {
+  const bin = mkdtempSync(join(tmpdir(), "ox-fake-"));
+  writeFileSync(join(bin, "ox"), `#!/bin/sh\ncat <<'JSON'\n${stdout}\nJSON\n`, { mode: 0o755 });
+  const path = process.env.PATH;
+  process.env.PATH = `${bin}:${path}`;
+  try {
+    return await run();
+  } finally {
+    process.env.PATH = path;
+    rmSync(bin, { recursive: true, force: true });
+  }
+};
 
 describe("expiringSoon", () => {
   const now = new Date("2026-08-14T00:00:00Z");
@@ -26,19 +40,32 @@ describe("expiringSoon", () => {
 });
 
 describe("credential source reporting", () => {
-  it("names the token when one was supplied, since a PAT carries no user claims", () => {
-    expect(credentialSource({ token: () => "oxp_x" })).toBe("SAGEOX_TOKEN");
+  it("names the token when the child carried one, since a PAT carries no user claims", () => {
+    expect(credentialSource({ SAGEOX_TOKEN: "oxp_x" })).toBe("SAGEOX_TOKEN");
   });
 
-  it("reports the auth file when no token was supplied", () => {
+  it("reports the auth file when the child carried no token", () => {
     expect(credentialSource({})).toBe("auth file");
-    // The ref is declared but nothing is mounted under it: what `resolveSecret` returns
-    // then is `undefined`, and the auth file is what will have done the work.
-    expect(credentialSource({ token: () => undefined })).toBe("auth file");
   });
 
   it("prefers the token even when an auth file is also configured, as ox does", () => {
-    expect(credentialSource({ token: () => "oxp_x", configHome: "/mnt/secrets-store/ox" })).toBe("SAGEOX_TOKEN");
+    expect(credentialSource({ SAGEOX_TOKEN: "oxp_x", XDG_CONFIG_HOME: "/mnt/secrets-store/ox" })).toBe(
+      "SAGEOX_TOKEN",
+    );
+  });
+
+  it("labels the run from the env the child got, not from a second reading", async () => {
+    // `OxScope.token` reads a file that a rotation rewrites under this process — that is
+    // the point of resolving it per child — so a reading taken after `ox status` exits can
+    // disagree with the one that built its env, and `doctor` would then name a credential
+    // the run never used. One reading, and the label comes off the env it produced.
+    let reads = 0;
+    const status = await withFakeOx(JSON.stringify({ auth: { authenticated: true } }), () =>
+      oxStatus({ token: () => (reads++ === 0 ? "oxp_x" : undefined) }),
+    );
+
+    expect(status.source).toBe("SAGEOX_TOKEN");
+    expect(reads).toBe(1);
   });
 });
 
@@ -49,19 +76,6 @@ describe("credential source reporting", () => {
  * times they outnumber the real teams on the menu.
  */
 describe("the teams this machine can see", () => {
-  const withFakeOx = async <T>(stdout: string, run: () => Promise<T>): Promise<T> => {
-    const bin = mkdtempSync(join(tmpdir(), "ox-teams-"));
-    writeFileSync(join(bin, "ox"), `#!/bin/sh\ncat <<'JSON'\n${stdout}\nJSON\n`, { mode: 0o755 });
-    const path = process.env.PATH;
-    process.env.PATH = `${bin}:${path}`;
-    try {
-      return await run();
-    } finally {
-      process.env.PATH = path;
-      rmSync(bin, { recursive: true, force: true });
-    }
-  };
-
   const listing = JSON.stringify({
     primary_team: "team_jihjpfkt8b",
     teams: [

--- a/packages/core/src/team-server.ts
+++ b/packages/core/src/team-server.ts
@@ -229,6 +229,13 @@ export interface OxScope {
    * An access token supplied out-of-band, for CI and containers where no interactive
    * `ox login` can happen. Takes precedence over anything on disk.
    *
+   * A reading and not a value, for the same reason capability health is one: it changes
+   * under a running process. A secrets-store CSI driver with rotation on rewrites the
+   * mounted file in place, and a string captured when the gateway booted would keep
+   * stamping the revoked value onto every `ox` child until somebody restarted the
+   * Deployment — for a credential already sitting current on the container's own disk.
+   * {@link oxEnv} calls this once per child, which is a file read next to a process spawn.
+   *
    * Unlike a logged-in `auth.json`, this carries no refresh credential: ox stamps a
    * rolling 24h expiry and treats a server 401 as the truth. A long-running agent on a
    * token alone will eventually need it rotated — mount `auth.json` instead if you want
@@ -243,7 +250,7 @@ export interface OxScope {
    * production, so the default is already right and a knob would only add a way to be
    * wrong.
    */
-  token?: string;
+  token?: () => string | undefined;
   /**
    * Where ox runs.
    *
@@ -260,11 +267,16 @@ export function oxCwd(scope: OxScope): string {
   return scope.cwd ?? homedir();
 }
 
-/** Env for the ox child. Built explicitly so a credential is never passed by accident. */
+/**
+ * Env for the ox child. Built explicitly so a credential is never passed by accident, and
+ * built per child so the credential it carries is the one on disk now — see
+ * {@link OxScope.token}.
+ */
 export function oxEnv(scope: OxScope, base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const env = { ...base };
   if (scope.configHome) env.XDG_CONFIG_HOME = scope.configHome;
-  if (scope.token) env.SAGEOX_TOKEN = scope.token;
+  const token = scope.token?.();
+  if (token) env.SAGEOX_TOKEN = token;
   return env;
 }
 
@@ -350,7 +362,8 @@ const LATCHED: Partial<Record<OxFailure, { failure: ProbeFailure; remedy: string
     failure: "not-authenticated",
     remedy:
       "rotate this deployment's SageOx credential — the secret the team brain's `token` " +
-      "names, or the auth file under its `configHome` — then restart",
+      "names, or the auth file under its `configHome`. The next lookup reads it, so a " +
+      "file-mounted value needs no restart; one supplied in the environment does",
   },
 };
 

--- a/packages/core/src/team-server.ts
+++ b/packages/core/src/team-server.ts
@@ -275,8 +275,17 @@ export function oxCwd(scope: OxScope): string {
 export function oxEnv(scope: OxScope, base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   const env = { ...base };
   if (scope.configHome) env.XDG_CONFIG_HOME = scope.configHome;
-  const token = scope.token?.();
-  if (token) env.SAGEOX_TOKEN = token;
+  if (scope.token) {
+    const token = scope.token();
+    // A configured ref is the authority on this agent's credential, including when it
+    // reads as nothing: the child then carries no token and falls back to `configHome`,
+    // never to a `SAGEOX_TOKEN` this process happens to have inherited. On a host running
+    // several agents that ambient value is another agent's credential, and ox would take
+    // it and answer normally as someone else. Deleting matters more now that the ref is
+    // read per child than it did when one boot-time reading stood for the process.
+    if (token) env.SAGEOX_TOKEN = token;
+    else delete env.SAGEOX_TOKEN;
+  }
   return env;
 }
 

--- a/packages/core/test/team-http.test.ts
+++ b/packages/core/test/team-http.test.ts
@@ -127,8 +127,22 @@ describe("origin checks", () => {
 
 describe("ox credential handling", () => {
   it("passes a token supplied out-of-band, for containers with no interactive login", () => {
-    const env = oxEnv({ token: "tok_abc" }, { PATH: "/usr/bin" });
+    const env = oxEnv({ token: () => "tok_abc" }, { PATH: "/usr/bin" });
     expect(env.SAGEOX_TOKEN).toBe("tok_abc");
+  });
+
+  it("reads the token per child, so a mount rewritten under the process is what goes out", () => {
+    let mounted = "tok_old";
+    const scope = { token: () => mounted };
+    expect(oxEnv(scope, {}).SAGEOX_TOKEN).toBe("tok_old");
+    mounted = "tok_new";
+    expect(oxEnv(scope, {}).SAGEOX_TOKEN).toBe("tok_new");
+  });
+
+  it("adds no credential when the secret is not there to read, rather than an empty one", () => {
+    // What `resolveSecret` returns for an unmounted ref. `SAGEOX_TOKEN=` would be a
+    // credential as far as ox is concerned, and it would lose to the auth file silently.
+    expect(oxEnv({ token: () => undefined }, {}).SAGEOX_TOKEN).toBeUndefined();
   });
 
   it("points ox at a mounted auth file when given one", () => {
@@ -143,7 +157,7 @@ describe("ox credential handling", () => {
   });
 
   it("supports both at once — the token wins in ox, and both are the gateway's to hold", () => {
-    const env = oxEnv({ token: "tok_abc", configHome: "/mnt/secrets-store/ox" }, {});
+    const env = oxEnv({ token: () => "tok_abc", configHome: "/mnt/secrets-store/ox" }, {});
     expect(env).toMatchObject({ SAGEOX_TOKEN: "tok_abc", XDG_CONFIG_HOME: "/mnt/secrets-store/ox" });
   });
 });

--- a/packages/core/test/team-http.test.ts
+++ b/packages/core/test/team-http.test.ts
@@ -145,6 +145,25 @@ describe("ox credential handling", () => {
     expect(oxEnv({ token: () => undefined }, {}).SAGEOX_TOKEN).toBeUndefined();
   });
 
+  it("clears an inherited token when the configured ref reads as nothing", () => {
+    // The gateway's own environment is not this agent's credential. On a host running
+    // several agents each with its own ref, an ambient `SAGEOX_TOKEN` is somebody else's,
+    // and ox would authenticate as them rather than fall back to the auth file.
+    const env = oxEnv({ token: () => undefined, configHome: "/mnt/secrets-store/ox" }, {
+      SAGEOX_TOKEN: "oxp_someone_else",
+      PATH: "/usr/bin",
+    });
+
+    expect(env.SAGEOX_TOKEN).toBeUndefined();
+    expect(env).toMatchObject({ XDG_CONFIG_HOME: "/mnt/secrets-store/ox", PATH: "/usr/bin" });
+  });
+
+  it("leaves an inherited token alone when no ref is configured at all", () => {
+    // A workstation call — `doctor` with no team brain declared — means to use whatever
+    // login this shell already has. Only a configured ref speaks for the agent.
+    expect(oxEnv({ team: "team_x" }, { SAGEOX_TOKEN: "oxp_mine" }).SAGEOX_TOKEN).toBe("oxp_mine");
+  });
+
   it("points ox at a mounted auth file when given one", () => {
     const env = oxEnv({ configHome: "/mnt/secrets-store/ox" }, { PATH: "/usr/bin" });
     expect(env.XDG_CONFIG_HOME).toBe("/mnt/secrets-store/ox");

--- a/packages/core/test/team-server.test.ts
+++ b/packages/core/test/team-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -11,6 +11,7 @@ import {
   TEAM_TOOLS,
   TEAM_TOOL_NAMES,
   type OxFailure,
+  type OxScope,
   type TeamBrain,
   type TeamOx,
   type TeamPassage,
@@ -55,6 +56,9 @@ async function until(condition: () => boolean, what: string): Promise<void> {
 async function withFakeOx<T>(
   script: string | undefined,
   body: (brain: TeamBrain, bin: string) => Promise<T>,
+  // Taken as a function of the directory, because the only scope any test here varies is
+  // the credential, and a credential is a path under it.
+  scope: (bin: string) => OxScope = () => ({}),
 ): Promise<{ value: T; log: string }> {
   const bin = mkdtempSync(join(tmpdir(), "ox-fake-"));
   if (script !== undefined) writeFileSync(join(bin, "ox"), `#!/bin/sh\n${script}\n`, { mode: 0o755 });
@@ -63,7 +67,7 @@ async function withFakeOx<T>(
   const logged: string[] = [];
   const warn = vi.spyOn(console, "warn").mockImplementation((line) => void logged.push(String(line)));
   try {
-    const value = await body(makeOxTeam({ team: "team_x", cwd: bin }), bin);
+    const value = await body(makeOxTeam({ team: "team_x", cwd: bin, ...scope(bin) }), bin);
     return { value, log: logged.join("\n") };
   } finally {
     warn.mockRestore();
@@ -324,6 +328,36 @@ describe("the team brain's own capability health", () => {
       return [dead, brain.readings()[0].health];
     });
     expect(value).toEqual(["Unavailable", "Ok"]);
+  });
+
+  it("hands each lookup the credential on disk now, so a rotated secret self-heals", async () => {
+    // The other half of "clears itself on the next answer": that latch only clears if the
+    // next lookup can still get one, and with a token read once at boot it cannot — a
+    // secrets-store CSI driver rewrites the file under the mount and the process goes on
+    // sending the revoked value. The fake records what it was handed.
+    const RECORDS_TOKEN = `printf '%s' "$SAGEOX_TOKEN" > ./seen\necho '{"team_context":{"results":[]}}'`;
+    const { value } = await withFakeOx(
+      RECORDS_TOKEN,
+      async (brain, bin) => {
+        const seen = () => readFileSync(join(bin, "seen"), "utf8");
+        writeFileSync(join(bin, "secret"), "tok_old");
+        await brain.search("x", 5);
+        const before = seen();
+        writeFileSync(join(bin, "secret"), "tok_new");
+        await brain.search("x", 5);
+        return [before, seen()];
+      },
+      // Stands in for `resolveSecret` against a mounted secrets directory, down to
+      // answering `undefined` for a ref with no file — which is what a token captured
+      // before this body wrote one would have carried for the whole process.
+      (bin) => ({
+        token: () => {
+          const path = join(bin, "secret");
+          return existsSync(path) ? readFileSync(path, "utf8").trim() : undefined;
+        },
+      }),
+    );
+    expect(value).toEqual(["tok_old", "tok_new"]);
   });
 
   it("reads an answer with no passages as Ok, never as an empty corpus", async () => {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0648d-6ccb-745d-8505-2f250ebc015b">Session</a>
<!-- /sageox:pr-header -->

Closes #23.

## What was needed

Rotate a credential in the external store and, with a secrets-store CSI driver running with rotation enabled, the file under the agent's `--secrets` directory is refreshed in place within a couple of minutes. The agent goes on sending the old value for the rest of the process's life. Recovering needs a Deployment restart — a real interruption on a running agent, for a value already sitting current on the container's own filesystem.

`resolveSecret()` returns a **string**. `buildBrain` resolved it once, at startup, and `oxEnv()` stamped that captured string onto every `ox` child. This was documented behaviour rather than an oversight, which is why #23 is a request to revisit the contract — and it sat oddly beside this project's own readiness rule, [*"Re-read transient states. Hand readings over as a function, not a value."*](docs/startup-and-readiness.md) Capability readings follow that rule; the credential deciding whether those readings can succeed was handed over as a value.

```mermaid
flowchart LR
  A["CSI rewrites the secret<br/>under the mount"] --> B{"when is it read?"}
  B -->|"before: once, at boot"| C["every ox child carries<br/>the revoked value —<br/>restart to recover"]
  B -->|"now: per ox child"| D["next lookup carries<br/>the new value,<br/>the latch clears"]
```

## What this ships

- **`packages/core/src/team-server.ts`** — `OxScope.token` becomes `() => string | undefined`, and `oxEnv()` calls it while building the env for each child. That is the whole mechanism: an `lstat` and a small `readFileSync` next to a process spawn.
- **`packages/cli/src/cli.ts`** — the gateway and `doctor` pass `() => resolveSecret(...)` instead of its result.
- **`packages/cli/src/ox.ts`** — `credentialSource()` calls the reading, so a ref that is declared but unmounted correctly reports `auth file` rather than claiming a token did the work.
- The `not-authenticated` remedy drops **"then restart"**. That clause was the cached token's consequence; leaving it would send an operator to do the ceremony this change removes. It now says a file-mounted value is read by the next lookup, and only a value supplied in the environment needs a restart — `process.env` genuinely cannot change under a running process.
- CHANGELOG, plus the four places that stated the old contract: [`docs/deployment-contract.md`](docs/deployment-contract.md), [`docs/aws-eks-deployment.md`](docs/aws-eks-deployment.md), [`docs/guide/reference.md`](docs/guide/reference.md), [`docs/guide/troubleshooting.md`](docs/guide/troubleshooting.md).

It composes with `f8542f3` exactly as the issue predicted. The latch already cleared on the next answered lookup — but that lookup could never *get* an answer while it kept sending the revoked value. Rotation now self-heals with nobody involved, and a genuine revoke is the only case left needing a person, which is the honest split.

## Three judgement calls

**Only this credential.** Every other one still resolves at startup, and that is correct rather than lazy: the Slack tokens open a Socket Mode connection, the Buzz identity becomes a signer, and the Anthropic key is stamped onto an ACP child spawned once (`brain-acp.ts:250`). Each is held by something a rotation would have to re-establish anyway, so re-reading the file would buy nothing. The `ox` token is the only credential handed to a *fresh process per use* — which is what makes per-invocation resolution free here and structural everywhere else.

**Our own bootstrap module never refreshes the mount, and I documented that rather than changing it.** [`deploy/terraform/aws-eks-bootstrap/main.tf`](deploy/terraform/aws-eks-bootstrap/main.tf) leaves the CSI driver's `enableSecretRotation` at its default of off, so on the reference AWS path a restart is still the rotation step and this change is inert until an operator opts in. Enabling the reconciler is cluster-wide, adds Secrets Manager polling for every mount, and is a deploy decision #23 did not ask for. Say the word and it is a one-line follow-up.

That comment also had to change either way: it justified `syncSecret` with *"the runtime resolves credentials at process startup"* — a premise this PR removes — and conflated the Kubernetes-Secret mirror with the rotation reconciler, which are different settings. It now says what each one does.

**The suggested retry-on-auth-failure path is not here.** #23 offered it as an alternative, not an addition, and re-reading per invocation subsumes it: a retry would only ever re-read the same file this now reads first. Adding both would be a second mechanism for one failure.

## How I verified

`pnpm typecheck` and `pnpm test` (1115 tests, 63 files) green. `terraform fmt -check -recursive deploy/terraform` clean.

The test that fails without the change is `packages/core/test/team-server.test.ts` — *"hands each lookup the credential on disk now, so a rotated secret self-heals"*. A fake `ox` records the `SAGEOX_TOKEN` it was handed; the test rewrites the secret file between two lookups and asserts the two children saw `tok_old` then `tok_new`. It reads the file the way `resolveSecret` does, down to answering `undefined` for a ref with no file — which is what a token captured before the body wrote one would have carried for the whole process.

I checked the negative case by memoizing the resolution in `oxEnv` and re-running: the second child gets `tok_old` and the test fails on the assertion rather than crashing. `withFakeOx` grew one optional parameter to vary the scope, since the credential is the only scope field any test here needs to change.

Also in `packages/core/test/team-http.test.ts`: `oxEnv` reads the token per call, and a reading that answers `undefined` adds no `SAGEOX_TOKEN` at all — an empty one is a credential as far as ox is concerned, and it would lose to the auth file silently.

SageOx-Session: https://sageox.ai/c/ses_01a0648d-6ccb-745d-8505-2f250ebc015b

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790988257&installation_model_id=433550&pr_number=28&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F28&signature=65f872f19b90b1f207f9614606ae92b13bd49f6957ccb3dad8c1a72253cb1e0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File-mounted SageOx credentials are refreshed for each `ox` lookup, allowing rotated tokens to take effect without restarting when the mounted secret updates.
  * Credential reporting now matches the credentials supplied to each child process, including fallback to the authentication file when configured tokens are empty.

* **Documentation**
  * Updated deployment, credential rotation, and troubleshooting guidance.
  * Clarified that other credentials and environment-supplied tokens may require a restart.
  * Documented that automatic CSI secret rotation remains disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->