### PR TITLE
Cut the CHANGELOG section for 0.3.0 and move the chart to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-03
+
+Everything below shipped after `v0.2.0`.
+
+Published as `ghcr.io/sageox/agent-base:0.3.0`, which takes `:latest` and `:0.3`. `:0.2`
+stays on 0.2.0, and `:0` is not published at all — before 1.0.0 a minor bump may break
+you. Pin the digest recorded on the GitHub Release in production; the tags are for
+humans.
+
+Still pre-1.0: configuration format and CLI flags may move between minor versions. Three
+things a deployment already running 0.2.0 has to act on.
+
+**A long job started from chat now answers the thread it was asked in**, and its `report`
+channel post is then made or spared on the same terms a waited-for run has always been on
+— so under the default announce mode a clean verdict no longer posts there at all. A
+channel read as the record of every detached run is now a channel that has stopped hearing
+about the successful ones; the run records still hold them.
+
+**On Buzz, a channel event now waits for the directory subscription** (kind 10100) to
+answer on the same socket, which is what lets `limits.maxAgentChainDepth` recognise a
+sibling. Bounded at thirty seconds on a relay that sends no EOSE, and skipped entirely on
+one that refuses the kind — where the cap goes on not firing, as it did before.
+
+**A `token:` that names a non-default secretRef and resolves to nothing now leaves the
+`ox` child with no credential**, rather than letting it inherit whatever `SAGEOX_TOKEN` the
+gateway process happens to hold — which on a host running several agents is another
+agent's. Such an agent loses team memory and says so, where before it answered as somebody
+else. The default ref is unaffected: it resolves from that same variable.
+
+Two things want the new image before they are worth configuring: `surface-read` is not a
+server an older binary can be asked to add, and `mention` on `post_message` is dropped by
+one as an undeclared argument, leaving a post that wakes nobody.
+
+**The Helm chart moves to 0.11.0**, for the one entry here that is templates rather than
+code: `persistence.jobCheckouts` mounts an agent's repository checkouts into its CronJob
+Pods. It renders on 0.2.0's image, and it is the only entry that does not need the new one.
+`values.yaml` is unchanged, so there is nothing new to set unless you want it; the
+dependency pin in the chart's README moves with the version.
+
 ### Added
 
 - **An agent can read the surface it is already on.** `SurfaceAdapter` could post, react

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Run one or more SageOx Agent Toolkit identities on Kubernetes
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: "0.0.0"
 home: https://github.com/sageox/agent-toolkit
 sources:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -51,7 +51,7 @@ Or depend on it, and nest this chart's values under its name. Helm hands every s
 # Chart.yaml
 dependencies:
   - name: agent
-    version: 0.10.0
+    version: 0.11.0
     repository: "file://../agent-toolkit/deploy/helm"
 ```
 


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a069f7-1441-7e7b-a2e6-433a60c6c0c0">Session</a>
<!-- /sageox:pr-header -->

## Summary

Step 1 of the release process in [`CONTRIBUTING.md`](CONTRIBUTING.md): renames
`## [Unreleased]` to `## [0.3.0] - 2026-09-03`, opens a fresh one above it, and moves the
Helm chart to 0.11.0. `release.yml` refuses to publish `v0.3.0` until a heading by that
name exists, and summarizes the section beneath it into the GitHub Release notes.

**A minor and not a patch.** Four of the eleven entries add something an operator sets or a
brain or body calls: the `surface-read` server and its four tools, `mention` on
`post_message`, `channel_members` on the job channel, and `persistence.jobCheckouts` on the
chart. The rest are behavior a patch has no business carrying — a relayed answer coming
home, a detached job answering its asking thread, the team token re-read per `ox` child,
and the Buzz directory gate. Nothing moves the manifest format, so it is not a 1.0 question.

**The chart moves for the one entry that is templates rather than code.**
`persistence.jobCheckouts` mounts an agent's `workspace/repos` into its CronJob Pods
read-only, behind the required node affinity a `ReadWriteOnce` claim charges for. Minor
there too — additive, off by default, and `values.yaml` is unchanged, so there is nothing
new to set unless you want it. It renders on 0.2.0's image, and it is the only entry here
that does not need the new one; the dependency pin in the chart's README moves with the
version.

**Three things a deployment already running 0.2.0 has to act on lead the section**, because
an upgrade reads that first:

- A detached job started from chat now answers its asking thread, so its `report` post is
  made or spared on the same terms a waited-for run is — under the default announce mode a
  clean verdict stops posting there (`announces()`, `packages/core/src/job-host.ts:1271`,
  called with `detached && !answered`).
- A Buzz channel event now waits on the kind-10100 directory subscription, bounded at
  thirty seconds on a relay that sends no EOSE and skipped on one that refuses the kind.
- A `token:` naming a non-default secretRef that resolves to nothing now leaves the `ox`
  child with no credential rather than inheriting the gateway's ambient `SAGEOX_TOKEN`
  (`oxEnv`, `packages/core/src/team-server.ts:275`). Checked rather than assumed: the
  default ref is unaffected, because `resolveSecret` falls back to that same variable
  (`packages/core/src/secrets.ts:48`).

The "wants the new image" claim was checked the same way: `surface-read` is a server name an
older binary does not know, and `mention` reaches `PostArgs` as an undeclared argument on a
plain `z.object`, so an older binary drops it and the post wakes nobody.

`appVersion` stays the inert `"0.0.0"` placeholder — nothing reads it, and deployments pin
`imageRef` by digest.

## Test Plan

```
pnpm test                                                                             # 65 files, 1182 passed
pnpm typecheck                                                                        # clean
helm lint --strict deploy/helm --values deploy/helm/examples/two-agents.values.yaml   # 0 failed
deploy/helm/tests/{jobs,consume,bundle,networkpolicy}.sh                              # 4x ok
```

The generated release notes were rendered locally by running `release.yml`'s own awk against
the new file with `VERSION=0.3.0`: eleven lead sentences under Added / Changed / Fixed, and
the preamble correctly excluded, which is what #21 established.

No behavior changes to test — the diff is a CHANGELOG heading, a chart version, and the
README pin that tracks it. The chart suite is what proves the bump did not disturb what the
templates render.

## Note for the reviewer

#21 shipped in this release and changed the notes to lead sentences only, so the three
act-on items above appear in `CHANGELOG.md` and **not** on the GitHub Release page. That is
what #21 intended ("the section itself is the reasoning... it stays in CHANGELOG.md,
linked under the summary"), but 0.3.0 is the first release to land under the new format
with upgrade warnings to carry. Say the word and I will promote them into their own bullets
instead.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Tests added, or N/A documented — N/A, no code changes; existing chart suite re-run
- [x] `pnpm typecheck && pnpm test` green
- [x] Deployment checks run if `deploy/` changed
- [x] CHANGELOG entry added if user-facing — this PR is the CHANGELOG cut
- [x] Breaking change documented — none; the three behavior changes lead the section
- [x] Docs updated if behavior or configuration changed — chart README pin

</details>

SageOx-Session: https://sageox.ai/c/ses_01a069f7-1441-7e7b-a2e6-433a60c6c0c0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791076317&installation_model_id=433550&pr_number=37&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F37&signature=1f125d24e1b6f9167cb89c5817fc8aebda860ab4bf21f22dc727be2a84d914a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 0.3.0, including upgrade considerations, compatibility requirements, release image tags, and behavior updates.
  - Documented improved handling for thread-directed job responses, token references, and agent-chain limits.
  - Updated Helm chart documentation to version 0.11.0.
- **Deployment**
  - Released Helm chart version 0.11.0, including support for optional repository checkout mounts for CronJobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->