### PR TITLE
Read the roster the relay keeps, since an agent's own record is not membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never invited to, or a Buzz directory record that omits one, is an agent that connects,
   authenticates, subscribes and is never spoken to, with no error on either side. The two
   surfaces spell it differently and the guide says so — Slack lists every channel the bot
-  joined, so the answer can be wider than the configuration; Buzz has no join, so it returns
-  the overlap of the configured channels and the agent's own directory record and is never
-  wider than the configured list. **Empty and cannot-answer never collapse** — a surface that cannot make a read
+  joined, so the answer can be wider than the configuration; on Buzz being in a channel and
+  being addressable in it are two facts, so it returns the overlap of the configured channels
+  and the agent's own directory record and is never wider than the configured list.
+  **`listMembers` is the surface's own roster on both**, `conversations.members` on Slack and
+  the relay's channel-membership event on Buzz — never a directory record, which is its
+  author's claim about itself and would confirm membership for a key that was never granted
+  any. Where a surface can also say whether a mention of a member *in that channel* would
+  reach them, the ref carries `mentionable`: `false` is somebody in the room who cannot be
+  addressed there, which is the silence a roll call would otherwise grade as a dead agent.
+  **Empty and cannot-answer never collapse** — a surface that cannot make a read
   refuses it by name, because zero members and no membership read look identical to anything
   handed `[]` for both.
 

--- a/docs/guide/chat-surfaces.md
+++ b/docs/guide/chat-surfaces.md
@@ -649,12 +649,21 @@ authenticates, subscribes, and is simply never spoken to.
 **The two surfaces answer it differently, because "in a channel" means different things.**
 On Slack it is `users.conversations`: every channel the bot was invited to, including ones
 `agent.yaml` never mentions, so the list can be wider than the configuration as well as
-narrower. On Buzz there is no join — the agent hears a channel because it subscribes to a
-configured one, and is addressable there because its directory record lists it — so
-`list_channels` returns the **overlap** of those two and is never wider than the configured
-list. A configured channel missing from it is one the record does not cover, which is the
-Buzz spelling of the same failure: a client gates its mention picker on that record and
-strips the mention at send, so every signal on both sides reports healthy.
+narrower. On Buzz it takes two things being true — the agent hears a channel because it
+subscribes to a configured one, and is addressable there because its directory record lists
+it — so `list_channels` returns the **overlap** of those two and is never wider than the
+configured list. A configured channel missing from it is one the record does not cover,
+which is the Buzz spelling of the same failure: a client gates its mention picker on that
+record and strips the mention at send, so every signal on both sides reports healthy.
+
+`list_members` is a different read and answers the relay rather than the agent: it is the
+channel's own membership record, so an identity that published a directory record naming a
+channel it was never added to does not appear in it. Where the relay holds a directory
+record for a member, the answer also carries `mentionable` — whether a mention of that
+member *in this channel* would reach them. A member with `mentionable: false` is in the room
+and cannot be addressed there, which is the one silence a roll call would otherwise read as
+a dead agent. A channel the relay keeps no membership record for is refused rather than
+answered empty: an empty channel and a relay that keeps no rosters are different findings.
 
 **Two of the four are bounded to a configured channel, and two are not.** `list_members`
 and `read_channel` name a channel and resolve it exactly as a post does, so no id the agent

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -278,7 +278,8 @@ const replies = threadRoot
 // asked and did not answer, and the channel being empty is a different finding entirely.
 // `mentionable === false` grades it once more, where the surface can say so: that member is
 // in the channel and the mention above would not have woken it, so its silence says nothing
-// about whether it is running.
+// about whether it is running. Absent is that question unanswered for that member and never
+// a no, so test against `false` rather than for falsiness.
 ```
 
 **What it is bounded to.** `post_message` reaches the channel `report` names and there is no

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -233,7 +233,7 @@ MCP `tools/call` over HTTP, so a `curl` is enough and there is still nothing to 
 |---|---|---|
 | `post_message` | `text`, optionally `mentions` — who to address it to — and optionally a `threadRoot` this run posted | `{"posted": true, "threadRoot": "…"}` — `null` where the surface named no id, so there is nothing to read back |
 | `thread_read` | `root` — a `threadRoot` this run was handed — and optionally `limit` | `{"replies": [{"author", "text", "ts"}, …]}`, oldest first |
-| `channel_members` | optionally `limit`. No destination: the channel is the one `report` names | `{"members": [{"surface", "id", "isSelf", "isAgent", "name"}, …]}` |
+| `channel_members` | optionally `limit`. No destination: the channel is the one `report` names | `{"members": [{"surface", "id", "isSelf", "isAgent", "name", "mentionable"}, …]}` |
 
 ```js
 const call = async (name, args) =>
