### PR TITLE
Pin what an empty gate sentence renders as, since the two emptiness tests differ on purpose

### DIFF
--- a/packages/core/src/verdict.ts
+++ b/packages/core/src/verdict.ts
@@ -133,7 +133,10 @@ export function describeVerdict(v: Verdict, proven: ProvenVoice = "labelled"): s
   switch (v.status) {
     case "PASS": {
       // Tested against `v.detail` rather than against `said`: the label comes off the
-      // body's own sentence, never off the fallback composed on the line above.
+      // body's own sentence, never off the fallback composed on the line above. Truthiness
+      // rather than `!== undefined` — `detail: ""` is admissible and reaches `said` intact,
+      // so the stricter test that would look like it matched the `??` renders a line with
+      // nothing in it.
       const said = v.detail ?? `${v.gate} passed (${v.reason}).`;
       return proven === "verbatim" && v.detail ? said : `PROVEN: ${said}`;
     }

--- a/packages/core/test/verdict.test.ts
+++ b/packages/core/test/verdict.test.ts
@@ -137,6 +137,15 @@ describe("a proven line rendered verbatim", () => {
     );
   });
 
+  it("keeps the label on an empty sentence, so no setting can post a blank line", () => {
+    // `GateResultSchema` bounds `detail` with `string().optional()` and no `min(1)`, so a
+    // body may write an empty one — and `??` keeps it rather than composing the fallback.
+    // Truthiness is the whole of what stands between that and a channel line with nothing
+    // in it, and it is one keystroke from a change that reads like a tidy-up.
+    expect(describeVerdict(said("shift", 0, ""), "verbatim")).toBe("PROVEN: ");
+    expect(describeVerdict(said("shift", 0, ""))).toBe("PROVEN: ");
+  });
+
   it("changes nothing when it is not asked for", () => {
     expect(describeVerdict(said("shift", 0, shift))).toBe(`PROVEN: ${shift}`);
     expect(describeVerdict(said("shift", 0, shift), "labelled")).toBe(`PROVEN: ${shift}`);


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06d48-6538-756e-98ad-dc8639ce89e8">Session</a>
<!-- /sageox:pr-header -->

Follow-up to #40, which added `report.proven`. No behaviour changes.

## What was needed

`describeVerdict`'s PASS branch tests the same field two ways, one line apart:

```ts
const said = v.detail ?? `${v.gate} passed (${v.reason}).`;          // null/undefined only
return proven === "verbatim" && v.detail ? said : `PROVEN: ${said}`; // truthiness
```

`GateResultSchema` bounds `detail` with `string().optional()` and no `min(1)`, so a body may legitimately write an empty one. The two tests disagree about that case **on purpose**: `??` keeps the empty string rather than composing the fallback, then the truthiness check rejects it and falls to the labelled branch, so it renders `PROVEN: ` — exactly what it rendered before `proven` existed.

Nothing said so, and the mismatch reads like an oversight. Aligning the second check with the first — `v.detail !== undefined` — looks like a tidy-up and posts a channel line with nothing in it.

## What this ships

The reason, beside the code, and a test that fails without it. With the "tidy-up" applied:

```
AssertionError: expected '' to be 'PROVEN: '
Tests  1 failed | 24 passed (25)
```

That empty string is the blank post, caught at the source.

## Why not just tighten the schema

`min(1)` on `detail` would refuse the entire artifact over one cosmetic slip, and a refused artifact reads as UNKNOWN — so a body that wrote an empty sentence would lose every gate it actually ran. That is a severe answer to a harmless mistake. `PROVEN: ` is the proportionate one.

`announces()` already agrees with this reading: it keys on the same truthiness (`gates.some((gate) => gate.detail)`), so an empty detail is not a sentence worth announcing either. The rendering path and the announcing path now say so consistently, and one of them is tested.

## Verified

`pnpm test` — 1190 passed, 65 files. `pnpm typecheck` — clean. Regression proven by flipping the check, watching the assertion fail, and restoring it.

No `CHANGELOG.md` entry: behaviour is unchanged, so there is nothing user-facing to report.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a06d48-6538-756e-98ad-dc8639ce89e8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791143029&installation_model_id=433550&pr_number=41&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F41&signature=5318bd156c913243895685a34267f2acea3cd78b2d3ca902c13132af25876ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved verbatim rendering for verdicts with empty detail text, producing the expected `PROVEN: ` output in both default and verbatim modes.

- **Documentation**
  - Clarified how verdict rendering handles detail text, including empty strings.

- **Tests**
  - Added regression coverage for empty-detail verdict rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->