### PR TITLE
Let a passing gate speak in its own words, since a pass has nothing left to oversell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A passing gate's own sentence can render as written.** The host puts `PROVEN:` in front
+  of every line a passing gate produces, which is right while the sentence after it is the
+  host's own machine phrasing and wrong for a job whose gates are a shift report — a body
+  that wrote *the bench is full, so I tended #3961 instead* composed something for a person
+  to read, and the machine word in front of it is the one thing making it read as
+  machinery. Declare `report.proven: verbatim` and that sentence posts as written.
+  It reaches PASS alone, and only the lines a body wrote: a passing gate that said nothing
+  still reads `PROVEN: …`, because the sentence there is the host's; FAIL and UNKNOWN keep
+  their label under every value, since that label is the whole of what stops a body's
+  reassuring prose from reading as a success. Nothing about how a verdict is derived or
+  recorded moves, and the headline stays host-phrased — a combined verdict carries none of
+  the body's words for `verbatim` to render. The default, `labelled`, is what every job
+  posts today, so a job that declares nothing reads exactly as it did.
+
 ## [0.3.0] - 2026-09-03
 
 Everything below shipped after `v0.2.0`.

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -208,6 +208,27 @@ and it lowers no floor: a body that wrote no gates is UNKNOWN and is announced.
 No mode announces a job the switch or a suspension refused: that silence is about a posture
 somebody chose, and the run these modes weigh never happened.
 