@@ -276,6 +276,9 @@ const replies = threadRoot
 
 // `roster` is what grades the silence: an id on it that did not reply is an agent that was
 // asked and did not answer, and the channel being empty is a different finding entirely.
+// `mentionable === false` grades it once more, where the surface can say so: that member is
+// in the channel and the mention above would not have woken it, so its silence says nothing
+// about whether it is running.
 ```
 
 **What it is bounded to.** `post_message` reaches the channel `report` names and there is no

--- a/packages/adapter-buzz/src/buzz.ts
+++ b/packages/adapter-buzz/src/buzz.ts
@@ -393,9 +393,13 @@ export class BuzzAdapter implements SurfaceAdapter {
    * in.
    *
    * The membership kind is addressable, so the newest event at the channel's address is the
-   * current roster. A relay holding none cannot answer, and this throws rather than
-   * returning `[]`: an empty roster is a real finding — the channel nobody joined — and
-   * must not also be what a relay that keeps no rosters looks like.
+   * current roster — newest across publishers rather than per publisher, which leaves the
+   * relay's write policy deciding who may say who is in a channel. Nothing here can check
+   * that: an `authors` filter would need a per-channel owner, and no manifest carries one.
+   *
+   * A relay holding no roster cannot answer, and this throws rather than returning `[]`: an
+   * empty roster is a real finding — the channel nobody joined — and must not also be what a
+   * relay that keeps no rosters looks like.
    */
   async listMembers(channel: ChannelRef, limit?: number): Promise<readonly ActorRef[]> {
     const relay = this.relay;
@@ -420,9 +424,26 @@ export class BuzzAdapter implements SurfaceAdapter {
     // the roster is one event, so a relay-side limit would trim how many rosters came back
     // and not how many people are named in the one that did.
     //
+    // Normalized and deduplicated before `limit`, because both decide who fits under it: one
+    // pubkey tagged twice, or tagged once in hex and once as an npub, would take two of the
+    // slots and come back twice. A tag that is no pubkey at all names nobody here —
+    // `describeActor`'s finding for the same value — and dropping it keeps it out of the
+    // `authors` filter below, which one unusable entry can cost its whole answer.
+    //
     // `"p"` rather than `BUZZ_DEFAULTS.mentionTag`: on this kind the tag names a member, and
     // the two would drift apart the moment a relay spelled either differently.
-    const pubkeys = roster.tags.filter((tag) => tag[0] === "p" && tag[1]).map((tag) => tag[1]);
+    const pubkeys = [
+      ...new Set(
+        roster.tags.flatMap((tag) => {
+          if (tag[0] !== "p" || !tag[1]) return [];
+          try {
+            return [toHexPubkey(tag[1])];
+          } catch {
+            return [];
+          }
+        }),
+      ),
+    ];
     const members = limit === undefined ? pubkeys : pubkeys.slice(0, limit);
     if (members.length === 0) return [];
 

--- a/packages/adapter-buzz/src/buzz.ts
+++ b/packages/adapter-buzz/src/buzz.ts
@@ -378,36 +378,79 @@ export class BuzzAdapter implements SurfaceAdapter {
   }
 
   /**
-   * Who the relay's directory says is in one configured channel.
+   * Who the relay says is in one configured channel — its channel-membership event.
    *
-   * That is the membership Buzz has: there is no join, and a record naming the channel is
-   * what makes its author addressable there. So the roster is agents, and a person who
-   * reads the channel is not on it — which is the honest answer to the question a probe is
-   * really asking, "who would a post here have woken".
+   * The relay's roster, which is the question `SlackAdapter.listMembers` answers from
+   * `conversations.members`. Not the directory: a record naming this channel is its
+   * author's claim about itself, so a key that was never granted membership can publish
+   * one, and a caller diagnosing the failure {@link listChannels} describes would be told
+   * membership was confirmed on the agent's own say-so. What the directory does answer is
+   * `mentionable`, read below off the same records that put names to the roster.
    *
    * Its own REQ rather than the directory subscription `start` opens, because that one is
    * opened only for a caller that passed a listener: a `job run` starts this adapter to
    * post one line, and would otherwise read an empty roster and report a channel nobody is
-   * in. Kind 10100 is replaceable, so newest per author is the current record.
+   * in.
+   *
+   * The membership kind is addressable, so the newest event at the channel's address is the
+   * current roster. A relay holding none cannot answer, and this throws rather than
+   * returning `[]`: an empty roster is a real finding — the channel nobody joined — and
+   * must not also be what a relay that keeps no rosters looks like.
    */
   async listMembers(channel: ChannelRef, limit?: number): Promise<readonly ActorRef[]> {
     const relay = this.relay;
     if (!relay) throw new Error("BuzzAdapter.start() must be called before listMembers()");
     this.assertConfigured(channel);
 
-    // `limit` is applied after the channel filter and never on the wire, unlike the two
-    // reads below: a relay-side limit trims the newest records regardless of which channel
-    // they name, so it could drop a member of this one and leave the roster short with
-    // nothing to say it had been.
-    const records = newestPerAuthor(await this.query(relay, { kinds: [DIRECTORY_KIND] }));
+    const roster = newest(
+      await this.query(relay, {
+        kinds: [BUZZ_DEFAULTS.membershipKind],
+        // NIP-01's identifier tag, which on this kind is the channel the roster is for.
+        "#d": [channel.id],
+      }),
+    );
+    if (!roster) {
+      throw new Error(
+        `the relay holds no membership record for Buzz channel ${channel.id}, so who is ` +
+          "in it cannot be read",
+      );
+    }
 
-    const members = records.flatMap((event) => {
-      const record = directoryRecord(event);
-      return record.channels.includes(channel.id)
-        ? [this.actor(event.pubkey, record.name, true)]
-        : [];
+    // `limit` bounds the members and never the wire, unlike `readThread` and `readChannel`:
+    // the roster is one event, so a relay-side limit would trim how many rosters came back
+    // and not how many people are named in the one that did.
+    //
+    // `"p"` rather than `BUZZ_DEFAULTS.mentionTag`: on this kind the tag names a member, and
+    // the two would drift apart the moment a relay spelled either differently.
+    const pubkeys = roster.tags.filter((tag) => tag[0] === "p" && tag[1]).map((tag) => tag[1]);
+    const members = limit === undefined ? pubkeys : pubkeys.slice(0, limit);
+    if (members.length === 0) return [];
+
+    // One REQ for the whole roster, over the two kinds `describeActor` reads for one id: an
+    // agent publishes a directory record, a person only the NIP-01 profile.
+    const records = newestPerAuthor(
+      await this.query(relay, {
+        kinds: [DIRECTORY_KIND, BUZZ_DEFAULTS.profileKind],
+        authors: members,
+      }),
+    );
+
+    return members.map((pubkey) => {
+      const own = records.filter((event) => event.pubkey === pubkey);
+      const directory = own.find((event) => event.kind === DIRECTORY_KIND);
+      if (!directory) {
+        // Nothing here answers `mentionable` for a pubkey with no directory record, so it
+        // is left unset rather than false: what makes a person mentionable on this relay is
+        // not something the directory says.
+        const profile = own[0];
+        return this.actor(pubkey, profile ? directoryRecord(profile).name : undefined, false);
+      }
+      const record = directoryRecord(directory);
+      return {
+        ...this.actor(pubkey, record.name, true),
+        mentionable: record.channels.includes(channel.id),
+      };
     });
-    return limit === undefined ? members : members.slice(0, limit);
   }
 
   /**
@@ -662,6 +705,14 @@ function newestPerAuthor(events: Event[]): Event[] {
     if (!held || supersedes(event, held)) current.set(key, event);
   }
   return [...current.values()];
+}
+
+/** The current event among several at one address, by {@link supersedes}. */
+function newest(events: Event[]): Event | undefined {
+  return events.reduce<Event | undefined>(
+    (held, event) => (!held || supersedes(event, held) ? event : held),
+    undefined,
+  );
 }
 
 /**

--- a/packages/adapter-buzz/src/normalize.ts
+++ b/packages/adapter-buzz/src/normalize.ts
@@ -23,6 +23,12 @@ export const BUZZ_DEFAULTS = {
   profileKind: 0,
   /** NIP-25 reaction. */
   reactionKind: 7,
+  /**
+   * The relay's channel-membership event: addressable, `d` naming the channel, one `p` tag
+   * per member as `["p", <pubkey>, "", <role>]`. The only roster the relay vouches for — a
+   * directory record is its author's claim about itself.
+   */
+  membershipKind: 39002,
   /** Buzz's ephemeral typing indicator, as built by buzz-acp. */
   typingKind: 20002,
   /** NIP-09 deletion. */

--- a/packages/adapter-buzz/test/buzz.test.ts
+++ b/packages/adapter-buzz/test/buzz.test.ts
@@ -11,6 +11,8 @@ import { FakeRelay } from "./fake-relay.ts";
 const agentSk = generateSecretKey();
 const agentPk = getPublicKey(agentSk);
 const userSk = generateSecretKey();
+/** Whoever the relay lets write a channel's roster — never this agent, and never a member. */
+const channelOwnerSk = generateSecretKey();
 
 let relay: FakeRelay;
 afterEach(async () => {
@@ -1066,6 +1068,21 @@ describe("BuzzAdapter reads the surface it is on", () => {
       sk,
     );
 
+  /** The relay's roster for one channel: `d` names it, one `p` tag per member. */
+  const membersOf = (channel: string, members: Uint8Array[], at = now - 86400) =>
+    finalizeEvent(
+      {
+        kind: BUZZ_DEFAULTS.membershipKind,
+        created_at: at,
+        tags: [
+          ["d", channel],
+          ...members.map((sk) => ["p", getPublicKey(sk), "", "member"]),
+        ],
+        content: "",
+      },
+      channelOwnerSk,
+    );
+
   it("lists only the configured channels its own directory record covers", async () => {
     relay = await FakeRelay.start();
     const a = newAdapter({
@@ -1086,22 +1103,71 @@ describe("BuzzAdapter reads the surface it is on", () => {
     await a.stop();
   });
 
-  it("names the agents whose records list the channel, and nobody else", async () => {
+  it("names who the relay's roster says is in the channel, not who claims to be", async () => {
     relay = await FakeRelay.start();
     const a = newAdapter();
     await a.start();
     const siblingSk = generateSecretKey();
-    const elsewhereSk = generateSecretKey();
+    const claimantSk = generateSecretKey();
+    relay.backlog.push(membersOf("hive", [siblingSk, userSk]));
     relay.backlog.push(registeredIn(siblingSk, "ida", ["hive"]));
-    relay.backlog.push(registeredIn(elsewhereSk, "otto", ["ops"]));
-    // A person who talks in hive has no record, so no client offers their mention there
-    // either — the roster is who a post would have woken.
-    relay.backlog.push(inChannel("hive", "hello"));
+    relay.backlog.push(profile(userSk, "alice"));
+    // A record naming hive is its author's claim about itself, and anyone holding a key can
+    // publish one. The roster is what the relay vouches for, so this key is not in it.
+    relay.backlog.push(registeredIn(claimantSk, "otto", ["hive"]));
 
     const members = await a.listMembers!({ surface: "buzz", id: "hive", isPublic: false });
-    expect(members.map((member) => member.name)).toEqual(["ida"]);
-    expect(members[0].id).toBe(getPublicKey(siblingSk));
-    expect(members[0].isAgent).toBe(true);
+    expect(members.map((member) => member.id)).toEqual([
+      getPublicKey(siblingSk),
+      getPublicKey(userSk),
+    ]);
+    expect(members[0]).toMatchObject({ name: "ida", isAgent: true, mentionable: true });
+    // A person publishes no directory record, so nothing here answers whether a mention
+    // would reach them — which is not the same answer as no.
+    expect(members[1]).toMatchObject({ name: "alice", isAgent: false });
+    expect(members[1].mentionable).toBeUndefined();
+    await a.stop();
+  });
+
+  it("marks a member the directory does not make addressable in this channel", async () => {
+    relay = await FakeRelay.start();
+    const a = newAdapter();
+    await a.start();
+    const siblingSk = generateSecretKey();
+    relay.backlog.push(membersOf("hive", [siblingSk]));
+    // On the roster and registered elsewhere: a client strips the mention at send, so a roll
+    // call that addressed it reads back as silence from an agent plainly in the room.
+    relay.backlog.push(registeredIn(siblingSk, "ida", ["ops"]));
+
+    const members = await a.listMembers!({ surface: "buzz", id: "hive", isPublic: false });
+    expect(members).toMatchObject([{ name: "ida", isAgent: true, mentionable: false }]);
+    await a.stop();
+  });
+
+  it("refuses a channel the relay keeps no roster for rather than calling it empty", async () => {
+    relay = await FakeRelay.start();
+    const a = newAdapter();
+    await a.start();
+    // The channel nobody joined is the failure these reads exist to find, and an empty list
+    // is what it looks like — so a relay that keeps no roster must not answer with one.
+    relay.backlog.push(registeredIn(generateSecretKey(), "ida", ["hive"]));
+
+    await expect(
+      a.listMembers!({ surface: "buzz", id: "hive", isPublic: false }),
+    ).rejects.toThrow(/no membership record for Buzz channel hive/);
+    await a.stop();
+  });
+
+  it("bounds the roster by `limit`, which the one-event read cannot ask the relay for", async () => {
+    relay = await FakeRelay.start();
+    const a = newAdapter();
+    await a.start();
+    const first = generateSecretKey();
+    relay.backlog.push(membersOf("hive", [first, generateSecretKey()]));
+    relay.backlog.push(registeredIn(first, "ida", ["hive"]));
+
+    const members = await a.listMembers!({ surface: "buzz", id: "hive", isPublic: false }, 1);
+    expect(members.map((member) => member.id)).toEqual([getPublicKey(first)]);
     await a.stop();
   });
 
@@ -1157,6 +1223,7 @@ describe("BuzzAdapter reads the surface it is on", () => {
     // Kind 10100 is replaceable, so a relay is meant to hold one per author. A relay that
     // serves both is not an error a caller can see — it is a roster naming a channel the
     // agent has left, from a read whose whole job is to be trusted about that.
+    relay.backlog.push(membersOf("hive", [agentSk, siblingSk]));
     relay.backlog.push(registeredIn(agentSk, "ida", ["hive", "lobby"], now - 86400));
     relay.backlog.push(registeredIn(agentSk, "ida", ["hive"], now - 60));
     relay.backlog.push(registeredIn(siblingSk, "otto-was", ["ops"], now - 86400));
@@ -1167,6 +1234,8 @@ describe("BuzzAdapter reads the surface it is on", () => {
     // The older record put otto in ops, the current one in hive — and names it differently.
     const members = await a.listMembers!({ surface: "buzz", id: "hive", isPublic: false });
     expect(members.map((member) => member.name)).toEqual(["ida", "otto"]);
+    // Read off the current record too: the older one would have made otto unaddressable here.
+    expect(members.map((member) => member.mentionable)).toEqual([true, true]);
     expect(await a.describeActor!(getPublicKey(siblingSk))).toMatchObject({ name: "otto" });
     await a.stop();
   });

--- a/packages/adapter-buzz/test/buzz.test.ts
+++ b/packages/adapter-buzz/test/buzz.test.ts
@@ -1068,15 +1068,23 @@ describe("BuzzAdapter reads the surface it is on", () => {
       sk,
     );
 
-  /** The relay's roster for one channel: `d` names it, one `p` tag per member. */
-  const membersOf = (channel: string, members: Uint8Array[], at = now - 86400) =>
+  /**
+   * The relay's roster for one channel: `d` names it, one `p` tag per member. A string
+   * member is tagged verbatim, so a test can hand it what a relay got wrong.
+   */
+  const membersOf = (channel: string, members: Array<Uint8Array | string>, at = now - 86400) =>
     finalizeEvent(
       {
         kind: BUZZ_DEFAULTS.membershipKind,
         created_at: at,
         tags: [
           ["d", channel],
-          ...members.map((sk) => ["p", getPublicKey(sk), "", "member"]),
+          ...members.map((member) => [
+            "p",
+            typeof member === "string" ? member : getPublicKey(member),
+            "",
+            "member",
+          ]),
         ],
         content: "",
       },
@@ -1144,6 +1152,26 @@ describe("BuzzAdapter reads the surface it is on", () => {
     await a.stop();
   });
 
+  it("reads the newest roster at the channel's address, not whichever arrived first", async () => {
+    relay = await FakeRelay.start();
+    const a = newAdapter();
+    await a.start();
+    const leftSk = generateSecretKey();
+    const stayedSk = generateSecretKey();
+    // The membership kind is addressable, so a relay is meant to hold one roster per channel
+    // address. One that serves a superseded roster as well is not an error a caller can see
+    // — it is a channel reported to still hold whoever has left it. Pushed oldest first, so
+    // arrival order and the rule disagree and taking whichever came first is a failure here.
+    relay.backlog.push(membersOf("hive", [leftSk], now - 86400));
+    relay.backlog.push(membersOf("hive", [stayedSk], now - 60));
+    relay.backlog.push(registeredIn(stayedSk, "otto", ["hive"]));
+    relay.backlog.push(registeredIn(leftSk, "ida", ["hive"]));
+
+    const members = await a.listMembers!({ surface: "buzz", id: "hive", isPublic: false });
+    expect(members.map((member) => member.name)).toEqual(["otto"]);
+    await a.stop();
+  });
+
   it("refuses a channel the relay keeps no roster for rather than calling it empty", async () => {
     relay = await FakeRelay.start();
     const a = newAdapter();
@@ -1168,6 +1196,25 @@ describe("BuzzAdapter reads the surface it is on", () => {
 
     const members = await a.listMembers!({ surface: "buzz", id: "hive", isPublic: false }, 1);
     expect(members.map((member) => member.id)).toEqual([getPublicKey(first)]);
+    await a.stop();
+  });
+
+  it("normalizes and deduplicates the roster before `limit`, so neither costs a member", async () => {
+    relay = await FakeRelay.start();
+    const a = newAdapter();
+    await a.start();
+    const firstSk = generateSecretKey();
+    const secondSk = generateSecretKey();
+    // One member tagged twice — once in upper case — and one tag that is no pubkey at all.
+    // Both are the relay's to get wrong, and either takes a slot `limit` owes a real member.
+    relay.backlog.push(
+      membersOf("hive", [firstSk, getPublicKey(firstSk).toUpperCase(), "nobody", secondSk]),
+    );
+    relay.backlog.push(registeredIn(firstSk, "ida", ["hive"]));
+    relay.backlog.push(registeredIn(secondSk, "otto", ["hive"]));
+
+    const members = await a.listMembers!({ surface: "buzz", id: "hive", isPublic: false }, 2);
+    expect(members.map((member) => member.name)).toEqual(["ida", "otto"]);
     await a.stop();
   });
 

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -145,12 +145,20 @@ export interface SurfaceAdapter {
   listChannels?(): Promise<readonly ChannelRef[]>;
 
   /**
-   * Who is in one channel this adapter serves, in no promised order.
+   * Who is in one channel this adapter serves, as the surface reports membership, in no
+   * promised order.
+   *
+   * The surface's roster and never an actor's own claim about itself — Slack reads
+   * `conversations.members`, Buzz the relay's channel-membership event. An identity that
+   * published a record naming the channel but was never granted membership is not in it,
+   * and a read that said otherwise would confirm membership on the agent's own say-so:
+   * exactly the case {@link listChannels} exists to catch.
    *
    * Bounded like {@link readThread}: `limit` is a ceiling on how many come back, and a
    * surface that cannot answer omits the method. The refs carry a `name` wherever the
    * surface can put one to the id — a roster of bare ids does not answer the question
-   * anyone asks a membership read.
+   * anyone asks a membership read — and {@link ActorRef.mentionable} wherever the surface
+   * can also say whether a mention there would reach them.
    */
   listMembers?(channel: ChannelRef, limit?: number): Promise<readonly ActorRef[]>;
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -39,6 +39,19 @@ export interface ActorRef {
    * bare ids answers nobody's question about who is in a channel.
    */
   name?: string;
+  /**
+   * A mention of this id, posted in the channel this ref was read from, would reach it.
+   *
+   * Channel-scoped, so only `SurfaceAdapter.listMembers` sets it, and only for an id the
+   * surface holds something that answers it about. Absent is "not answered here" and never
+   * "no" — `SurfaceAdapter.readThread`'s rule.
+   *
+   * `false` is the finding worth having, and Buzz is where it happens: an agent can be on a
+   * channel's roster and have no directory record naming that channel, and a client strips
+   * its mention at send. A roll call that addressed it reads back as silence from an agent
+   * that is plainly in the room.
+   */
+  mentionable?: boolean;
 }
 
 export interface InboundEvent {

--- a/packages/core/src/job-channel.ts
+++ b/packages/core/src/job-channel.ts
@@ -275,9 +275,11 @@ function tools(report: NonNullable<JobConfig["report"]>): unknown[] {
       description:
         `Read who is in ${where}, this job's own report channel — the only channel this ` +
         "tool reads, so it takes no destination. Answers `{members}`, each " +
