### PR TITLE
Bound the suite for the process it spawns, since the default is calibrated for this one

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,21 @@ import { defineConfig } from "vitest/config";
 // `test/` at the root is for invariants that belong to no single package — see
 // test/naming.test.ts, which reads the whole tracked tree.
 export default defineConfig({
-  test: { include: ["packages/**/test/**/*.test.ts", "test/**/*.test.ts"] },
+  test: {
+    include: ["packages/**/test/**/*.test.ts", "test/**/*.test.ts"],
+    /**
+     * Vitest's 5s default is calibrated for work that happens in this process. The slow
+     * tests here are not that: they spawn `bin/sageox-agent` as a real child process, or
+     * wait on a real socket, so their wall time is a CI runner's load rather than anything
+     * the test does. Six tests in four files had already escaped the default one at a time
+     * — `20_000`, `10_000`, `30_000` twice over. The seventh had not, and a `job run` case
+     * that spawns the CLI four times (1.8s here) timed out on a loaded runner instead, on a
+     * diff that changed only comments.
+     *
+     * Raised once here rather than a seventh time in place, since the next test found this
+     * way is the argument against finding them this way. An explicit per-test timeout still
+     * wins, so the six that name their own wait keep saying what they are waiting for.
+     */
+    testTimeout: 15_000,
+  },
 });


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06d48-6538-756e-98ad-dc8639ce89e8">Session</a>
<!-- /sageox:pr-header -->

Fixes the CI flake that surfaced on #41, where `Test and typecheck` failed on a diff containing only comment lines and passed on rerun of the same SHA.

## What failed

`packages/cli/test/job-run.test.ts` — "refuses a target the job did not declare" — `Test timed out in 5000ms`. It spawns `bin/sageox-agent` as a child process **four times** in one test: 1.8s locally, and a loaded shared runner is free to take three times that.

## Why the config and not that test

Vitest's 5s default is calibrated for work that happens in-process. This suite's slow tests are not that — they spawn the CLI for real, or wait on a real socket, so their wall time tracks runner load rather than anything the test does.

**The repository had already escaped that default six times, in four files:**

| File | Bound |
|---|---|
| `adapter-buzz/test/profile.test.ts` | `20_000` |
| `adapter-buzz/test/buzz.test.ts` | `10_000` |
| `cli/test/agent-cwd.test.ts` (×2) | `30_000` |
| `cli/test/run-directory.test.ts` (×2) | `30_000` |

Six escapes is not six coincidences; it is the default being wrong for this suite, discovered one timeout at a time. So it is raised once here rather than a seventh time in place.

Fixing only the test that failed would also have left the *worse* case untouched. Measured across all 1190 tests, the slowest unbounded one is `buzz.test.ts`'s "resumes from the newest event seen" at **3194ms against 5000ms — a 1.6× margin**, tighter than the 2.7× margin of the test that actually flaked. It is unbounded for exactly the same reason the other was: nobody had watched it fail yet.

## What it does not loosen

- **An explicit per-test timeout still wins over the default**, so all six above keep saying what their test is waiting for. None is touched.
- **A hung test still fails** — ten seconds later than before, against a suite that runs in ninety-six.

## Verified by probe, not by reasoning

A throwaway test that sleeps 6s passes under the new bound, and with the line removed fails with `Test timed out in 5000ms` — the exact CI message. The probe was deleted; it is not in this diff.

Full suite green **five consecutive runs**, 1190 tests, 65 files. `pnpm typecheck` clean.

## One thing I could not pin down

During this work a single run reported `1 failed | 1189 passed` and I did not capture which test it was. It has not reproduced in the five runs since. I am flagging it rather than dropping it: if there is a second, non-timeout flake in this suite, this PR does not fix it, and I would rather that be written down than discovered later as a surprise. No `CHANGELOG.md` entry — this changes how tests are bounded, and nothing an operator of a deployed agent can observe.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a06d48-6538-756e-98ad-dc8639ce89e8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791150637&installation_model_id=433550&pr_number=42&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F42&signature=2f2961d9bdc3659f292fff0e2ef782e681fee9fdb367a0e874132955788c0733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test discovery now explicitly includes root-level and package test files.
  * Tests have a default timeout of 15 seconds, while individual test timeouts remain effective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->