### PR TITLE
Cut the CHANGELOG section for 0.3.1, since neither entry leaves an operator anything to do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-04
+
+Published as `ghcr.io/sageox/agent-base:0.3.1`, which takes `:latest` and moves `:0.3`
+forward onto it. There is nothing new to set, and no `agent.yaml` that works today stops
+working.
+
+One behaviour changes without being asked for: `limits.turnTimeoutMs` now also bounds the
+brain's tool calls. At its default that is the more permissive of the two clocks, so a call
+the brain used to abandon inside a still-live turn now runs to the end of it. An agent that
+lowered `turnTimeoutMs` to bound a wedged channel has tightened its tool calls by the same
+move — those calls were already outliving the turn that would have used their result, so
+nothing that reaches a channel today stops reaching it, but the number now means both
+things.
+
 - **A job short enough to wait for is no longer abandoned partway through the wait.** There
   was a third clock nothing in the bundle named: the brain's MCP client gives up on a tool
   call on its own timeout, and whenever that was shorter than the turn it was the one that


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06f23-a683-7d04-8a23-fab332b96896">Session</a>
<!-- /sageox:pr-header -->

Renames `## [Unreleased]` to `## [0.3.1] - 2026-09-04` and opens a fresh one above it —
step 1 of the release process in CONTRIBUTING.md. `release.yml` refuses to publish
`v0.3.1` until a heading by that name exists, and summarizes the section beneath it into
the GitHub Release notes.

Rebased onto `main` to pick up #45, so the section now covers two entries.

**#45 leads the section**, because it is the only thing here that moves without being asked
to: `limits.turnTimeoutMs` now also bounds the brain's tool calls. #40 follows — it adds
`report.proven`, which is off by default and reads exactly as it did for a job that declares
nothing.

**A patch and not a minor.** Neither entry adds something to set, and no `agent.yaml` that
works today stops working. At the default `turnTimeoutMs`, #45 makes the tool-call clock the
more permissive of the two, so a call the brain used to abandon inside a still-live turn now
runs to the end of it. Where `turnTimeoutMs` was lowered it becomes the tighter clock, but
only over calls that were already outliving the turn that would have used their result — so
nothing reaching a channel today stops reaching it.

What that buys is the floating tag. This repo publishes no `:0`, because before 1.0.0 a
minor bump is a breaking change — which makes `0.MINOR` the compatibility line and `:0.3`
the ref an operator tracks. A patch moves `:0.3` forward onto 0.3.1, which is the honest
signal here: safe to pick up.

The preamble still **names the coupling** rather than leaving it to be found. `turnTimeoutMs`
now means two things, and only one of them is what an operator set it for — someone who
lowered it to bound a wedged channel has tightened their tool calls by the same move.

**The chart does not move.** Nothing under `deploy/` has changed since `v0.3.0`.

**#41 and #42 get no entry**, because neither changes anything an operator can observe: #41
pins what an empty gate `detail` renders as, behind #40's own new field, and #42 raises
`testTimeout` in `vitest.config.ts`, which configures the test runner and no runtime path.

## Verification

- `pnpm test` green — 1192 tests across 65 files, on the rebased tree. `pnpm typecheck` green.
- `release.yml`'s `^## \[0.3.1\]` gate matches the new heading.
- Ran the workflow's own release-note `awk` against this file: it yields both lead sentences
  in section order and ignores the preamble, which is not a `- ` bullet.

  ```
  - A job short enough to wait for is no longer abandoned partway through the wait.
  - A passing gate's own sentence can render as written.
  ```

SageOx-Session: https://sageox.ai/c/ses_01a06e9c-2841-7e53-a756-118f56d2fa96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added changelog information for version 0.3.1, dated September 4, 2026.
  - Documented publication of the `ghcr.io/sageox/agent-base:0.3.1` container image and updates to the `:latest` and `:0.3` tags.
  - Confirmed that deployment configuration behavior remains unchanged for existing deployments.
  - Documented timeout alignment for job runs, including coverage for brain tool calls.
  - Added documentation for `report.proven: verbatim`, which renders passing gate output without the `PROVEN:` prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->