+`PROVEN:` in front of that sentence is right while the sentence after it is the host's, and
+wrong for the job whose gates *are* the report — a body that wrote *the bench is full, so I
+tended #3961 instead* composed something for a person to read, and the machine word in front
+of it is what makes a human update read like machinery. Declare `proven: verbatim` and it
+posts as written:
+
+```yaml
+report:
+  surface: buzz
+  channel: "…"
+  proven: verbatim     # default: labelled
+```
+
+It is presentation and it reaches PASS alone. A passing gate that wrote no `detail` still
+reads `PROVEN: …`, because the sentence there is the host's machine phrasing rather than
+anybody's prose. **FAIL and UNKNOWN keep their label under both values** — that label is the
+whole of what stops a body's *everything looks clean* on a gate that exited 1 from reading
+as a success, and no setting takes it away. The verdict is still minted here from what the
+body ran, and the headline is still host-phrased: a combined verdict carries none of the
+body's words, so there is nothing there for `verbatim` to render.
+
 ## A job that probes
 
 Everything above describes a job that **observes**: it reads something, writes the gates it

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1724,7 +1724,7 @@ async function jobCmd(argv: string[]): Promise<void> {
   // Headline, then the gates beneath it — the shape a job's status post takes, and the
   // reason it takes it: the verdict is what gets read, and the gates are why it says that.
   // The same rendering the chat tool returns, so one run reads one way wherever it lands.
-  process.stdout.write(describeJobRun(run));
+  process.stdout.write(describeJobRun(run, job.report?.proven));
   const denied = run.outcome === "denied-switch" || run.outcome === "denied-suspend";
   if (denied && trigger === "on-request") {
     process.stdout.write("  a run started from this CLI is `system`, and does not bypass\n");

--- a/packages/core/src/job-host.ts
+++ b/packages/core/src/job-host.ts
@@ -25,6 +25,7 @@ import {
   describeVerdict,
   isProven,
   verdictFromGate,
+  type ProvenVoice,
   type Verdict,
 } from "./verdict.ts";
 
@@ -701,7 +702,7 @@ export class JobHost {
     const report = job.report;
     const post = this.opts.post;
     if (!report || !post || !announces(run, detached, report.announce)) return;
-    const { headline, detail } = jobStatus(run);
+    const { headline, detail } = jobStatus(run, report.proven);
 
     // Every line is attempted on its own. One rejection is as likely to be about one
     // message — too long, rate-limited, refused by the guard — as about the channel, and a
@@ -1199,7 +1200,10 @@ export class JobHost {
  * {@link describeJobRun}. The verdict line is `describeVerdict`'s, so an unrun gate cannot
  * be phrased as a passing one here either.
  */
-export function jobStatus(run: JobRun): { headline: string; detail: readonly string[] } {
+export function jobStatus(
+  run: JobRun,
+  proven?: ProvenVoice,
+): { headline: string; detail: readonly string[] } {
   // With one gate the combined verdict already *is* that gate, said once — and a count is
   // only information when there is something for it to be a count of.
   const threaded = run.gates.length > 1;
@@ -1210,7 +1214,7 @@ export function jobStatus(run: JobRun): { headline: string; detail: readonly str
     headline:
       `job ${run.jobSlug} ${run.outcome} in ${run.endedAt - run.startedAt}ms — ` +
       `${run.reason}. ${describeVerdict(run.verdict)}${tally}`,
-    detail: threaded ? run.gates.map(describeVerdict) : [],
+    detail: threaded ? run.gates.map((gate) => describeVerdict(gate, proven)) : [],
   };
 }
 
@@ -1222,8 +1226,8 @@ export function jobStatus(run: JobRun): { headline: string; detail: readonly str
  * another in a channel is two reports of one run, and the one somebody acts on is whichever
  * they saw.
  */
-export function describeJobRun(run: JobRun): string {
-  const { headline, detail } = jobStatus(run);
+export function describeJobRun(run: JobRun, proven?: ProvenVoice): string {
+  const { headline, detail } = jobStatus(run, proven);
   const lines = [headline, ...detail.map((line) => `  ${line}`)];
   // Only ever true for a run a human asked for, so it reaches the person who asked. It is
   // deliberately not in the headline: the channel is told about runs, not about postures.

--- a/packages/core/src/job-server.ts
+++ b/packages/core/src/job-server.ts
@@ -326,7 +326,8 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
         // forgotten which message it was answering. The verdict goes back as the same text
         // a waited-for call returns, so the two shapes read alike where they arrive.
         const home = answering?.() ?? null;
-        const answer = home && reply ? (run: JobRun) => reply(home, describeRun(run)) : undefined;
+        const answer =
+          home && reply ? (run: JobRun) => reply(home, describeRun(run, job)) : undefined;
         const start = await host.startRequest(
           job,
           requester(agentName, answering, owner),
@@ -334,19 +335,22 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
           answer,
         );
         return start.refused
-          ? describeRun(start.refused)
+          ? describeRun(start.refused, job)
           : describeStart(job, start, answer !== undefined);
       }
-      return describeRun(await host.request(job, requester(agentName, answering, owner), params));
+      return describeRun(
+        await host.request(job, requester(agentName, answering, owner), params),
+        job,
+      );
     },
   });
 }
 
 /** A finished run, plus the one thing about a refusal the brain can do something with. */
-function describeRun(run: JobRun): string {
+function describeRun(run: JobRun, job: JobConfig): string {
   const parked = run.outcome === "denied-switch" || run.outcome === "denied-suspend";
   return (
-    describeJobRun(run) +
+    describeJobRun(run, job.report?.proven) +
     // Named here rather than left to the reason line, because the brain is about to
     // explain the refusal to whoever asked, and which side of the bypass this run fell on
     // is the part of it they can act on.

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -861,6 +861,20 @@ const JobSchema = z
          */
         announce: z.enum(["unproven", "always", "reported"]).default("unproven"),
         /**
+         * How a *passing* gate's line reads. `ProvenVoice` in `verdict.ts` has the rule.
+         *
+         * `labelled`, the default, is the shape every job has had: `PROVEN:` in front of
+         * every passing line. It is right while the sentence after it is the host's, and
+         * wrong for the job whose gates are a shift report — a body that wrote *the bench is
+         * full, so I tended what's already open* composed something for a person to read,
+         * and the machine word in front of it is what makes it read as machinery.
+         *
+         * `verbatim` buys no pass and hides no failure: it reaches PASS alone, the verdict
+         * is still minted from what the body ran, and the headline stays host-phrased —
+         * a combined verdict carries none of the body's words.
+         */
+        proven: z.enum(["labelled", "verbatim"]).default("labelled"),
+        /**
          * Whether this job's body may talk through this channel while it runs, rather than
          * only being reported into it when it is over.
          *

--- a/packages/core/src/verdict.ts
+++ b/packages/core/src/verdict.ts
@@ -104,6 +104,21 @@ export function combineVerdicts(verdicts: readonly Verdict[]): Verdict {
 }
 
 /**
+ * How a passing line is rendered — the only presentation choice a job gets, and it reaches
+ * PASS alone.
+ *
+ * `labelled` is the default and the shape every job has had: `PROVEN:` in front of the
+ * sentence. `verbatim` drops that word for the sentences a *body* wrote — a passing gate
+ * carrying a `detail` renders as that detail and nothing else — so a job whose gates are a
+ * shift report reads as one. A passing gate with no `detail` is unmoved by it: the sentence
+ * there is the host's machine phrasing, and unlabelled machine phrasing is not prose.
+ *
+ * FAIL and UNKNOWN are unmoved by either value. Their label is the whole of what stops a
+ * body's reassuring sentence from reading as a pass, and no setting may take it away.
+ */
+export type ProvenVoice = "labelled" | "verbatim";
+
+/**
  * UNKNOWN and FAIL must not contain a word a skimming reader could mistake for
  * success. `verdict.test.ts` asserts it.
  *
@@ -111,12 +126,17 @@ export function combineVerdicts(verdicts: readonly Verdict[]): Verdict {
  * status word in front of it is still this module's, so a body that writes "all clear"
  * on a gate that exited 1 gets "FAILED: all clear" rather than a line that reads as a
  * pass. `combineVerdicts` never copies a detail forward, so the run's own verdict — the
- * one `jobStatus` puts in the headline — stays entirely host-phrased.
+ * one `jobStatus` puts in the headline — stays entirely host-phrased, under either
+ * {@link ProvenVoice}: there is no detail on a combined verdict for `verbatim` to render.
  */
-export function describeVerdict(v: Verdict): string {
+export function describeVerdict(v: Verdict, proven: ProvenVoice = "labelled"): string {
   switch (v.status) {
-    case "PASS":
-      return `PROVEN: ${v.detail ?? `${v.gate} passed (${v.reason}).`}`;
+    case "PASS": {
+      // Tested against `v.detail` rather than against `said`: the label comes off the
+      // body's own sentence, never off the fallback composed on the line above.
+      const said = v.detail ?? `${v.gate} passed (${v.reason}).`;
+      return proven === "verbatim" && v.detail ? said : `PROVEN: ${said}`;
+    }
     case "FAIL":
       return `FAILED: ${v.detail ?? `${v.gate} did not pass (${v.reason}).`}`;
     case "UNKNOWN": {

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -15,7 +15,7 @@ import {
 import type { EventRef } from "../src/events.ts";
 import type { SwitchLookup, SwitchSource } from "../src/kill-switch.ts";
 import { loadManifest, type JobAnnounce, type JobConfig } from "../src/manifest.ts";
-import { combineVerdicts, describeVerdict } from "../src/verdict.ts";
+import { combineVerdicts, describeVerdict, type ProvenVoice } from "../src/verdict.ts";
 
 const base =
   "name: x\nbrain: {provider: mock}\nsurfaces: [{kind: console}]\nrespondTo: anyone\n" +
@@ -609,6 +609,7 @@ describe("the status post", () => {
   const feed = (
     id: (n: number) => EventRef | undefined = named,
     announce: JobAnnounce = "unproven",
+    proven: ProvenVoice = "labelled",
   ) => {
     const posts: Array<{ text: string; threadRoot?: EventRef; mentions?: readonly string[] }> = [];
     const post: JobPoster = async (report, text, threadRoot, mentions) => {
@@ -619,7 +620,13 @@ describe("the status post", () => {
       posts.push({ text, threadRoot, mentions });
       // Whole-object, so a field added to the destination has to be accounted for here
       // rather than reaching every poster unnoticed.
-      expect(report).toEqual({ surface: "console", channel: "hive", announce, probe: false });
+      expect(report).toEqual({
+        surface: "console",
+        channel: "hive",
+        announce,
+        proven,
+        probe: false,
+      });
       return id(posts.length);
     };
     return { posts, post };
@@ -653,7 +660,9 @@ describe("the status post", () => {
       { surface: "c", nativeId: "e1" },
       { surface: "c", nativeId: "e1" },
     ]);
-    expect(posts.slice(1).map((p) => p.text)).toEqual(run.gates.map(describeVerdict));
+    expect(posts.slice(1).map((p) => p.text)).toEqual(
+      run.gates.map((gate) => describeVerdict(gate)),
+    );
   });
 
   it("threads the body's own sentence, and keeps the headline the host's", async () => {
@@ -756,6 +765,52 @@ describe("the status post", () => {
     ]);
     // The body chose to speak; it did not choose what it is called.
     expect(posts[0].text).not.toContain(said);
+  });
+
+  it("drops the PROVEN label from a passing body's sentence when the job asks it to", async () => {
+    // The job this exists for: a scheduled shift report, whose gates are prose written for
+    // the people in the channel. `PROVEN:` in front of that sentence is the one thing
+    // making a human update read like machinery.
+    const said = "The bench is full, so I tended [#3961](https://example.test/p/3961) instead.";
+    const { posts, post } = feed(named, "reported", "verbatim");
+    const run = await host(undefined, post).tick(
+      body(
+        `${MARK}${WRITE}JSON.stringify({gates:[{gate:"shift",executed:true,exitCode:0,` +
+          `detail:${JSON.stringify(said)}}]}))`,
+        { report: "{surface: console, channel: hive, announce: reported, proven: verbatim}" },
+      ),
+    );
+
+    expect(run.verdict.status).toBe("PASS");
+    expect(posts.slice(1).map((p) => p.text)).toEqual([
+      // The host's own gate said nothing, so there is no body sentence to render and the
+      // label stays: unlabelled machine phrasing is not prose.
+      "PROVEN: job:sweep passed (gate job:sweep exited 0).",
+      said,
+    ]);
+    // Presentation only. The verdict is unmoved, and the headline is still minted from the
+    // combined verdict — which carries no body's words for `verbatim` to render.
+    expect(posts[0].text).toContain("PROVEN: combined passed");
+    expect(posts[0].text).not.toContain(said);
+  });
+
+  it("keeps the label on a failing gate however the job asks it to render a pass", async () => {
+    // The floor: `verbatim` is over PASS alone. A body that writes a reassuring sentence on
+    // a gate that exited 1 must not be able to buy a line that reads as a success.
+    const { posts, post } = feed(named, "unproven", "verbatim");
+    await host(undefined, post).tick(
+      body(
+        `${MARK}${WRITE}JSON.stringify({gates:[{gate:"shift",executed:true,exitCode:1,` +
+          `detail:"all clear, nothing to do"},{gate:"idle",executed:false,exitCode:null}]}))`,
+        { report: "{surface: console, channel: hive, proven: verbatim}" },
+      ),
+    );
+
+    expect(posts.slice(1).map((p) => p.text)).toEqual([
+      "PROVEN: job:sweep passed (gate job:sweep exited 0).",
+      "FAILED: all clear, nothing to do",
+      "NOT PROVEN: gate idle did not execute. No verdict — treat as unsafe until a gate runs.",
+    ]);
   });
 
   it("says nothing under reported for a proven run whose gates carry no sentence", async () => {

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -919,7 +919,13 @@ describe("jobs", () => {
     ).toThrow(/report.surface/);
     expect(
       loadManifest(withJob({ report: "{surface: console, channel: hive}" })).jobs[0].report,
-    ).toEqual({ surface: "console", channel: "hive", announce: "unproven", probe: false });
+    ).toEqual({
+      surface: "console",
+      channel: "hive",
+      announce: "unproven",
+      proven: "labelled",
+      probe: false,
+    });
   });
 
   it("gates the status post on the verdict unless the job says otherwise", () => {
@@ -938,6 +944,20 @@ describe("jobs", () => {
     // altogether would throw `Unrecognized key: "announce"` and satisfy a looser match.
     expect(() =>
       loadManifest(withJob({ report: "{surface: console, channel: hive, announce: sometimes}" })),
+    ).toThrow(/expected one of/);
+  });
+
+  it("labels a proven line unless the job asks for the body's own sentence", () => {
+    // The default is the rendering every job had before the field existed. Presentation
+    // only, and over PASS alone — `verdict.test.ts` holds the half that matters.
+    const declared = (report: string) => loadManifest(withJob({ report })).jobs[0].report?.proven;
+    expect(declared("{surface: console, channel: hive}")).toBe("labelled");
+    expect(declared("{surface: console, channel: hive, proven: verbatim}")).toBe("verbatim");
+
+    // A word nobody implements is refused rather than read as `verbatim`: a job asking for
+    // prose and silently getting the label back is the failure this field exists to end.
+    expect(() =>
+      loadManifest(withJob({ report: "{surface: console, channel: hive, proven: human}" })),
     ).toThrow(/expected one of/);
   });
 

--- a/packages/core/test/verdict.test.ts
+++ b/packages/core/test/verdict.test.ts
@@ -113,6 +113,36 @@ describe("a gate's own detail", () => {
   });
 });
 
+// `report.proven: verbatim` — presentation, and only over PASS. These assertions are the
+// contract: a rewording that lets `verbatim` reach FAIL or UNKNOWN must fail here.
+describe("a proven line rendered verbatim", () => {
+  const said = (gate: string, exitCode: number | null, detail: string) =>
+    verdictFromGate({ gate, executed: true, exitCode, detail });
+  const shift = "The bench is full, so I tended [#3961](https://example.test/p/3961) instead.";
+
+  it("renders a passing body's own sentence as written", () => {
+    expect(describeVerdict(said("shift", 0, shift), "verbatim")).toBe(shift);
+  });
+
+  it("still labels a passing gate that said nothing — that sentence is the host's", () => {
+    expect(describeVerdict(pass("ci"), "verbatim")).toBe("PROVEN: ci passed (gate ci exited 0).");
+  });
+
+  it("cannot take the label off a FAIL or an UNKNOWN", () => {
+    expect(describeVerdict(said("ci", 1, "everything looks clean"), "verbatim")).toBe(
+      "FAILED: everything looks clean",
+    );
+    expect(describeVerdict(said("ci", null, "everything looks clean"), "verbatim")).toBe(
+      "NOT PROVEN: everything looks clean. No verdict — treat as unsafe until a gate runs.",
+    );
+  });
+
+  it("changes nothing when it is not asked for", () => {
+    expect(describeVerdict(said("shift", 0, shift))).toBe(`PROVEN: ${shift}`);
+    expect(describeVerdict(said("shift", 0, shift), "labelled")).toBe(`PROVEN: ${shift}`);
+  });
+});
+
 // The `@ts-expect-error` cases are checked by `pnpm typecheck`, which fails if any of
 // them stops erroring — that is the regression worth catching.
 describe("a verdict cannot be forged", () => {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06d48-6538-756e-98ad-dc8639ce89e8">Session</a>
<!-- /sageox:pr-header -->

Closes #39.

## What was needed

The host prefixes every passing gate's line with `PROVEN:`. That is right while the sentence after it is the host's own machine phrasing, and wrong for a job whose gates are a shift report — a body that wrote *the bench is full, so I tended [#3961] instead* composed something for a person to read, and the machine word in front of it is the one thing making a human update read like machinery:

> PROVEN: WIP freeze: 3 open >= cap 3 — answered 1 review thread while draining…

There was no way to ask for that sentence as written.

## What this ships

One manifest field on the report destination:

```yaml
report:
  surface: buzz
  channel: hive
  proven: verbatim     # default: labelled
```

`verbatim` renders a **passing, body-authored** detail as written. `labelled` is the default and is exactly what every job posts today.

## Why the knob can exist at all

`PROVEN:` is there to stop a body's words being read as a stronger verdict than the host minted. PASS is the strongest verdict, so there is nothing left to oversell. That one rule is what makes the setting safe over PASS and impossible over the other two:

- **FAIL and UNKNOWN keep their label under both values.** That label is the whole of what stops `everything looks clean` on a gate that exited 1 from reading as a success.
- **A passing gate that wrote no `detail` still reads `PROVEN: …`** — the sentence there is the host's, and unlabelled machine phrasing is not prose.
- **The machine word is never removable.** `seal` is the sole construction of a run's verdict and always goes through `combineVerdicts`, which copies no `detail` forward — so the headline renders a host-minted status word under every setting, and no consumer loses the machine verdict.
- Nothing about how a verdict is derived or recorded moves. This is presentation.

An unimplemented word is refused at load rather than read as a default: a job asking for prose and silently getting the label back is the failure this field exists to end.

## Where it applies

All three rendering doors pass it — the channel post, the chat tool, and `job run` on the CLI — so a run still reads one way wherever it lands, which is the rule `describeJobRun` already stated.

## How it was verified

`pnpm test` — 1189 passed, 65 files. `pnpm typecheck` — clean.

New tests that fail without the change:

| Test | Holds |
|---|---|
| `verdict.test.ts` | The rendering rule, including that `verbatim` cannot take the label off a FAIL or an UNKNOWN |
| `job-host.test.ts` | A real job body end-to-end through a `proven: verbatim` manifest, asserting the headline stays host-phrased; and that a failing gate keeps its label however the job asks a pass to render |
| `manifest.test.ts` | The default, and that an unimplemented word is refused |

`typecheck` also caught a real hazard the new parameter introduces — `gates.map(describeVerdict)` would pass the array index where the setting goes. One existing test did that and is fixed; any future point-free call is now a build error, and the misuse degrades to the labelled default regardless.

## Notes for a reviewer

- `report.proven` sits beside `announce`, in the block already documented as owning the post's shape. It governs text that also reaches the CLI and chat tool, so a job with no `report` block cannot ask for `verbatim` — that path's reader is the brain, which wants the machine word. If `report` ever becomes plural, a rendering setting inside it becomes ill-defined and the key should move up a level; that is a one-line schema move pre-1.0.
- `labelled` matches the repository's existing spelling.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a06d48-6538-756e-98ad-dc8639ce89e8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791132960&installation_model_id=433550&pr_number=40&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F40&signature=fb26f5338f37d87a1d0903577e01c07fcaa751b92bd1932048ffcf1ff9218a99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `verbatim` report mode for passing gate messages, allowing body-written sentences to appear without the `PROVEN:` prefix.
  - The default `labelled` mode remains unchanged.
  - Failed and unknown results remain labelled, and host-generated headlines are unaffected.

- **Documentation**
  - Updated the job report contract with configuration details and examples.

- **Tests**
  - Added coverage for default, labelled, and verbatim presentation behaviors, including validation of unsupported settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->