### PR TITLE
Let a job Pod read the agent's checkouts, since the index cannot travel read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `sageox-agent run`, in its own process, so what a body finds there depends on where it is
   running: a run the brain starts is inside that process and, on an agent whose brain has
   code tools, sees one — while every other run is a standalone `job run`, which builds no
-  workspace whatever its trigger and reads one only where its target mounted it.
+  workspace whatever its trigger and reads one only where its target makes one visible.
   `docs/job-contract.md` has the rule, the test to make before looking, and what to do when
   the answer is no; `job run` is now held to it by a test that fails if it ever starts
   warming a workspace of its own.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **The job body contract says what a body finds on disk.** A body must not read
+- **The job body contract says what a body finds on disk.** A body never writes
   `workspace/` — the repository checkouts and the `ox` index there are built by
   `sageox-agent run`, in its own process, so what a body finds there depends on where it is
   running: a run the brain starts is inside that process and, on an agent whose brain has
   code tools, sees one — while every other run is a standalone `job run`, which builds no
-  workspace whatever its trigger. A body that reads a checkout works when someone asks for
-  it and fails on its tick. `docs/job-contract.md` has the rule, what to do instead, and
-  why a shared working tree is the wrong fix; `job run` is now held to it by a test that fails if
-  it ever starts warming a workspace of its own.
+  workspace whatever its trigger and reads one only where its target mounted it.
+  `docs/job-contract.md` has the rule, the test to make before looking, and what to do when
+  the answer is no; `job run` is now held to it by a test that fails if it ever starts
+  warming a workspace of its own.
+
+- **A scheduled job can read the agent's repository checkouts.** A job Pod's `/agents` is an
+  `emptyDir`, so a body on its 3am tick started from nothing — no checkout, and no way to
+  afford the clone inside its budget — while the agent Pod beside it held the same
+  repositories, cloned once and fast-forwarded since, on its claim. The chart's new
+  `persistence.jobCheckouts` mounts `workspace/repos` from that claim into the agent's
+  CronJob Pods, read-only and `subPath`-narrowed, with a required pod affinity onto the
+  agent's node — the price a `ReadWriteOnce` claim charges, and the reason a tick that
+  cannot land there is lost as a `DeadlineExceeded` Job rather than run without the code it
+  was written to read. The `ox` index does not come with them: `ox` opens its store
+  read-write and reports one it cannot write as corrupt, so a shared index would answer a
+  search from nothing rather than fail. Off by default, per agent, and
+  [the chart's README](deploy/helm/README.md#a-job-that-reads-the-agents-checkouts) has the
+  three things it deliberately does not do.
 
 ### Changed
 

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -346,15 +346,58 @@ ServiceAccount, secret mount, shared volumes, and resource numbers. It stages th
 itself, with the same init container the agent Pod runs — a job that waited on the
 Deployment to have gone first would lose its run on a fresh install, and nothing retries it.
 
-What it does not get is the agent's claim. `/agents` in a job Pod is an `emptyDir`, fresh
-for the run and gone with it, because the claim is `ReadWriteOnce` and a job Pod mounting it
-could only attach where the Deployment Pod already ran — anywhere else the Pod sat in
-`Init:0/1` behind a `Multi-Attach error for volume` until `activeDeadlineSeconds` killed it,
-with empty logs, because the body never started. Nothing a run needs is on that claim: it
-stages its own bundle, reads its kill switch through the relay, and writes its verdict
-under the container's own tmpdir. A job body that genuinely shares durable state with the
-agent gets a `sharedVolumes` entry, on a claim you back with an access mode that allows two
-Pods to mount it — `ReadWriteMany` for anything that may land on a second node.
+What it does not get by default is the agent's claim. `/agents` in a job Pod is an
+`emptyDir`, fresh for the run and gone with it, because the claim is `ReadWriteOnce` and a
+job Pod mounting it can only attach where the Deployment Pod already ran — anywhere else the
+Pod sits in `Init:0/1` behind a `Multi-Attach error for volume` until `activeDeadlineSeconds`
+kills it, with empty logs, because the body never started. Nothing the envelope needs is on
+that claim: the run stages its own bundle, reads its kill switch through the relay, and
+writes its verdict under the container's own tmpdir. A job body that genuinely shares
+durable state with the agent gets a `sharedVolumes` entry, on a claim you back with an
+access mode that allows two Pods to mount it — `ReadWriteMany` for anything that may land on
+a second node.
+
+### A job that reads the agent's checkouts
+
+The one thing on that claim a scheduled run cannot cheaply build for itself is the
+repository checkouts under `workspace/repos`. The agent Pod clones them at startup and only
+fast-forwards them afterwards; a job Pod starting from nothing pays the whole clone out of
+its budget, every tick. `persistence.jobCheckouts` mounts them into this agent's CronJob
+Pods, read-only:
+
+```yaml
+agents:
+  beekeeper:
+    persistence:
+      size: 20Gi
+      jobCheckouts: true
+```
+
+A body then finds `workspace/repos/<owner>--<repo>` under its working directory, where a run
+started from chat already finds it
+([the job body contract](../../docs/job-contract.md#what-a-body-finds-on-disk)).
+
+Three things this deliberately does not do.
+
+**It does not hand over the claim.** The mount is `subPath`-narrowed to `workspace/repos`,
+so `state.json` and the local memory vault stay in the Deployment Pod. `workspace/ox-data`
+— the `ox` code index — is left out for a second reason: `ox` opens its store read-write, so
+against a read-only one it reports corruption, `ox code search` errors, and `ox code status`
+answers zeroes over `index_exists: true`. An index that reads as empty is worse for a job
+than no index at all, so a job body's `ox` finds none and says so.
+
+**It does not make the tree writable.** `readOnly` is on the mount, so the kernel refuses:
+the agent fast-forwards those trees at every start, and a body writing there is a second
+writer on a tree it does not own. A body that needs a tree of its own clones from the mount
+— `git clone --depth 1 workspace/repos/<owner>--<repo> ./work` is local, needs no token, and
+costs no network.
+
+**It does not let a run proceed without it.** The claim is `ReadWriteOnce`, so these Pods
+carry a required `podAffinity` onto the node the Deployment Pod runs on. While that Pod is
+missing — a drain, a rescheduling, an agent scaled to zero — the job Pod is unschedulable
+and the tick is lost as a `DeadlineExceeded` Job. That is the intended behaviour: a body
+written to read code, running without the code, is a green run that proved nothing. Leave
+`jobCheckouts` off for an agent whose jobs must fire while the agent itself is down.
 
 ### A job that reads the Kubernetes API
 

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -105,6 +105,12 @@ scheduled run is lost.
 {{- define "agent.agentVolumeMounts" -}}
 - name: agent-data
   mountPath: /agents
+{{- if and .job .agent.persistence.jobCheckouts }}
+- name: checkouts
+  mountPath: /agents/{{ .name }}/workspace/repos
+  subPath: {{ .name }}/workspace/repos
+  readOnly: true
+{{- end }}
 {{- range $volume := .agent.sharedVolumes }}
 - name: {{ $volume.name }}
   mountPath: {{ $volume.mountPath | quote }}
@@ -167,10 +173,22 @@ from under the `Read(//mnt/secrets-store/**)` deny rule's sibling without the re
 claim is `ReadWriteOnce`, which binds it to one node: a job Pod the scheduler placed on any
 other node could not attach it, and sat in `Init:0/1` behind a `Multi-Attach` event until
 `activeDeadlineSeconds` killed it — with nothing in the job's own logs, because the body
-never started. A scheduled run needs nothing that is on the claim: it stages its own bundle
-from `/config`, reads its kill switch through the relay, and writes its verdict under the
-container's own tmpdir. Durable state a job body does share with the agent goes on a
+never started. A scheduled run needs nothing else that is on the claim: it stages its own
+bundle from `/config`, reads its kill switch through the relay, and writes its verdict under
+the container's own tmpdir. Durable state a job body does share with the agent goes on a
 `sharedVolumes` claim, which the operator backs with an access mode that allows it.
+
+`persistence.jobCheckouts` is the one exception, and it is the same claim a second time:
+read-only, and narrowed by `subPath` to `workspace/repos`, the repository checkouts
+`sageox-agent run` clones and fast-forwards. The Pod affinity in `cronjob.yaml` is what
+makes that attachable at all. Narrowed rather than the whole claim, because two things on it
+are not a job's to read: `state.json` and the local memory vault are the agent's own, and
+`workspace/ox-data` is an index `ox` opens read-write — pointed at a store it cannot write,
+it reports corruption and answers a search from nothing, which is worse than having none.
+
+`readOnly` sits on the mount rather than on the claim reference: the kubelet creates a
+missing `subPath` directory on the volume and cannot do that through a read-only attach, and
+an agent that has never had a `repos.conf` has no `workspace/repos` for it to find.
 
 The bundle arrives on whatever volume the consumer named, passed through verbatim: a
 ConfigMap, an image, a claim, a CSI volume. The chart's contract is the directory at
@@ -183,6 +201,11 @@ No volume at all is the case where the bundle rides inside `bundle.stageImage` i
 {{- if .job }}
   emptyDir: {}
 {{- else }}
+  persistentVolumeClaim:
+    claimName: {{ include "agent.claimName" . }}
+{{- end }}
+{{- if and .job .agent.persistence.jobCheckouts }}
+- name: checkouts
   persistentVolumeClaim:
     claimName: {{ include "agent.claimName" . }}
 {{- end }}

--- a/deploy/helm/templates/cronjob.yaml
+++ b/deploy/helm/templates/cronjob.yaml
@@ -79,6 +79,27 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if $agent.persistence.jobCheckouts }}
+          # The checkouts mount is the agent's own `ReadWriteOnce` claim, and one node at a
+          # time can attach it. Required and not preferred: a Pod the scheduler placed
+          # anywhere else would wait behind a `Multi-Attach` event with empty logs, while an
+          # unschedulable one says which constraint it failed. So when the agent Pod is
+          # missing — a drain, a rescheduling, an agent scaled to zero — the tick is lost as
+          # a `DeadlineExceeded` Job rather than run without the checkout it asked for.
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      {{- include "agent.agentSelectorLabels" $context | nindent 22 }}
+                    # The Deployment's Pod and not another job Pod of this agent: those
+                    # carry the same selector labels, and a node holding only one of them is
+                    # a node the claim is not attached to.
+                    matchExpressions:
+                      - key: agent-toolkit/job
+                        operator: DoesNotExist
+          {{- end }}
           securityContext:
             fsGroup: 10001
             fsGroupChangePolicy: OnRootMismatch

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -133,6 +133,8 @@ fi
 # with empty logs, and `DoesNotExist` keeps another job Pod of the same agent — which
 # carries the same selector labels — from standing in for the Deployment's.
 counted 1 "podAffinity:"
+present "requiredDuringSchedulingIgnoredDuringExecution:"
+absent "preferredDuringSchedulingIgnoredDuringExecution:"
 present "topologyKey: kubernetes.io/hostname"
 present "operator: DoesNotExist"
 present "key: agent-toolkit/job"

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -93,6 +93,10 @@ present "mountPath: /mnt/secrets-store"
 counted 2 "emptyDir: {}"
 absent "claimName: agents-harry"
 absent "claimName: agents-ida"
+# And nothing pins a job Pod anywhere, which is what a job that needs no claim buys: it
+# runs on whichever node has room, whatever the agent Pod is doing.
+absent "name: checkouts"
+absent "podAffinity"
 
 # The Deployment keeps the claim. Its `/agents` holds the cursors, local memory, checkouts
 # and indexes the contract calls durable, so gating the mount on the wrong side of `.job`
@@ -101,6 +105,46 @@ rendered=$(helm template agents "$chart" --values "$values" --show-only template
 present "claimName: agents-harry"
 present "claimName: agents-ida"
 absent "emptyDir"
+
+# `persistence.jobCheckouts` mounts the one thing on the claim a scheduled run could not
+# cheaply build for itself: the checkouts the agent Pod clones and fast-forwards. Narrowed
+# by `subPath` to `workspace/repos`, so `workspace/ox-data`, `state.json` and the local
+# memory vault stay in the Deployment Pod — an index `ox` cannot write is reported corrupt
+# and answers a search from nothing, and the other two are not a job's to read.
+render --set agents.harry.persistence.jobCheckouts=true
+counted 2 "name: checkouts"
+present "mountPath: /agents/harry/workspace/repos"
+present "subPath: harry/workspace/repos"
+matched 1 "claimName: agents-harry$"
+# Read-only, and said on the mount. The agent fast-forwards that tree at every start, so a
+# body writing there is a second writer on a tree it does not own — and `ox` pointed at a
+# writable index deletes the store the moment it reads one as corrupt.
+if ! grep -A2 -F "mountPath: /agents/harry/workspace/repos" <<<"$rendered" | grep -qF "readOnly: true"; then
+  fail "the checkouts mount must be read-only"
+fi
+# Not on the claim reference, though: the kubelet creates a missing `subPath` directory
+# through it, and an agent that has never had a repos.conf has no `workspace/repos` yet.
+if grep -A2 -E "claimName: agents-harry$" <<<"$rendered" | grep -qF "readOnly"; then
+  fail "the checkouts claim reference must not be read-only"
+fi
+
+# The claim is ReadWriteOnce, so the Pod has to land where the agent Pod already holds it.
+# Required and not preferred: a Pod scheduled elsewhere waits behind a `Multi-Attach` event
+# with empty logs, and `DoesNotExist` keeps another job Pod of the same agent — which
+# carries the same selector labels — from standing in for the Deployment's.
+counted 1 "podAffinity:"
+present "topologyKey: kubernetes.io/hostname"
+present "operator: DoesNotExist"
+present "key: agent-toolkit/job"
+
+# `/agents` is still each job Pod's own `emptyDir` — the run stages its bundle there, and
+# the claim it now reads supplies one directory inside that tree and nothing else. ida sets
+# nothing, so this is per agent and not a release-wide flip.
+counted 2 "emptyDir: {}"
+rendered=$(helm template agents "$chart" --values "$values" \
+  --set agents.harry.persistence.jobCheckouts=true --show-only templates/deployment.yaml)
+absent "name: checkouts"
+absent "podAffinity"
 
 # Every scheduled Pod stages its own bundle, into the `emptyDir` above. One that waited on
 # the Deployment to have gone first would lose its run on a fresh install, and nothing

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -147,7 +147,11 @@
           "properties": {
             "size": { "type": "string", "minLength": 1 },
             "storageClass": { "type": "string" },
-            "existingClaim": { "$ref": "#/$defs/optionalObjectName" }
+            "existingClaim": { "$ref": "#/$defs/optionalObjectName" },
+            "jobCheckouts": {
+              "type": "boolean",
+              "description": "Mount this agent's repository checkouts — `workspace/repos` on its claim, cloned and fast-forwarded by the agent Pod — read-only into its CronJob Pods, and pin those Pods to the node the agent Pod runs on. Default false, which leaves a job Pod with the `emptyDir` it has always had. The claim is ReadWriteOnce, so the affinity is required rather than preferred: a job Pod anywhere else cannot attach it. The checkouts and nothing else on the claim — the `ox` index is left out because `ox` opens its store read-write and reports one it cannot write as corrupt, and the agent's cursors and local memory vault are not a job's to read."
+            }
           }
         },
         "jobs": {

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -106,6 +106,16 @@ provenance, admission past a parked switch, the soft kill switch read from the a
 memory, the budget's own bow-out, the run record, and the verdict artifact the job writes. A
 target supplies a clock, a process, a deadline, and durable state.
 
+A target **may** also let a scheduled run read the repository checkouts the agent's own
+workload maintains, and [the chart](#kubernetes-chart) does, per agent. Read-only is the
+whole of the offer: the agent fast-forwards those trees at every start, so a run writing to
+one is a second writer on a tree it does not own. The `ox` index beside them is not part of
+it — `ox` opens its store read-write and reports one it cannot write as corrupt, so a shared
+index answers a job's search from nothing instead of failing — and neither is the rest of
+the agent's durable state. A target that offers this owes a refusal rather than a
+substitute: a run that cannot reach the checkouts does not happen, because a body written to
+read code, running without the code, is a green run that proved nothing.
+
 ## Kubernetes chart
 
 [`deploy/helm`](../deploy/helm) is the canonical Kubernetes
@@ -143,11 +153,13 @@ the budget, and mints the verdict. The declaration reaches the chart as a mirror
 in that agent's values, because Helm cannot read an operator-supplied bundle at render
 time; the mirror carries the clock and the bound only — not the argv, not the switch —
 so it cannot become a second place a job is decided.
-[The chart's README](../deploy/helm/README.md#jobs) has the rendered shape and the one thing
-a job Pod does not share — the agent's `ReadWriteOnce` claim, which would tie its placement
-to the agent's node. It stages its bundle onto an `emptyDir` of its own instead, and a body
-that does share durable state with the agent gets a `sharedVolumes` claim whose access mode
-says so.
+[The chart's README](../deploy/helm/README.md#jobs) has the rendered shape and what a job
+Pod does not share by default — the agent's `ReadWriteOnce` claim, which ties its placement
+to the agent's node. It stages its bundle onto an `emptyDir` of its own instead.
+`persistence.jobCheckouts` buys back the repository checkouts alone, `subPath`-narrowed and
+read-only, and pays that placement price with a required pod affinity onto the agent's node.
+A body that shares other durable state with the agent gets a `sharedVolumes` claim whose
+access mode says so.
 
 A job Pod is the one pod spec that may hold a cluster token, opted into per agent with
 `serviceAccount.automountJobToken` and off by default. It runs the argv its `agent.yaml`

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -112,23 +112,38 @@ not inherited any more than anything else is.
 directory — `./body.sh` resolves because of it. In a container deployment a scheduled run
 stages that directory for itself, fresh, and drops it when the run ends.
 
-**`workspace/` is not part of it, and a body must not read it.** The repository checkouts
-under `workspace/repos` and the `ox` index under `workspace/ox-data` belong to
-`sageox-agent run`: it builds them at startup, in its own process, for the brain's code
-tools. Nothing else builds them — not `job run`, whatever its trigger — so what a body finds
-there depends on where it is running. A run the brain starts is inside the gateway's own
-process, and on an agent whose brain has code tools it does see a workspace: a racing one,
-because startup creates each repository's directory before `git` fills it and waits for
-neither the clone nor the index. Every other run is a standalone `job run`, which builds
-none, and in a container deployment does not share a filesystem with the gateway at all. A
-body that reads a checkout is a body that works when someone asks for it and fails on its
-3am tick.
+**`workspace/` is the agent's, and a body never writes it.** The repository checkouts under
+`workspace/repos` and the `ox` index under `workspace/ox-data` belong to `sageox-agent run`:
+it clones, fast-forwards and indexes them at startup, in its own process, for the brain's
+code tools. Nothing else builds them — not `job run`, whatever its trigger — so a body
+writing there is a second writer on a tree it does not own, and a body deleting there
+deletes an index the agent pays minutes to rebuild.
 
-**A body that wants a repository clones one** — shallow, and inside its budget. Durable state
-a body genuinely shares with the agent is a mount the deployment gives it
-([`sharedVolumes`](../deploy/helm/README.md#jobs) is the Kubernetes spelling), and a working
-tree is not that: the agent fast-forwards its checkout at every start, so a body writing
-there is a second writer on a tree it does not own.
+**Whether a body may read them depends on the deployment, so test before you look.** A run
+the brain starts is inside the gateway's own process and sees the workspace that process
+built — a racing one, because startup creates each repository's directory before `git` fills
+it and waits for neither the clone nor the index. A standalone `job run` sees what its target
+gave it: on a single host that is the same directory, and in a container deployment it is
+nothing at all unless the deployment says otherwise, which the chart spells
+`persistence.jobCheckouts`
+([the chart's README](../deploy/helm/README.md#a-job-that-reads-the-agents-checkouts)).
+One directory per repository, named `<owner>--<repo>` in lower case, and
+`[ -d workspace/repos/acme--widgets/.git ]` is the test — the directory alone can exist
+before `git` has filled it.
+
+**A body that needs a tree either way clones one** — shallow, and inside its budget. From
+the mount when there is one: `git clone --depth 1 workspace/repos/acme--widgets ./work` is
+local, needs no token, and costs no network. Durable state a body genuinely shares with the
+agent is a mount the deployment gives it
+([`sharedVolumes`](../deploy/helm/README.md#jobs) is the Kubernetes spelling); a working
+tree is not that, which is why the checkouts arrive read-only or not at all.
+
+**The index does not travel with them.** `ox` opens its store read-write, so pointed at a
+read-only one it reports corruption: `ox code search` errors, and `ox code status` answers
+zeroes over `index_exists: true`. A deployment that shares checkouts therefore shares the
+checkouts alone, and a body's `ox` finds no index rather than one that reads as empty.
+`ox query` is API-backed and needs no local store, so it works wherever the job has network
+and a credential.
 
 ## What the job writes back
 

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -127,9 +127,12 @@ gave it: on a single host that is the same directory, and in a container deploym
 nothing at all unless the deployment says otherwise, which the chart spells
 `persistence.jobCheckouts`
 ([the chart's README](../deploy/helm/README.md#a-job-that-reads-the-agents-checkouts)).
-One directory per repository, named `<owner>--<repo>` in lower case, and
-`[ -d workspace/repos/acme--widgets/.git ]` is the test — the directory alone can exist
-before `git` has filled it.
+One directory per repository, named `<owner>--<repo>` in lower case, and the test is
+`git -C workspace/repos/acme--widgets rev-parse --verify HEAD`, not the directory: startup
+creates it, and `git clone` creates `.git` inside it, before either has a ref to resolve.
+What that proves is one clone that got as far as writing one — never a lock. The agent
+fast-forwards these trees at every start, so a body reads a snapshot that can move under it,
+and a body that needs one that cannot clones its own.
 
 **A body that needs a tree either way clones one** — shallow, and inside its budget. From
 the mount when there is one: `git clone --depth 1 workspace/repos/acme--widgets ./work` is

--- a/packages/cli/test/job-run.test.ts
+++ b/packages/cli/test/job-run.test.ts
@@ -91,8 +91,8 @@ describe("sageox-agent job run", () => {
 
   it("warms no repository workspace, so a body cannot come to depend on one", async () => {
     // Declared and still not built. The clone, the fast-forward and `ox index code` belong
-    // to `run`, and a body that read what they leave behind would work on the chat door —
-    // which runs inside that process — and find nothing on the tick.
+    // to `run`, so a tick sees a checkout only where its deployment mounted one — read-only,
+    // and never one this process built.
     writeFileSync(join(bundle, "repos.conf"), "https://github.com/acme/service\n");
     body('echo "workspace $([ -d workspace ] && echo present || echo absent)"');
     const { stdout, code } = await job("shift");


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a065b7-0509-78e1-b9b0-88dc2f954411">Session</a>
<!-- /sageox:pr-header -->

Addresses #30 — the half of it that is buildable today. The index half is not, and the reason is measured below and filed as [sageox/ox#871](https://github.com/sageox/ox/issues/871), so I have not marked this `Closes`.

## What was needed

An agent's **chat surface** gets a persistent workspace: the `repos.conf` checkouts `createRepoWorkspace` clones and fast-forwards, kept on the agent's claim across restarts. Its **scheduled jobs** get an `emptyDir`. So the surface doing the long-running autonomous work has the least context — a job body has no checkout to read, and no room in a tick's budget to clone one, while the Deployment beside it holds the same repositories warm.

```mermaid
flowchart LR
  C["agent claim — ReadWriteOnce<br/>workspace/repos · workspace/ox-data · state.json · memory vault"]
  D["Deployment Pod<br/>/agents = the claim, read-write"]
  J["job Pod<br/>/agents = its own emptyDir"]
  C --- D
  C -. "jobCheckouts: workspace/repos only, read-only" .-> J
```

## What this ships

- **`deploy/helm/templates/_helpers.tpl`** — `persistence.jobCheckouts` adds one volume and one mount to a job Pod: the agent's own claim, `subPath`-narrowed to `workspace/repos`, `readOnly` on the mount. `/agents` stays the Pod's own `emptyDir`, so the run still stages its own bundle.
- **`deploy/helm/templates/cronjob.yaml`** — a required `podAffinity` onto the Deployment Pod's node, with `agent-toolkit/job: DoesNotExist` so another job Pod of the same agent — which carries the same selector labels — cannot stand in for it.
- **`values.schema.json`**, **`deploy/helm/tests/jobs.sh`**, and the three documents that stated the old contract: [the chart README](deploy/helm/README.md#a-job-that-reads-the-agents-checkouts), [`docs/deployment-contract.md`](docs/deployment-contract.md), [`docs/job-contract.md`](docs/job-contract.md).

The body-facing rule changes shape: `workspace/` was *"a body must not read it"*, and is now *"a body never **writes** it, and reads it only where the deployment mounted it"* — with the test to make first, since the directory can exist before `git` has filled it.

## The measured wrinkle: the index cannot come along

The issue proposed mounting the claim so a job gets the checkout **and** the `ox code` index. It cannot get the index. `ox` opens its codedb read-write and runs `integrity_check` at open, so against a store on a read-only filesystem:

```console
$ chmod -R a-w /tmp/ro-ox
$ XDG_DATA_HOME=/tmp/ro-ox ox code status --json
ERROR msg="sqlite corruption detected, removing database" err="integrity_check query failed: attempt to write a readonly database (1544)"
WARN  msg="failed to remove sqlite file" err="... permission denied"
  "commits": 0,
  "symbols": 0,
  "index_exists": true,

$ XDG_DATA_HOME=/tmp/ro-ox ox code search "createRepoWorkspace"
Error: open codedb: open codedb store: sqlite integrity check failed: codedb index is corrupt
```

Same bytes read writable: 19 commits, 1165 symbols. `search` at least fails loudly; **`status` reports the exact shape of a healthy-but-empty index**, which is the [`probeEmpty`](packages/cli/src/repos.ts) failure this repository already refuses to ship — a search that answers from an empty store, in fluent prose. So `workspace/ox-data` is deliberately outside the `subPath`, and a job body's `ox` finds *no* index rather than one that lies. If [sageox/ox#871](https://github.com/sageox/ox/issues/871) lands, the exclusion can go.

Worth noting the writable direction is worse, not better: the remedy for that diagnosis is `removing database`, stopped here only by the filesystem.

## Three judgement calls

**Required affinity, not preferred — and a lost tick is the defined behaviour.** The claim is `ReadWriteOnce`, so a job Pod placed on any other node waits behind a `Multi-Attach` event with empty logs until its deadline kills it. An unschedulable Pod at least names the constraint it failed. So while the agent Pod is missing — a drain, a reschedule, an agent scaled to zero — the tick is lost as a `DeadlineExceeded` Job rather than running without the code it was written to read. That is the question #30 left open, answered in the direction where a job that proved nothing cannot report green. The README says to leave the knob off for an agent whose jobs must fire while the agent is down.

**Per agent, in values — not per job.** #30 sketched `jobs[].run.workspace: read-only`. Chart values mirror a job's clock and bound *and nothing else* by contract, so a per-job key here would become the second place a job is decided. If a fleet later needs one job pinned and another not, that wants a real manifest declaration plus a host precondition — its own change, on the manifest side.

**`readOnly` on the mount, not on the claim reference.** The kubelet creates a missing `subPath` directory *through* that reference and cannot do it on a read-only attach; an agent that has never had a `repos.conf` has no `workspace/repos` yet. The container's view is read-only either way, which is what the kernel enforces against a second writer on a tree the gateway fast-forwards.

## How I verified

`pnpm test` (1118 tests, 63 files) and `pnpm typecheck` green. `helm lint --strict` and all four chart test scripts pass, plus the CI grep on the rendered stage script.

The test that fails without this change is `deploy/helm/tests/jobs.sh` — reverting both templates gives `expected 2 × 'name: checkouts', found 0`. I mutation-tested the two assertions that are easy to write vacuously:

| Mutation | Result |
|---|---|
| `readOnly: true` moved onto the claim reference | `the checkouts claim reference must not be read-only` |
| `readOnly: true` dropped from the mount | `the checkouts mount must be read-only` |

(The first caught a real bug in my own test: `grep -A2 -F "claimName: agents-harry$"` treats the `$` literally and never matches, so the check was silently vacuous until I switched it to `-E`.)

Default rendering is unchanged and asserted so: no `checkouts` volume, no `podAffinity`, and `/agents` still an `emptyDir` in both agents' job Pods.

SageOx-Session: https://sageox.ai/c/ses_01a065b7-0509-78e1-b9b0-88dc2f954411

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791048774&installation_model_id=433550&pr_number=33&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F33&signature=37728b3d6f2b76ca3652817c297d77a72f193dab65aea7838c42bb9f65f39cc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scheduled jobs can optionally access agent repository checkouts through read-only mounts.
  - Added configuration for checkout sharing with required same-node scheduling for persistent storage.
  - Jobs distinguish shared checkouts from isolated workspaces and durable state, including separate handling of the `ox` index.
  - Jobs require checkout availability before starting and can use shallow local clones for isolated work.

- **Documentation**
  - Clarified workspace behavior for standalone and brain-started runs.
  - Documented checkout readiness checks, read-only access, and durable-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->