-        "`{surface, id, isSelf, isAgent, name?}`. Use it to tell an agent that answered " +
-        "slowly from one that was never in the channel to be asked: an empty `members` " +
-        "means the channel is empty, and a surface that cannot say so is refused instead.",
+        "`{surface, id, isSelf, isAgent, name?, mentionable?}`. Use it to tell an agent " +
+        "that answered slowly from one that was never in the channel to be asked, and " +
+        "`mentionable: false` to tell both from a third: in the channel, and would not have " +
+        "been woken by the mention that addressed it. An empty `members` means the channel " +
+        "is empty, and a surface that cannot say so is refused instead.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/core/src/job-channel.ts
+++ b/packages/core/src/job-channel.ts
@@ -278,8 +278,10 @@ function tools(report: NonNullable<JobConfig["report"]>): unknown[] {
         "`{surface, id, isSelf, isAgent, name?, mentionable?}`. Use it to tell an agent " +
         "that answered slowly from one that was never in the channel to be asked, and " +
         "`mentionable: false` to tell both from a third: in the channel, and would not have " +
-        "been woken by the mention that addressed it. An empty `members` means the channel " +
-        "is empty, and a surface that cannot say so is refused instead.",
+        "been woken by the mention that addressed it. `mentionable` absent is that question " +
+        "left unanswered for that member and never a no, so test it against `false` rather " +
+        "than for falsiness. An empty `members` means the channel is empty, and a surface " +
+        "that cannot say so is refused instead.",
       inputSchema: {
         type: "object",
         properties: {

--- a/packages/core/src/surface-read.ts
+++ b/packages/core/src/surface-read.ts
@@ -163,10 +163,14 @@ function tools(egress: SurfaceEgress): ToolDecl[] {
     {
       name: LIST_MEMBERS,
       description:
-        "List who is in one of this agent's configured channels. Answers `{members}`, each " +
-        "`{surface, id, isSelf, isAgent, name?}` — `name` only where the surface could put " +
-        `one to the id. At most ${MAX_MEMBERS}. An empty list means the channel is empty; a ` +
-        "surface that cannot answer refuses instead, so the two never look alike.",
+        "List who is in one of this agent's configured channels, as the surface itself " +
+        "reports membership. Answers `{members}`, each " +
+        "`{surface, id, isSelf, isAgent, name?, mentionable?}` — `name` only where the " +
+        "surface could put one to the id, and `mentionable` only where it can say whether " +
+        "a mention of that id in this channel would reach them, so `mentionable: false` is " +
+        "somebody who is in the channel and would not be woken by being addressed there. " +
+        `At most ${MAX_MEMBERS}. An empty list means the channel is empty; a surface that ` +
+        "cannot answer refuses instead, so the two never look alike.",
       inputSchema: {
         type: "object",
         properties: {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0694b-d13f-7bbb-a0fa-05a298da5d52">Session</a>
<!-- /sageox:pr-header -->

Closes #35.

`BuzzAdapter.listMembers` answered a different question from `SlackAdapter.listMembers`,
and its doc justified that with a premise that is not true.

| | Read | Answered |
|---|---|---|
| `SlackAdapter.listMembers` | `conversations.members` | who is in the channel |
| `BuzzAdapter.listMembers` (before) | kind-10100 directory records filtered on `channel_ids` | who published a record claiming the channel |
| `BuzzAdapter.listMembers` (after) | the relay's kind-39002 membership event | who is in the channel |

A directory record is its author's claim about itself. An identity that was never granted
membership, but published a record naming the channel, came back as present — so a caller
acting on that read tells a human "membership confirmed" on evidence that establishes
nothing, in exactly the case the read was added to diagnose.

## What `listMembers` reads now

The newest event at the channel's `d` address, one member per `p` tag, then a single REQ
over the directory and NIP-01 profile kinds — the two `describeActor` already reads for one
id — to put names to the pubkeys and say which of them are agents. `limit` bounds the
members rather than the wire, because the roster is one event: a relay-side limit would
trim how many rosters came back and not how many people are named in the one that did.

**A channel the relay keeps no membership record for is refused, not answered `[]`.** An
empty roster is the channel nobody joined, which is the finding these reads exist to make,
so it must not also be what a relay that keeps no rosters looks like. That is the same
empty-vs-cannot-answer rule the rest of the seam already holds to.

`SurfaceAdapter.listMembers`' doc now states the contract both adapters keep: the surface's
own roster, never an actor's claim about itself.

## "Who would a post here have woken" keeps its own name

`ActorRef` gains `mentionable?: boolean`, set only by `listMembers` and only for an id the
surface holds something that answers it about. On Buzz that is a directory record whose
`channel_ids` cover the channel being read.

`false` is the finding worth having: a member who is in the room and whose mention a client
strips at send — the silence a roll call would otherwise grade as a dead agent. It surfaces
in `list_members`, in the job channel's `channel_members`, and in the roll-call example in
`docs/job-contract.md`.

**Absent is "not answered here" and never "no."** A person on the roster publishes no
directory record, and nothing in this repository establishes that a person without one is
unmentionable — so their `mentionable` is left unset rather than asserted `false`. Slack
sets it nowhere, for the same reason it omits a read it cannot make.

## The false premise

> *"That is the membership Buzz has: there is no join…"*

Buzz has one. The membership event above is on the wire, and the `buzz` CLI carries `join`,
`leave`, `members`, `add-member`, `remove-member`. The sentence is gone from `buzz.ts`, from
`docs/guide/chat-surfaces.md`, and from the CHANGELOG entry — each replaced with the true
reason where one was needed, rather than deleted and left dangling.

`listChannels` is untouched. Its doc makes no false claim, and changing what it reads is a
separate change.

## Verification

`pnpm test` (65 files, 1180 tests) and `pnpm typecheck` are green.

Four Buzz tests replace the two that asserted the old behaviour, and each fails without this
change: a claimant that published a record naming `hive` and is not on the roster is absent;
a member registered elsewhere reads `mentionable: false`; a person on the roster reads
`mentionable: undefined`; a channel the relay keeps no roster for is refused. The
replaceable-record test now also checks `mentionable` is read off the current record and not
a superseded one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a0694b-d13f-7bbb-a0fa-05a298da5d52

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791066919&installation_model_id=433550&pr_number=36&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F36&signature=d07347916d674d43a24c7002f4fbdaa3aa20c6c6595af6bf24f449556afab9cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel member listings now reflect the surface’s authoritative roster.
  * Member results include channel-specific `mentionable` status and agent/person metadata.
  * Channel visibility now requires both configured subscription and directory addressability.
  * Membership listings support result limits and deduplicated results.

* **Bug Fixes**
  * Current membership data is selected from the latest available roster.
  * Missing membership rosters are reported instead of producing inferred results.

* **Documentation**
  * Updated channel, membership, and job-contract documentation to explain roster-based membership and mentionability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->