### PR TITLE
Bound the brain's tool-call clock by the turn, since job_run already decides against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A job short enough to wait for is no longer abandoned partway through the wait.** There
+  was a third clock nothing in the bundle named: the brain's MCP client gives up on a tool
+  call on its own timeout, and whenever that was shorter than the turn it was the one that
+  bound. `job_run` waits for exactly those jobs whose deadline fits inside
+  `limits.turnTimeoutMs` — correct by its own arithmetic, against a number that never
+  applied. The brain was handed a failing tool and told the channel the job had produced
+  nothing; the job then finished and posted its own, correct result, and the only record the
+  gateway kept of the dropped call read `outcome=ok`. The brain subprocess is now started
+  with its tool-call timeout set from `limits.turnTimeoutMs`, so the number `job_run` weighs
+  a job's deadline against is the number that applies. Raise `limits.turnTimeoutMs` and both
+  bounds move together; there is nothing new to set.
+
 - **A passing gate's own sentence can render as written.** The host puts `PROVEN:` in front
   of every line a passing gate produces, which is right while the sentence after it is the
   host's own machine phrasing and wrong for a job whose gates are a shift report — a body

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -492,6 +492,8 @@ async function buildBrain(
       // is never in it.
       apiKey: resolveSecret("ANTHROPIC_API_KEY", { dir: secretsDir }),
       model: manifest.brain.model,
+      // The number `job_run` weighs a job's deadline against, so the two cannot disagree.
+      turnTimeoutMs: manifest.limits.turnTimeoutMs,
     }),
     closeHosted: async () => {
       for (const h of hosted) await h.close().catch(() => {});

--- a/packages/core/src/brain-acp.ts
+++ b/packages/core/src/brain-acp.ts
@@ -42,6 +42,11 @@ export interface AcpBrainOptions {
   mcpServers?: readonly unknown[];
   /** How long a channel's conversation is kept before it is closed. */
   sessionIdleMs?: number;
+  /**
+   * `limits.turnTimeoutMs`, as the spawned subprocess's `MCP_TOOL_TIMEOUT`. A `target`
+   * handed in instead is not a process and carries no such bound.
+   */
+  turnTimeoutMs?: number;
 }
 
 /** Long enough to keep a conversation alive across a coffee break. */
@@ -247,7 +252,11 @@ export class ClaudeAcpBrain implements Brain {
     const resolved = resolveBrainCommand();
     const child = spawn(resolved.command, resolved.args, {
       stdio: ["pipe", "pipe", "inherit"],
-      env: brainEnv(process.env, { apiKey: this.opts.apiKey, model: this.opts.model }),
+      env: brainEnv(process.env, {
+        apiKey: this.opts.apiKey,
+        model: this.opts.model,
+        turnTimeoutMs: this.opts.turnTimeoutMs,
+      }),
       cwd: this.opts.cwd,
     });
     this.child = child;

--- a/packages/core/src/brain-env.ts
+++ b/packages/core/src/brain-env.ts
@@ -42,7 +42,7 @@ export function passthroughEnv(
  */
 export function brainEnv(
   base: NodeJS.ProcessEnv,
-  opts: { apiKey?: string; model?: string } = {},
+  opts: { apiKey?: string; model?: string; turnTimeoutMs?: number } = {},
 ): NodeJS.ProcessEnv {
   const env = passthroughEnv(base);
   const apiKey = opts.apiKey ?? base.ANTHROPIC_API_KEY;
@@ -51,5 +51,8 @@ export function brainEnv(
   // gateway host would repin every agent it runs, invisibly to anyone reading the
   // bundle. Unpinned means the brain's own default, not the host's opinion.
   if (opts.model) env.ANTHROPIC_MODEL = opts.model;
+  // Otherwise the brain's own default ends a tool call inside a turn the gateway still
+  // considers live — and `job_run` waits for a job on the strength of that turn's number.
+  if (opts.turnTimeoutMs) env.MCP_TOOL_TIMEOUT = String(opts.turnTimeoutMs);
   return env;
 }

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -196,7 +196,10 @@ const LimitsSchema = z.object({
   maxAgentChainDepth: z.number().int().positive().default(2),
   maxConcurrentChannels: z.number().int().positive().default(4),
   channelQueueLimit: z.number().int().positive().default(32),
-  /** A turn that outlives this releases its channel; without it one hang wedges the gateway. */
+  /**
+   * A turn that outlives this releases its channel; without it one hang wedges the gateway.
+   * It is also the brain's MCP tool-call timeout, so no call is cut off inside a live turn.
+   */
   turnTimeoutMs: z.number().int().positive().default(120_000),
 });
 

--- a/packages/core/test/brain-env.test.ts
+++ b/packages/core/test/brain-env.test.ts
@@ -71,4 +71,13 @@ describe("brainEnv", () => {
     const env = brainEnv({ ...gatewayEnv, ANTHROPIC_MODEL: "claude-haiku-4-5" });
     expect("ANTHROPIC_MODEL" in env).toBe(false);
   });
+
+  it("bounds the brain's tool calls by the turn it is answering inside", () => {
+    expect(brainEnv(gatewayEnv, { turnTimeoutMs: 300_000 }).MCP_TOOL_TIMEOUT).toBe("300000");
+  });
+
+  it("overrides an ambient tool timeout, which no manifest could be read to allow", () => {
+    const env = brainEnv({ ...gatewayEnv, MCP_TOOL_TIMEOUT: "5000" }, { turnTimeoutMs: 300_000 });
+    expect(env.MCP_TOOL_TIMEOUT).toBe("300000");
+  });
 });


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a06ef5-9cda-74f1-ba8b-fe6f82e273e9">Session</a>
<!-- /sageox:pr-header -->

Fixes the first of the three suggestions in #44.

## What was needed

`job_run` decides whether to wait for a job or detach from it by comparing the job's own
deadline against `limits.turnTimeoutMs` (`packages/core/src/job-server.ts:324`). There is a
third clock in that decision and it appears on neither side of the comparison: **the brain's
MCP client gives up on a tool call on its own timeout, and nothing in the bundle named it.**
Whenever that bound was shorter than the turn, it was the one that bound.

Observed in #44: a job whose budget came to 195s against a 300s turn — so `job_run` waited,
correct by its own arithmetic — was abandoned by the harness at ~87.8s. The brain was handed
a failing tool, told the channel the job had timed out and produced nothing, and named two
people to go look. Three seconds later the job posted its own, correct result. A human saw
both messages. The only line the gateway kept for that call was `outcome=ok ms=90834`.

## What this ships

The brain subprocess is spawned with `MCP_TOOL_TIMEOUT` set from `limits.turnTimeoutMs`, so
the number `job_run` weighs a job's deadline against is the number that applies. It follows
the model pin's rule — set from the manifest, never from the ambient environment — so a
`MCP_TOOL_TIMEOUT` on the gateway host cannot quietly outrank a bundle's turn.

```
brainEnv(base, { apiKey, model, turnTimeoutMs })   →  MCP_TOOL_TIMEOUT=<turnTimeoutMs>
```

Raising `limits.turnTimeoutMs` now moves both bounds together; there is nothing new for an
operator to set, and no third number that can disagree with the other two.

## How it was verified

Two tests in `packages/core/test/brain-env.test.ts` — one that the turn's timeout reaches
`MCP_TOOL_TIMEOUT`, one that an ambient `MCP_TOOL_TIMEOUT` does not outrank it. Both fail
without the change (`expected undefined to be '300000'`). `pnpm typecheck` and `pnpm test`
are green: 65 files, 1192 tests.

## Deliberately not in this PR

Suggestion (3) of #44 — logging a waited call that completes after its turn has ended — is a
separate change and still worth doing on its own: it is what would catch these two clocks
drifting apart again, and today a job host cannot observe an abandoned call at all.
Suggestion (2) is the issue's own "failing that" alternative to this one, so it is moot.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a06ef5-9cda-74f1-ba8b-fe6f82e273e9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791160542&installation_model_id=433550&pr_number=45&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F45&signature=acf61b2f8efd42c484f05776c34816964cb4b10436bec23b5ba8d67275128d22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - AI tool calls now use the configured turn timeout and are cancelled consistently when a turn exceeds its deadline.
  - Configured timeout values now take precedence over inherited tool-timeout settings.
  - Timeout handling is now applied consistently to spawned AI processes and their tool calls.

- **Documentation**
  - Clarified that the timeout limits both AI turns and tool calls, releasing the channel when a turn runs too long.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->