### PR TITLE
Emit structured job lifecycle and work outcome events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Opt-in `AGENT_WORK_EVENTS=1` emits bounded, versioned job start/completion records
+  from both scheduled and chat hosts. Job reports may include typed artifact,
+  subject state, usage and health facts when `JOB_WORK_SCHEMA_VERSION=1` is present.
+  Child diagnostics are isolated from host event envelopes; raw gate details,
+  requester information and parameters are excluded. These are runtime reports,
+  not independent provider confirmation.
+
 ## [0.4.0] - 2026-09-07
 
 Everything below shipped after `v0.3.1`.

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -363,10 +363,11 @@ named fleets. Consumers must ignore unsupported schema versions.
 A start means admission succeeded, before setup and process spawn. It is not proof
 that the process started: a later `crashed` result can report `executed: false`.
 `deadline_ms` is the declared duration (`wallClockMs + deadlineHeadroomMs`),
-not an absolute timestamp guessed before setup completes. Setup time does not consume
-the process budget. `JOB_DEADLINE_AT` remains the absolute wall-clock cutoff passed
-to the body; the host allows cleanup headroom after that cutoff. Refusals and overlap skips emit only
-a terminal record, with no admitted deadline. `run.completed` names a terminal
+not an absolute timestamp guessed before setup completes. For local jobs, setup time
+does not consume the process budget. `JOB_DEADLINE_AT` remains the absolute
+wall-clock cutoff passed to the body; the host allows cleanup headroom after that
+cutoff. Refusals and overlap skips emit only a terminal record, with no admitted
+deadline. `run.completed` names a terminal
 **event**, whose `outcome` can still be denied, skipped, crashed, abandoned, or
 `budget-bowout`. Its `occurred_at` is the host's settlement time.
 
@@ -382,6 +383,9 @@ observed outcome.
 External-dispatch jobs use the dispatcher's existing run ID and settlement. The
 gateway emits a start after dispatch admission, which can precede worker startup;
 a cached terminal result or dispatcher refusal emits only a terminal record.
+Their platform deadline remains admission-based: dispatch and worker startup consume
+the declared budget. The worker subtracts elapsed time since the request's `startedAt`
+before launching the body and can report a timeout without starting it.
 Current dispatcher results carry aggregate verdicts and optional execution facts,
 not individual checks or work metadata: these events are marked `partial`. This
 contract does not expand the worker's termination-log protocol or cloud policies.
@@ -435,9 +439,11 @@ work fields never change how gates mint verdicts. The exported
 
 Providers, checks, and next actors use lowercase letter/digit/hyphen identifiers
 of at most 64 characters, beginning with a letter. IDs/scopes use up to 256 ASCII
-letters/digits or `_.:/-`, beginning with a letter or digit. Arrays allow at most
-100 items. Unknown fields, invalid values, malformed JSON, missing files, and files
-over 64 KiB never become invented work. Terminal `report_status` distinguishes
+letters/digits or `_./-`, beginning with a letter or digit. Colons are excluded,
+so URI schemes cannot be embedded in either field. Put namespace information in
+`provider` and `kind`, and use the provider-native ID (for example, `42`, not
+`issue:42`). Arrays allow at most 100 items. Unknown fields, invalid values, malformed
+JSON, missing files, and files over 64 KiB never become invented work. Terminal `report_status` distinguishes
 `valid`, `missing`, `invalid`, and `oversized`; invalid/absent reports retain the
 existing unproven verdict and expose no work facts. Empty gates also stay unproven.
 A future incompatible vocabulary requires a new advertised version; producers

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -14,6 +14,7 @@ with their own runtime image, durable status and cancellation, see [external job
 |---|---|
 | `JOB_SLUG` · `JOB_RUN_ID` · `JOB_TRIGGER` | Who this run is. The trigger is stamped from the entry point that started it, never passed in, so a job cannot claim a human asked for what a clock started. |
 | `JOB_VERDICT_PATH` | Where to write what you ran. |
+| `JOB_WORK_SCHEMA_VERSION` | `1` when structured reporting is enabled, otherwise empty. Gate optional work fields on this capability; see [schema 1](#structured-work-events-schema-1). |
 | `JOB_DEADLINE_AT` | Epoch ms at which the host stops you. Bow out before it. |
 | `JOB_HARNESS_TIMEOUT_MS` · `JOB_MAX_ITERATIONS` · `JOB_MAX_ATTEMPTS` · `JOB_MAX_SPEND_USD` · `JOB_MODEL` | The declared bounds the runtime cannot enforce for you. It can hold a job to a clock without knowing what it does; it cannot count an iteration or a dollar. |
 | `JOB_PARAM_<NAME>` | One per parameter this run was given, uppercased. Already validated against the declaration — see below. Absent when the run was given none. |
@@ -337,3 +338,127 @@ the status word in front of them is still minted by the host from what it ran. R
 channel is how a probe finds its evidence, never how it grades it — which is the point: the
 timing and the tally are deterministic code, and the brain only relays a result it did not
 invent.
+
+## Structured work events (schema 1)
+
+Set `AGENT_WORK_EVENTS=1` on `sageox-agent job run` or `sageox-agent run` to emit
+JSON Lines on **stdout**. The latter includes jobs requested through its MCP tool,
+including detached runs. With reporting disabled, child stdout/stderr and human
+status rendering retain their existing behavior. No collector or external service
+is required. Deployments must wait for a versioned toolkit release containing this
+contract before enabling it, and pin that release's image digest.
+
+A top-level `sageox_work_event` key is reserved for host lifecycle records. Read
+only stdout, accept `schema_version: 1`, and deduplicate by `(agent, run_id, event)`.
+`run_id` is the host's existing opaque ID: do not derive another one from timestamps
+or artifact IDs. Scope the agent name by deployment when combining independently
+named fleets. Consumers must ignore unsupported schema versions.
+
+```jsonl
+{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_at":"2026-09-07T03:05:00.000Z","event":"run.started","occurred_at":"2026-09-07T03:00:00.010Z"}}
+{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_at":"2026-09-07T03:05:00.000Z","event":"run.completed","occurred_at":"2026-09-07T03:00:12.000Z","outcome":"completed","verdict":"PASS","checks":[{"gate":"job:triage","executed":true,"exit_code":0,"source":"host"},{"gate":"ci","executed":true,"exit_code":0,"source":"producer"}],"report_status":"valid","partial":false}}
+```
+
+`started_at` records the attempt; the start event's `occurred_at` records admission.
+A start means admission succeeded, before setup and process spawn. It is not proof
+that the process started: a later `crashed` result can report `executed: false`.
+`deadline_at` is the declared hard deadline including cleanup headroom;
+`JOB_DEADLINE_AT` is earlier by that headroom. Refusals and overlap skips emit only
+a terminal record, with no admitted deadline. `run.completed` names a terminal
+**event**, whose `outcome` can still be denied, skipped, crashed, abandoned, or
+`budget-bowout`. Its `occurred_at` is the host's settlement time.
+
+`checks` retains execution and exit facts; `source` distinguishes the host process
+check from producer-reported checks. Optional `execution` holds process state,
+epoch-millisecond timestamps, actual exit code and signal number. A timeout may
+have an actual exit code of zero after cleanup while its combined `verdict` remains
+`UNKNOWN`. Neither process exit zero nor a passing gate confirms an artifact was
+created or an external subject is healthy. `verdict` retains the existing gate
+combination rules. A caller or chat transport timing out does not change the job's
+observed outcome.
+
+External-dispatch jobs use the dispatcher's existing run ID and settlement. The
+gateway emits a start after dispatch admission, which can precede worker startup;
+a cached terminal result or dispatcher refusal emits only a terminal record.
+Current dispatcher results carry aggregate verdicts and optional execution facts,
+not individual checks or work metadata: these events are marked `partial`. This
+contract does not expand the worker's termination-log protocol or cloud policies.
+
+A killed host can leave a start with **no terminal record**. Absence is not proof
+of success or failure. Observer/output failures are best-effort losses and never
+change job admission or settlement. There is no durable event queue or replay.
+
+### Optional facts in the existing verdict file
+
+When reporting is enabled for a local job, the host sets
+`JOB_WORK_SCHEMA_VERSION=1`; otherwise it sets an empty value. Producers must test
+for the supported value before adding fields. The host owns this variable and
+replaces any value declared by the child. Schema 1 extends the same strict
+`JOB_VERDICT_PATH` JSON object. Existing gates-only files remain valid; optional
+work fields never change how gates mint verdicts. The exported
+`VerdictArtifactSchema` and `WorkReportSchema` in core are the shared validators.
+
+```json
+{
+  "gates": [{ "gate": "ci", "executed": true, "exitCode": 0 }],
+  "artifacts": [{
+    "subject": { "provider": "github", "kind": "pull_request", "scope": "acme/service", "id": "42" },
+    "action": "created",
+    "observed_at": "2026-09-07T03:00:10Z",
+    "related_to": { "provider": "github", "kind": "issue", "scope": "acme/service", "id": "53" },
+    "next_actor": "reviewer"
+  }],
+  "work_observations": [{
+    "subject": { "provider": "github", "kind": "issue", "scope": "acme/service", "id": "53" },
+    "state": "waiting", "next_actor": "reviewer"
+  }],
+  "usage": { "scanned": 0, "outputs": 1, "model_calls": 2 },
+  "health": [{
+    "subject": { "provider": "runtime", "kind": "service", "id": "api" },
+    "check": "readiness", "status": "unknown", "observed_at": "2026-09-07T03:00:10Z"
+  }],
+  "partial": true
+}
+```
+
+| Field | Schema 1 vocabulary |
+|---|---|
+| Subject | `provider`, `kind`, `id`, optional `scope`. Kinds: `issue`, `pull_request`, `document`, `artifact`, `agent`, `service`, `job`. IDs/scopes are bounded identifiers, not URLs or prose. |
+| Artifact action | `created`, `updated`, `commented`, `completed`. |
+| Work observation state | `open`, `in_progress`, `waiting`, `blocked`, `completed`, `closed`, `unknown`. Provider-specific states map to these in the producer. |
+| Artifact/observation context | Optional `observed_at` (ISO timestamp with timezone), `related_to` (one subject), `next_actor` (identifier, not personal/requester information). |
+| Usage | Optional `model_calls`, `input_tokens`, `output_tokens`, `scanned`, `candidates`, `recommendations`, `findings`, `outputs` (nonnegative safe integers), and `cost_usd` (nonnegative finite number). Only measured values; zero means measured zero, absence means unreported. |
+| Health | Subject, `check` identifier, required observation timestamp, `status`: `healthy`, `degraded`, `unhealthy`, `unknown`. Producers define checks and health policy; runtime does not interpret cluster or fleet state. |
+| Partial | Optional boolean. True means bounded or incomplete producer knowledge, even when every gate passes. |
+
+Providers, checks, and next actors use lowercase letter/digit/hyphen identifiers
+of at most 64 characters, beginning with a letter. IDs/scopes use up to 256 ASCII
+letters/digits or `_.:/-`, beginning with a letter or digit. Arrays allow at most
+100 items. Unknown fields, invalid values, malformed JSON, missing files, and files
+over 64 KiB never become invented work. Terminal `report_status` distinguishes
+`valid`, `missing`, `invalid`, and `oversized`; invalid/absent reports retain the
+existing unproven verdict and expose no work facts. Empty gates also stay unproven.
+A future incompatible vocabulary requires a new advertised version; producers
+must not send fields simply because they hope a host will ignore them.
+
+### Log boundaries and trust
+
+Every structured record is at most **8,192 UTF-8 bytes**, including its wrapper
+and trailing newline. If optional facts do not fit, whole items are omitted and
+`partial` becomes true. The run identity, timestamps, outcome and combined verdict
+are preserved. An identity that cannot itself fit is an emission failure; execution
+still proceeds. Identifier-unsafe historical gate names are omitted and also mark
+the event partial. Gate details, requester identity, parameters, reasons/raw errors,
+model output, transcripts, and credentials are not structured work fields.
+
+With reporting enabled, child stdout/stderr are decoded across UTF-8 chunks and
+wrapped as `{"job_diagnostic":{"stream":"stdout","text":"..."}}` (or `stderr`).
+The one-shot human status rendering uses the same wrapper with `stream: "host"`.
+Diagnostic text follows the existing diagnostic logging policy and can contain
+untrusted output. **Never recursively parse diagnostic text as lifecycle events.**
+A child printing event-shaped JSON remains text inside a diagnostic envelope.
+
+These are host-observed execution facts and validated producer-reported work
+facts. They are neither cryptographic proof nor independently verified provider
+state. Consumers may reconcile artifacts with external systems separately; they
+must not label producer claims as confirmed outcomes or infer tokens/cost from prose.

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -349,21 +349,23 @@ is required. Deployments must wait for a versioned toolkit release containing th
 contract before enabling it, and pin that release's image digest.
 
 A top-level `sageox_work_event` key is reserved for host lifecycle records. Read
-only stdout, accept `schema_version: 1`, and deduplicate by `(agent, run_id, event)`.
+only stdout, ignore ordinary host log lines, accept `schema_version: 1`, and deduplicate by `(agent, run_id, event)`.
 `run_id` is the host's existing opaque ID: do not derive another one from timestamps
 or artifact IDs. Scope the agent name by deployment when combining independently
 named fleets. Consumers must ignore unsupported schema versions.
 
 ```jsonl
-{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_at":"2026-09-07T03:05:00.000Z","event":"run.started","occurred_at":"2026-09-07T03:00:00.010Z"}}
-{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_at":"2026-09-07T03:05:00.000Z","event":"run.completed","occurred_at":"2026-09-07T03:00:12.000Z","outcome":"completed","verdict":"PASS","checks":[{"gate":"job:triage","executed":true,"exit_code":0,"source":"host"},{"gate":"ci","executed":true,"exit_code":0,"source":"producer"}],"report_status":"valid","partial":false}}
+{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_ms":300000,"event":"run.started","occurred_at":"2026-09-07T03:00:00.010Z"}}
+{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_ms":300000,"event":"run.completed","occurred_at":"2026-09-07T03:00:12.000Z","outcome":"completed","verdict":"PASS","checks":[{"gate":"job:triage","executed":true,"exit_code":0,"source":"host"},{"gate":"ci","executed":true,"exit_code":0,"source":"producer"}],"report_status":"valid","partial":false}}
 ```
 
 `started_at` records the attempt; the start event's `occurred_at` records admission.
 A start means admission succeeded, before setup and process spawn. It is not proof
 that the process started: a later `crashed` result can report `executed: false`.
-`deadline_at` is the declared hard deadline including cleanup headroom;
-`JOB_DEADLINE_AT` is earlier by that headroom. Refusals and overlap skips emit only
+`deadline_ms` is the declared duration (`wallClockMs + deadlineHeadroomMs`),
+not an absolute timestamp guessed before setup completes. Setup time does not consume
+the process budget. `JOB_DEADLINE_AT` remains the absolute wall-clock cutoff passed
+to the body; the host allows cleanup headroom after that cutoff. Refusals and overlap skips emit only
 a terminal record, with no admitted deadline. `run.completed` names a terminal
 **event**, whose `outcome` can still be denied, skipped, crashed, abandoned, or
 `budget-bowout`. Its `occurred_at` is the host's settlement time.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1864,13 +1864,13 @@ async function jobCmd(argv: string[]): Promise<void> {
   // Headline, then the gates beneath it — the shape a job's status post takes, and the
   // reason it takes it: the verdict is what gets read, and the gates are why it says that.
   // The same rendering the chat tool returns, so one run reads one way wherever it lands.
-  const description = describeJobRun(run, job.report?.proven);
-  if (process.env.AGENT_WORK_EVENTS === "1") writeJobDiagnostic("host", description);
-  else process.stdout.write(description);
+  let description = describeJobRun(run, job.report?.proven);
   const denied = run.outcome === "denied-switch" || run.outcome === "denied-suspend";
   if (denied && trigger === "on-request") {
-    process.stdout.write("  a run started from this CLI is `system`, and does not bypass\n");
+    description += "  a run started from this CLI is `system`, and does not bypass\n";
   }
+  if (process.env.AGENT_WORK_EVENTS === "1") writeJobDiagnostic("host", description);
+  else process.stdout.write(description);
 
   // The exit code answers "did the run happen", not "what did it find". A job that ran its
   // gates and found a real failure is a working job, and a green job with a FAIL verdict

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -57,6 +57,8 @@ import {
   WorkerProfilesSchema,
   serveJobDispatcher,
   JobSchema,
+  jobWorkEvents,
+  writeJobDiagnostic,
   jobDeadlineMs,
   describeJobRun,
   serveJobs,
@@ -408,6 +410,7 @@ async function buildBrain(
     // and something has to settle it when this process is told to stop.
     jobs = new JobHost({
       external: externalJobs(),
+      ...jobWorkEvents(manifest.name),
       switchSource: await jobSwitchSource(manifest, secretsDir),
       secretOpts: { dir: secretsDir },
       // A job started from chat announces itself exactly as a scheduled one does. The
@@ -1838,6 +1841,7 @@ async function jobCmd(argv: string[]): Promise<void> {
   const host = new JobHost({
     external: externalJobs(),
     requestId: process.env.AGENT_JOB_REQUEST_ID ? `${process.env.AGENT_JOB_REQUEST_ID}:${slug}` : undefined,
+    ...jobWorkEvents(manifest.name),
     switchSource,
     post: reporter?.post,
     read: reporter?.read,
@@ -1860,7 +1864,9 @@ async function jobCmd(argv: string[]): Promise<void> {
   // Headline, then the gates beneath it — the shape a job's status post takes, and the
   // reason it takes it: the verdict is what gets read, and the gates are why it says that.
   // The same rendering the chat tool returns, so one run reads one way wherever it lands.
-  process.stdout.write(describeJobRun(run, job.report?.proven));
+  const description = describeJobRun(run, job.report?.proven);
+  if (process.env.AGENT_WORK_EVENTS === "1") writeJobDiagnostic("host", description);
+  else process.stdout.write(description);
   const denied = run.outcome === "denied-switch" || run.outcome === "denied-suspend";
   if (denied && trigger === "on-request") {
     process.stdout.write("  a run started from this CLI is `system`, and does not bypass\n");

--- a/packages/cli/test/job-run.test.ts
+++ b/packages/cli/test/job-run.test.ts
@@ -499,3 +499,18 @@ it("finishes the job when the stdout consumer disconnects after admission", asyn
     expect(readFileSync(completed, "utf8")).toBe("done");
   } finally { child.kill("SIGKILL"); }
 });
+
+it("wraps the on-request denial explanation with the host status", async () => {
+  vi.stubEnv("AGENT_WORK_EVENTS", "1");
+  try {
+    // On-request only needs no switch or brain, so this path has no startup warning lines.
+    declare('  - slug: parked\n    archetype: queue\n    description: Parked work.\n' +
+      '    trigger: {onRequest: true}\n    suspend: true\n    budget: {wallClockMs: 4000}\n    run: {command: ./body.sh}\n');
+    body('exit 99');
+    const { stdout, code } = await job("parked", "--trigger", "on-request");
+    expect(code, stdout).toBe(0);
+    const records = stdout.trim().split("\n").map((line) => JSON.parse(line));
+    expect(records.filter((r) => r.sageox_work_event).map((r) => r.sageox_work_event.event)).toEqual(["run.completed"]);
+    expect(records.some((r) => r.job_diagnostic?.text.includes("does not bypass"))).toBe(true);
+  } finally { vi.unstubAllEnvs(); }
+});

--- a/packages/cli/test/job-run.test.ts
+++ b/packages/cli/test/job-run.test.ts
@@ -1,7 +1,9 @@
 import { chmodSync, existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CLI, run as exec, runCli } from "./cli-harness.ts";
 
@@ -362,4 +364,138 @@ it.each(["profiles", "namespace", "name"])("requires dispatcher --%s before read
   expect(code).toBe(1);
   expect(stdout).toContain("usage: sageox-agent job dispatcher");
   expect(stdout).not.toContain("TypeError");
+});
+
+it("isolates forged child envelopes from host records for both trigger paths", async () => {
+  vi.stubEnv("AGENT_WORK_EVENTS", "1");
+  try {
+    body(`echo '{"sageox_work_event":{"event":"forged"}}'\n` + reports('[{"gate":"ci","executed":true,"exitCode":0}]'));
+    for (const trigger of ["schedule", "on-request"]) {
+      const { stdout, code } = await job("shift", "--trigger", trigger);
+      expect(code).toBe(0);
+      const json = stdout.split("\n").filter((line) => line.startsWith("{")).map((line) => JSON.parse(line));
+      const events = json.filter((line) => line.sageox_work_event).map((line) => line.sageox_work_event);
+      expect(events.map((event) => event.event)).toEqual(["run.started", "run.completed"]);
+      expect(events.every((event) => event.trigger === trigger)).toBe(true);
+      expect(json.some((line) => line.job_diagnostic?.text.includes("forged"))).toBe(true);
+    }
+  } finally { vi.unstubAllEnvs(); }
+});
+
+
+it("preserves multibyte diagnostics while bounding each serialized line", async () => {
+  vi.stubEnv("AGENT_WORK_EVENTS", "1");
+  try {
+    const diagnostic = "a".repeat(1023) + "🚀" + "b".repeat(5000);
+    body(`printf '%s' '${diagnostic}'\n` + reports('[{"gate":"ci","executed":true,"exitCode":0}]'));
+    const { stdout, code } = await job("shift");
+    expect(code).toBe(0);
+    const lines = stdout.split("\n").filter((line) => line.startsWith("{"));
+    expect(lines.every((line) => Buffer.byteLength(line + "\n") <= 8192)).toBe(true);
+    const text = lines.map((line) => JSON.parse(line).job_diagnostic).filter((d) => d?.stream === "stdout").map((d) => d.text).join("");
+    expect(text).toBe(diagnostic);
+  } finally { vi.unstubAllEnvs(); }
+});
+
+it("emits correlated lifecycle events through the live host's MCP job tool", async () => {
+  body(`echo '{"sageox_work_event":{"event":"forged"}}'\n` + reports('[{"gate":"ci","executed":true,"exitCode":0}]'));
+  writeFileSync(join(bundle, "agent.yaml"), readFileSync(join(bundle, "agent.yaml"), "utf8")
+    .replace("provider: mock", "provider: claude-acp").replace("brains: [{preset: local}]", "brains: []\ntools: ./settings.json")
+    .replace('trigger: {schedules: ["0 3 * * *"], onRequest: true, webhook: true}', "trigger: {onRequest: true}")
+    .replace("    killSwitch: {failDirection: open}\n", ""));
+  writeFileSync(join(bundle, "settings.json"), JSON.stringify({ permissions: {
+    defaultMode: "acceptEdits", allow: ["mcp__jobs__job_run"], deny: ["Read(//mnt/secrets-store/**)"],
+  } }));
+  // Real ACP wire protocol; the fake brain calls the actual guarded MCP server.
+  const fake = join(bundle, "claude-agent-acp");
+  writeFileSync(fake, `#!${process.execPath}\n` + `
+let jobs;
+const send = (id, result) => process.stdout.write(JSON.stringify({jsonrpc:"2.0",id,result})+"\\n");
+require("readline").createInterface({input:process.stdin}).on("line",async line=>{
+  const m=JSON.parse(line);
+  if(m.method==="initialize") send(m.id,{protocolVersion:1,agentCapabilities:{mcpCapabilities:{http:true}}});
+  else if(m.method==="session/new") {jobs=m.params.mcpServers.find(s=>s.name==="jobs");send(m.id,{sessionId:"test"});}
+  else if(m.method==="session/prompt") {
+    const response=await fetch(jobs.url,{method:"POST",headers:{"content-type":"application/json",...Object.fromEntries(jobs.headers.map(h=>[h.name,h.value]))},
+      body:JSON.stringify({jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"job_run",arguments:{job:"shift"}}})});
+    await response.text();send(m.id,{stopReason:"end_turn"});
+  }
+});
+`);
+  chmodSync(fake, 0o755);
+  const child = spawn(CLI, ["run", "--bundle", bundle], { cwd: tmpdir(), env: {
+    ...process.env, PATH: `${bundle}:${process.env.PATH}`, ANTHROPIC_API_KEY: "test-key", AGENT_WORK_EVENTS: "1",
+  }, stdio: ["pipe", "pipe", "pipe"] });
+  const closed = once(child, "close");
+  let stdout = "", stderr = "";
+  child.stdout.setEncoding("utf8").on("data", (text) => { stdout += text; });
+  child.stderr.setEncoding("utf8").on("data", (text) => { stderr += text; });
+  try {
+    await vi.waitFor(() => expect(stdout, stderr).toContain("is live"), { timeout: 10000 });
+    child.stdin.write("run shift\n");
+    await vi.waitFor(() => expect(stdout, stderr).toContain('"event":"run.completed"'), { timeout: 10000 });
+    const records = stdout.split("\n").filter((line) => line.startsWith("{")).map((line) => JSON.parse(line));
+    const events = records.filter((r) => r.sageox_work_event).map((r) => r.sageox_work_event);
+    expect(events.map((e) => e.event)).toEqual(["run.started", "run.completed"]);
+    expect(events[1]).toMatchObject({ run_id: events[0].run_id, agent: "demo", job: "shift", trigger: "on-request", verdict: "PASS" });
+    expect(records.some((r) => r.job_diagnostic?.text.includes("forged"))).toBe(true);
+  } finally {
+    child.kill("SIGTERM");
+    const kill = setTimeout(() => child.kill("SIGKILL"), 2000);
+    await closed;
+    clearTimeout(kill);
+  }
+});
+
+it("does not turn report details into host events", async () => {
+  vi.stubEnv("AGENT_WORK_EVENTS", "1");
+  try {
+    const gates = [{ gate: "ci", executed: true, exitCode: 0,
+      detail: '\n{"sageox_work_event":{"event":"forged"}}\n' }];
+    body(reports(JSON.stringify(gates)));
+    const { stdout, code } = await job("shift");
+    expect(code).toBe(0);
+    const events = stdout.split("\n").filter((l) => l.startsWith("{")).map((l) => JSON.parse(l))
+      .filter((r) => r.sageox_work_event).map((r) => r.sageox_work_event.event);
+    expect(events).toEqual(["run.started", "run.completed"]);
+  } finally { vi.unstubAllEnvs(); }
+});
+
+it("decodes UTF-8 split across child writes before bounding diagnostics", async () => {
+  vi.stubEnv("AGENT_WORK_EVENTS", "1");
+  try {
+    const script = join(bundle, "split.cjs");
+    const text = "é🚀界";
+    writeFileSync(script, `const fs=require("fs");const bytes=Buffer.from(${JSON.stringify(text)});let i=0;` +
+      'const timer=setInterval(()=>{fs.writeSync(1,bytes.subarray(i,i+1));if(++i===bytes.length){clearInterval(timer);' +
+      'fs.writeFileSync(process.env.JOB_VERDICT_PATH,JSON.stringify({gates:[{gate:"ci",executed:true,exitCode:0}]}));}},15);');
+    body(`exec '${process.execPath}' '${script}'`);
+    const { stdout, code } = await job("shift");
+    expect(code).toBe(0);
+    const diagnostics = stdout.split("\n").filter((l) => l.startsWith("{")).map((l) => JSON.parse(l).job_diagnostic)
+      .filter((d) => d?.stream === "stdout").map((d) => d.text).join("");
+    expect(diagnostics).toBe(text);
+    expect(diagnostics).not.toContain("�");
+  } finally { vi.unstubAllEnvs(); }
+});
+
+it("finishes the job when the stdout consumer disconnects after admission", async () => {
+  const script = join(bundle, "disconnected.cjs"), completed = join(bundle, "completed");
+  writeFileSync(script, 'setTimeout(()=>{console.log("child diagnostic");' +
+    `require("fs").writeFileSync(${JSON.stringify(completed)},"done");` +
+    'require("fs").writeFileSync(process.env.JOB_VERDICT_PATH,JSON.stringify({gates:[{gate:"ci",executed:true,exitCode:0}]}));},100);');
+  body(`exec '${process.execPath}' '${script}'`);
+  const child = spawn(CLI, ["job", "run", "shift", "--bundle", bundle], { env: { ...process.env, AGENT_WORK_EVENTS: "1" }, stdio: ["ignore", "pipe", "pipe"] });
+  const closed = once(child, "close");
+  let stdout = "", stderr = "";
+  child.stdout.setEncoding("utf8").on("data", (text) => {
+    stdout += text;
+    if (stdout.includes('"event":"run.started"')) child.stdout.destroy();
+  });
+  child.stderr.setEncoding("utf8").on("data", (text) => { stderr += text; });
+  try {
+    const [code] = await closed;
+    expect(code, stderr).toBe(0);
+    expect(readFileSync(completed, "utf8")).toBe("done");
+  } finally { child.kill("SIGKILL"); }
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,3 +35,4 @@ export { ExternalJobs, ExternalRequestSchema, workerResult } from "./external-jo
 export { JobDispatcher, JobKubeApi, WorkerProfilesSchema, serveJobDispatcher } from "./job-dispatcher.ts";
 export { JobSchema } from "./manifest.ts";
 export { type WorkerDiagnostics } from "./job-diagnostics.ts";
+export * from "./work-events.ts";

--- a/packages/core/src/job-host.ts
+++ b/packages/core/src/job-host.ts
@@ -86,8 +86,8 @@ export type JobOutcome =
 export interface JobRun {
   work?: WorkReport;
   reportStatus?: "valid" | "missing" | "invalid" | "oversized";
-  /** Declared hard deadline, including cleanup headroom; absent for refusals. */
-  deadlineAt?: number;
+  /** Declared deadline duration, including cleanup headroom; absent for refusals. */
+  deadlineMs?: number;
   checks?: readonly WorkCheck[];
   jobSlug: string;
   runId: string;
@@ -153,7 +153,7 @@ export interface JobStart {
 /** The facts a run has before its body does. Named because four signatures below take it. */
 type RunBase = Pick<
   JobRun,
-  "jobSlug" | "runId" | "trigger" | "requestedBy" | "startedAt" | "parameters" | "deadlineAt" | "execution"
+  "jobSlug" | "runId" | "trigger" | "requestedBy" | "startedAt" | "parameters" | "deadlineMs" | "execution"
 >;
 
 /** {@link JobStart}, plus the record the run will end with. Never leaves this file. */
@@ -927,16 +927,16 @@ export class JobHost {
         }
         if (status.state === "finished") {
           const run = { ...externalRun(request, status),
-            ...(status.outcome === "skipped-overlap" ? {} : { deadlineAt: status.startedAt + jobDeadlineMs(job) }) };
+            ...(status.outcome === "skipped-overlap" ? {} : { deadlineMs: jobDeadlineMs(job) }) };
           this.observeRun(run);
           return { runId, refused: run, finished: Promise.resolve(run) };
         }
         base.startedAt = status.startedAt;
-        this.observeStart(base, status.startedAt + jobDeadlineMs(job));
+        this.observeStart(base, jobDeadlineMs(job));
         // A gateway shutdown stops observation only. Kubernetes still owns the worker,
         // deadline and durable record, so shutdown must never mark this run abandoned.
         const finished = this.opts.external!.wait(request, this.externalWaits.signal).then(async (run) => {
-          run.deadlineAt = base.deadlineAt;
+          run.deadlineMs = base.deadlineMs;
           this.observeRun(run);
           await this.settle(job, run, detached, answer);
           return run;
@@ -944,7 +944,7 @@ export class JobHost {
         return { runId, refused: null, finished };
       }
       running = true;
-      this.observeStart(base, Date.now() + jobDeadlineMs(job));
+      this.observeStart(base, jobDeadlineMs(job));
       if (detached) this.owed.set(runId, () => this.giveUp(job, base, admission, answer));
       return {
         runId,
@@ -1041,24 +1041,24 @@ export class JobHost {
     }
     const report = await this.readReport(verdictPath, job);
     const { gates, work, reportStatus } = report;
-    const checks = [{ gate: jobGate(job), executed: true, exitCode: execution.exitCode }, ...report.checks];
-
     // A body this host stopped never got to speak, whatever it managed to exit with on the
     // way out — a job told to stop has not finished its work, so a 0 from it is not a
     // statement about that work. `exitCode: null` is the one input that yields UNKNOWN for
     // a process that ran, and it is the same encoding a signal death already arrives as.
-    const processGate = verdictFromGate({
+    const processCheck = {
       gate: jobGate(job),
       executed: true,
       exitCode: execution.bowedOut || execution.interrupted ? null : execution.exitCode,
-    });
+    };
+    const processGate = verdictFromGate(processCheck);
+    const checks = [processCheck, ...report.checks];
 
     if (execution.bowedOut) {
       return {
         outcome: "budget-bowout",
         execution: execution.info,
         gates: [processGate, ...gates],
-      work, checks, reportStatus,
+        work, checks, reportStatus,
         reason:
           `the job body was still running after its ${job.budget.wallClockMs}ms wall clock ` +
           `and was asked to stop, with ${job.budget.deadlineHeadroomMs}ms to finish writing`,
@@ -1069,7 +1069,7 @@ export class JobHost {
         outcome: "crashed",
         execution: execution.info,
         gates: [processGate, ...gates],
-      work, checks, reportStatus,
+        work, checks, reportStatus,
         reason: `the job body died on ${execution.signal ?? "an unreported signal"}`,
       };
     }
@@ -1150,7 +1150,6 @@ export class JobHost {
         (this.opts.workEvents ? process.stdout : process.stderr).on("drain", resumeErr);
         child.stdout!.setEncoding("utf8").on("data", (text: string) => stdout.write(text));
         child.stderr!.setEncoding("utf8").on("data", (text: string) => stderr.write(text));
-
       }
       child.once("spawn", () => { base.execution = info = { ...info, state: "running" }; publish(); });
       const checkpoint = job.worker ? setInterval(() => publish(), 1000) : undefined;
@@ -1174,8 +1173,8 @@ export class JobHost {
       const bowOut = setTimeout(() => {
         bowedOut = true;
         stop("SIGTERM");
-      }, base.deadlineAt === undefined ? job.budget.wallClockMs : Math.max(0, Number(env.JOB_DEADLINE_AT) - Date.now()));
-      const hardStop = setTimeout(() => stop("SIGKILL"), base.deadlineAt === undefined ? jobDeadlineMs(job) : Math.max(0, base.deadlineAt - Date.now()));
+      }, job.budget.wallClockMs);
+      const hardStop = setTimeout(() => stop("SIGKILL"), jobDeadlineMs(job));
 
       const settle = (execution: Execution) => {
         clearTimeout(bowOut);
@@ -1278,7 +1277,7 @@ export class JobHost {
       JOB_VERDICT_PATH: verdictPath,
       JOB_WORK_SCHEMA_VERSION: this.opts.workEvents ? "1" : "",
       /** When this host will ask the body to stop. The body should bow out before it. */
-      JOB_DEADLINE_AT: String((base.deadlineAt ?? Date.now() + jobDeadlineMs(job)) - job.budget.deadlineHeadroomMs),
+      JOB_DEADLINE_AT: String(Date.now() + job.budget.wallClockMs),
       JOB_HARNESS_TIMEOUT_MS: String(job.budget.harnessTimeoutMs),
       JOB_MAX_ITERATIONS: String(job.budget.maxIterations),
       JOB_MAX_ATTEMPTS: String(job.budget.maxAttempts),
@@ -1357,15 +1356,17 @@ export class JobHost {
     return complete;
   }
 
-  private observeStart(base: RunBase, deadlineAt: number): void {
+  /** Record admission facts even without a listener; observer failures cannot deny a run. */
+  private observeStart(base: RunBase, deadlineMs: number): void {
+    base.deadlineMs = deadlineMs;
     if (!this.opts.onStart) return;
-    base.deadlineAt = deadlineAt;
     const { jobSlug, runId, trigger, startedAt } = base;
     try {
-      Promise.resolve(this.opts.onStart?.({ jobSlug, runId, trigger, startedAt, admittedAt: Date.now(), deadlineAt })).catch(() => {});
+      Promise.resolve(this.opts.onStart?.({ jobSlug, runId, trigger, startedAt, admittedAt: Date.now(), deadlineMs })).catch(() => {});
     } catch { /* Observers cannot change admission. */ }
   }
 
+  /** Publish local or dispatched settlement without letting a listener reject it. */
   private observeRun(run: JobRun): void {
     try { Promise.resolve(this.opts.onRun?.(run)).catch(() => {}); }
     catch { /* Observers cannot change settlement. */ }

--- a/packages/core/src/job-host.ts
+++ b/packages/core/src/job-host.ts
@@ -1,10 +1,10 @@
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, open, readFile, rm } from "node:fs/promises";
+import { mkdir, open, rm } from "node:fs/promises";
 import { constants, tmpdir } from "node:os";
 import { join } from "node:path";
-import { z } from "zod";
 import { ExternalJobs, externalRun, jobDefinition, type ExternalRequest, type ExternalStatus } from "./external-jobs.ts";
+import { VerdictArtifactSchema, MAX_WORK_REPORT_BYTES, writeJobDiagnostic, type WorkReport, type WorkCheck, type WorkStart } from "./work-events.ts";
 import {
   admitJob,
   type JobAdmission,
@@ -84,6 +84,11 @@ export type JobOutcome =
  * that reported nothing and a job that never ran must not read the same.
  */
 export interface JobRun {
+  work?: WorkReport;
+  reportStatus?: "valid" | "missing" | "invalid" | "oversized";
+  /** Declared hard deadline, including cleanup headroom; absent for refusals. */
+  deadlineAt?: number;
+  checks?: readonly WorkCheck[];
   jobSlug: string;
   runId: string;
   /** Stamped from the entry point that started the run. Never passed in — see {@link JobHost}. */
@@ -148,7 +153,7 @@ export interface JobStart {
 /** The facts a run has before its body does. Named because four signatures below take it. */
 type RunBase = Pick<
   JobRun,
-  "jobSlug" | "runId" | "trigger" | "requestedBy" | "startedAt" | "parameters"
+  "jobSlug" | "runId" | "trigger" | "requestedBy" | "startedAt" | "parameters" | "deadlineAt" | "execution"
 >;
 
 /** {@link JobStart}, plus the record the run will end with. Never leaves this file. */
@@ -253,6 +258,10 @@ export interface JobHostOptions {
   workDir?: string;
   /** Every run record, always — denied and dropped ticks included. */
   onRun?: (run: JobRun) => void;
+  /** Admitted execution, before setup/spawn; no call for refusals or overlap. */
+  onStart?: (run: WorkStart) => void;
+  /** Wrap body output so it cannot impersonate host lifecycle records. */
+  workEvents?: boolean;
   /**
    * The environment a job body is built *from* — never the environment it gets. Defaults to
    * this process's, and either way only `passthroughEnv` and what the job declared survive
@@ -272,27 +281,6 @@ export interface JobHostOptions {
    */
   secretOpts?: { dir?: string | readonly string[]; env?: NodeJS.ProcessEnv };
 }
-
-/**
- * One gate the job body observed. Deliberately not a verdict: the body reports what it
- * *ran*, and this host is the only thing that turns that into a PASS. A body cannot write
- * `{"status":"PASS"}` because nothing here reads a status.
- */
-const GateResultSchema = z
-  .object({
-    gate: z.string().min(1),
-    /** Did the gate process start? Nothing about how it ended — that is `exitCode`. */
-    executed: z.boolean(),
-    /** What it said on the way out. `null` when it never said anything. */
-    exitCode: z.number().int().nullable(),
-    /** The body's own sentence about this gate. Rendered by `describeVerdict`, never read to decide. */
-    detail: z.string().optional(),
-  })
-  // Strict because the field a body would add is `status`, and quietly ignoring an attempt
-  // to compose a verdict is worse than refusing the artifact: refusing reads as UNKNOWN.
-  .strict();
-
-const VerdictArtifactSchema = z.object({ gates: z.array(GateResultSchema) }).strict();
 
 /** The validated values one run was given, by declared name. */
 export type JobParams = Readonly<Record<string, string | number>>;
@@ -317,7 +305,7 @@ export const MAX_PARAM_LENGTH = 1024;
  * `envelope` calls it because the doors keep multiplying — a chat tool, an operator's CLI —
  * and a bound only some of them apply is a bound the manifest cannot be read for.
  *
- * Refuses rather than ignores an undeclared name, on `GateResultSchema`'s reasoning: quietly
+ * Refuses rather than ignores an undeclared name, on `VerdictArtifactSchema`'s reasoning: quietly
  * dropping a value somebody meant to send is how a run acts on a target nobody chose.
  */
 export function jobParams(job: JobConfig, given: Readonly<Record<string, unknown>>): JobParams {
@@ -727,6 +715,7 @@ export class JobHost {
     answer?: JobAnswer,
   ): Promise<void> {
     if (!this.claim(base.runId)) return; // its body finished first and has already spoken
+    const executed = base.execution !== undefined && !["starting", "not-started"].includes(base.execution.state);
     const run = this.record({
       ...base,
       switch: admission.switch,
@@ -736,7 +725,8 @@ export class JobHost {
       // `exitCode: null` is already the encoding for exactly that — a process that ran and
       // said nothing readable — so an abandoned run is UNKNOWN by the same arithmetic every
       // other unproven run is, rather than by a second rule written here.
-      gates: [verdictFromGate({ gate: jobGate(job), executed: true, exitCode: null })],
+      gates: [verdictFromGate({ gate: jobGate(job), executed, exitCode: null })],
+      checks: [{ gate: jobGate(job), executed, exitCode: base.execution?.exitCode ?? null }],
       reason:
         `this host was asked to stop while the ${job.slug} body was still running, ` +
         "so nothing here will read what it proved",
@@ -859,6 +849,7 @@ export class JobHost {
           switch: null,
           bypassedSwitch: false,
           gates: [didNotRun],
+          checks: [{ gate: jobGate(job), executed: false, exitCode: null }],
           reason: `${job.slug} does not arm the ${trigger} trigger, so nothing may start it that way`,
         }),
       );
@@ -874,6 +865,7 @@ export class JobHost {
           switch: null,
           bypassedSwitch: false,
           gates: [didNotRun],
+          checks: [{ gate: jobGate(job), executed: false, exitCode: null }],
           reason: `a ${job.slug} run is still in flight; this ${trigger} tick was dropped`,
         }),
       );
@@ -894,6 +886,7 @@ export class JobHost {
             switch: admission.switch,
             bypassedSwitch: false,
             gates: [didNotRun],
+            checks: [{ gate: jobGate(job), executed: false, exitCode: null }],
             reason: admission.reason,
           }),
         );
@@ -914,6 +907,7 @@ export class JobHost {
             // Never ran, and the gate says so — the same `abandoned` as a run whose body was
             // already going, told apart by the one field that knows the difference.
             gates: [didNotRun],
+            checks: [{ gate: jobGate(job), executed: false, exitCode: null }],
             reason:
               `this host was asked to stop while ${job.slug} was still being admitted, ` +
               "so the run was never started",
@@ -932,19 +926,25 @@ export class JobHost {
           throw new Error(`external dispatch uncertain for run ${runId}; retrieve its status before retrying`);
         }
         if (status.state === "finished") {
-          const run = externalRun(request, status);
+          const run = { ...externalRun(request, status),
+            ...(status.outcome === "skipped-overlap" ? {} : { deadlineAt: status.startedAt + jobDeadlineMs(job) }) };
+          this.observeRun(run);
           return { runId, refused: run, finished: Promise.resolve(run) };
         }
+        base.startedAt = status.startedAt;
+        this.observeStart(base, status.startedAt + jobDeadlineMs(job));
         // A gateway shutdown stops observation only. Kubernetes still owns the worker,
         // deadline and durable record, so shutdown must never mark this run abandoned.
         const finished = this.opts.external!.wait(request, this.externalWaits.signal).then(async (run) => {
-          this.opts.onRun?.(run);
+          run.deadlineAt = base.deadlineAt;
+          this.observeRun(run);
           await this.settle(job, run, detached, answer);
           return run;
         });
         return { runId, refused: null, finished };
       }
       running = true;
+      this.observeStart(base, Date.now() + jobDeadlineMs(job));
       if (detached) this.owed.set(runId, () => this.giveUp(job, base, admission, answer));
       return {
         runId,
@@ -988,13 +988,14 @@ export class JobHost {
   private async execute(
     job: JobConfig,
     base: RunBase,
-  ): Promise<Pick<JobRun, "outcome" | "gates" | "reason" | "execution">> {
-    const verdictPath = join(await this.workDir(), `${job.slug}-${base.runId}.json`);
+  ): Promise<Pick<JobRun, "outcome" | "gates" | "reason" | "execution" | "work" | "checks" | "reportStatus">> {
+    let verdictPath: string;
     const unstarted = verdictFromGate({ gate: jobGate(job), executed: false, exitCode: null });
 
     let env: NodeJS.ProcessEnv;
     let channel: HostedMcp | undefined;
     try {
+      verdictPath = join(await this.workDir(), `${job.slug}-${base.runId}.json`);
       channel = await this.openChannel(job);
       env = this.envelope(job, base, verdictPath, channel);
     } catch (error) {
@@ -1020,23 +1021,27 @@ export class JobHost {
         outcome: "crashed",
         execution,
         gates: [unstarted],
+        checks: [{ gate: jobGate(job), executed: false, exitCode: null }],
         reason: `the job body could not be started: ${errorLine(error)}`,
       };
     }
     // Closed the moment the body is: this listener exists for one run, and one that
     // outlived its body would be a port on this host with a live token and nothing left
     // that legitimately holds it.
-    const execution = await this.spawnBody(job, env).finally(() => channel?.close());
+    const execution = await this.spawnBody(job, env, base).finally(() => channel?.close());
 
     if (!execution.started) {
       return {
         outcome: "crashed",
         execution: execution.info,
         gates: [unstarted],
+        checks: [{ gate: jobGate(job), executed: false, exitCode: null }],
         reason: `the job body could not be started: ${job.run.command} did not run`,
       };
     }
-    const gates = await this.readGates(verdictPath, job);
+    const report = await this.readReport(verdictPath, job);
+    const { gates, work, reportStatus } = report;
+    const checks = [{ gate: jobGate(job), executed: true, exitCode: execution.exitCode }, ...report.checks];
 
     // A body this host stopped never got to speak, whatever it managed to exit with on the
     // way out — a job told to stop has not finished its work, so a 0 from it is not a
@@ -1053,6 +1058,7 @@ export class JobHost {
         outcome: "budget-bowout",
         execution: execution.info,
         gates: [processGate, ...gates],
+      work, checks, reportStatus,
         reason:
           `the job body was still running after its ${job.budget.wallClockMs}ms wall clock ` +
           `and was asked to stop, with ${job.budget.deadlineHeadroomMs}ms to finish writing`,
@@ -1063,6 +1069,7 @@ export class JobHost {
         outcome: "crashed",
         execution: execution.info,
         gates: [processGate, ...gates],
+      work, checks, reportStatus,
         reason: `the job body died on ${execution.signal ?? "an unreported signal"}`,
       };
     }
@@ -1072,6 +1079,7 @@ export class JobHost {
       outcome: "completed",
       execution: execution.info,
       gates: [processGate, ...gates],
+      work, checks, reportStatus,
       reason: `the job body exited ${execution.exitCode}`,
     };
   }
@@ -1101,25 +1109,27 @@ export class JobHost {
     });
   }
 
-  private spawnBody(job: JobConfig, env: NodeJS.ProcessEnv): Promise<Execution> {
+  private spawnBody(job: JobConfig, env: NodeJS.ProcessEnv, base: RunBase): Promise<Execution> {
     return new Promise<Execution>((resolve) => {
       const knownSecrets = [...(this.opts.diagnosticSecrets ?? []), ...Object.keys({ ...job.run.secrets, ...job.run.jobSecrets })
         .map((name) => env[name]).filter((value): value is string => Boolean(value))];
-      const stdout = job.worker && diagnosticOutput(knownSecrets, (text) => {
-        if (!process.stdout.write(text)) child.stdout?.pause();
+      const capture = Boolean(job.worker || this.opts.workEvents);
+      const stdout = capture && diagnosticOutput(knownSecrets, (text) => {
+        if (!(this.opts.workEvents ? writeJobDiagnostic("stdout", text) : process.stdout.write(text))) child.stdout?.pause();
       });
-      const stderr = job.worker && diagnosticOutput(knownSecrets, (text) => {
-        if (!process.stderr.write(text)) child.stderr?.pause();
+      const stderr = capture && diagnosticOutput(knownSecrets, (text) => {
+        if (!(this.opts.workEvents ? writeJobDiagnostic("stderr", text) : process.stderr.write(text))) child.stderr?.pause();
       });
       let info: ExecutionInfo = { state: "starting", startedAt: Date.now(), exitCode: null, signal: null };
+      base.execution = info;
       const publish = (complete = false) => {
-        if (stdout && stderr) this.reportDiagnostics({ execution: info, stdout: stdout.snapshot(), stderr: stderr.snapshot(), complete });
+        if (job.worker && stdout && stderr) this.reportDiagnostics({ execution: info, stdout: stdout.snapshot(), stderr: stderr.snapshot(), complete });
       };
       // `command` + `args[]` is the whole interface: no shell, so nothing can be word-split
       // or interpolated into one. Only the bundle ever names these — never a channel
       // message, an issue body, or a webhook payload.
       const child = spawn(job.run.command, job.run.args, {
-        stdio: ["ignore", job.worker ? "pipe" : "inherit", job.worker ? "pipe" : "inherit"],
+        stdio: ["ignore", capture ? "pipe" : "inherit", capture ? "pipe" : "inherit"],
         env,
         // Its own process group, so stopping a job stops what the job started. Every
         // real job body shells out — to a coding harness, to a test run, to `gh` — and
@@ -1137,11 +1147,12 @@ export class JobHost {
       if (stdout && stderr) {
         // Keep the forwarding buffers bounded when the container's log sink is slow.
         process.stdout.on("drain", resumeOut);
-        process.stderr.on("drain", resumeErr);
+        (this.opts.workEvents ? process.stdout : process.stderr).on("drain", resumeErr);
         child.stdout!.setEncoding("utf8").on("data", (text: string) => stdout.write(text));
         child.stderr!.setEncoding("utf8").on("data", (text: string) => stderr.write(text));
-        child.once("spawn", () => { info = { ...info, state: "running" }; publish(); });
+
       }
+      child.once("spawn", () => { base.execution = info = { ...info, state: "running" }; publish(); });
       const checkpoint = job.worker ? setInterval(() => publish(), 1000) : undefined;
 
       /** The group, not the process. Already-gone is not a failure to stop something. */
@@ -1163,16 +1174,16 @@ export class JobHost {
       const bowOut = setTimeout(() => {
         bowedOut = true;
         stop("SIGTERM");
-      }, job.budget.wallClockMs);
-      const hardStop = setTimeout(() => stop("SIGKILL"), jobDeadlineMs(job));
+      }, base.deadlineAt === undefined ? job.budget.wallClockMs : Math.max(0, Number(env.JOB_DEADLINE_AT) - Date.now()));
+      const hardStop = setTimeout(() => stop("SIGKILL"), base.deadlineAt === undefined ? jobDeadlineMs(job) : Math.max(0, base.deadlineAt - Date.now()));
 
       const settle = (execution: Execution) => {
         clearTimeout(bowOut);
         clearTimeout(hardStop);
         if (checkpoint) clearInterval(checkpoint);
-        if (job.worker) {
+        if (capture) {
           process.stdout.removeListener("drain", resumeOut);
-          process.stderr.removeListener("drain", resumeErr);
+          (this.opts.workEvents ? process.stdout : process.stderr).removeListener("drain", resumeErr);
           process.removeListener("SIGTERM", interrupt);
           stdout && stdout.end(); stderr && stderr.end();
           info = {
@@ -1181,6 +1192,7 @@ export class JobHost {
             state: !execution.started ? "not-started" : bowedOut ? "timed-out" : interrupted ? "interrupted"
               : execution.signal ? "signalled" : "exited",
           };
+          base.execution = info;
           execution.info = info;
           execution.interrupted = interrupted;
           publish(true);
@@ -1194,7 +1206,7 @@ export class JobHost {
         else settle({ started: false, exitCode: null, signal: null, bowedOut: false });
       });
       // Drain the pipes before sealing a worker's diagnostics; exit can precede stderr.
-      if (job.worker) child.once("close", (exitCode, signal) => settle({ started: !startFailed, exitCode, signal, bowedOut }));
+      if (capture) child.once("close", (exitCode, signal) => settle({ started: !startFailed, exitCode, signal, bowedOut }));
       child.on("exit", (exitCode, signal) => {
         // The job is over when its body is, so nothing the body started may outlive it.
         //
@@ -1210,7 +1222,7 @@ export class JobHost {
         // would have been grouped with is already gone. Nothing a host does closes that —
         // there is no group left to signal. The container boundary is what covers it.
         stop("SIGKILL");
-        if (!job.worker) settle({ started: true, exitCode, signal, bowedOut });
+        if (!capture) settle({ started: true, exitCode, signal, bowedOut });
       });
     });
   }
@@ -1264,8 +1276,9 @@ export class JobHost {
       JOB_RUN_ID: base.runId,
       JOB_TRIGGER: base.trigger,
       JOB_VERDICT_PATH: verdictPath,
+      JOB_WORK_SCHEMA_VERSION: this.opts.workEvents ? "1" : "",
       /** When this host will ask the body to stop. The body should bow out before it. */
-      JOB_DEADLINE_AT: String(Date.now() + job.budget.wallClockMs),
+      JOB_DEADLINE_AT: String((base.deadlineAt ?? Date.now() + jobDeadlineMs(job)) - job.budget.deadlineHeadroomMs),
       JOB_HARNESS_TIMEOUT_MS: String(job.budget.harnessTimeoutMs),
       JOB_MAX_ITERATIONS: String(job.budget.maxIterations),
       JOB_MAX_ATTEMPTS: String(job.budget.maxAttempts),
@@ -1295,35 +1308,37 @@ export class JobHost {
    * handle it. A job that ran, exited 0, and reported nothing has proven nothing, and an
    * empty gate list says so in the body's own words.
    */
-  private async readGates(verdictPath: string, job: JobConfig): Promise<readonly Verdict[]> {
-    const unproven = [
-      verdictFromGate({ gate: `${jobGate(job)}:verdict`, executed: false, exitCode: null }),
-    ];
+  private async readReport(verdictPath: string, job: JobConfig): Promise<{
+    gates: readonly Verdict[]; checks: readonly WorkCheck[]; work?: WorkReport; reportStatus: JobRun["reportStatus"];
+  }> {
+    const missing = { gate: `${jobGate(job)}:verdict`, executed: false, exitCode: null };
+    const unproven = { gates: [verdictFromGate(missing)], checks: [] };
     try {
       let artifact: string;
-      if (!job.worker) artifact = await readFile(verdictPath, "utf8");
-      else {
-        const file = await open(verdictPath, "r");
-        try {
-          const buffer = Buffer.alloc(64 * 1024 + 1);
-          let bytesRead = 0;
-          while (bytesRead < buffer.length) {
-            const chunk = await file.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead);
-            if (!chunk.bytesRead) break;
-            bytesRead += chunk.bytesRead;
-          }
-          if (bytesRead > 64 * 1024) return unproven;
-          artifact = buffer.toString("utf8", 0, bytesRead);
-        } finally { await file.close(); }
-      }
+      const file = await open(verdictPath, "r");
+      try {
+        const buffer = Buffer.alloc(MAX_WORK_REPORT_BYTES + 1);
+        let bytesRead = 0;
+        while (bytesRead < buffer.length) {
+          const chunk = await file.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead);
+          if (!chunk.bytesRead) break;
+          bytesRead += chunk.bytesRead;
+        }
+        if (bytesRead > MAX_WORK_REPORT_BYTES) return { ...unproven, reportStatus: "oversized" };
+        artifact = buffer.toString("utf8", 0, bytesRead);
+      } finally { await file.close(); }
       const parsed = VerdictArtifactSchema.safeParse(JSON.parse(artifact));
-      if (!parsed.success || parsed.data.gates.length === 0) return unproven;
-      return parsed.data.gates.map(verdictFromGate);
-    } catch {
-      return unproven;
+      if (!parsed.success) return { ...unproven, reportStatus: "invalid" };
+      const { gates, ...work } = parsed.data;
+      return {
+        gates: gates.length ? gates.map(verdictFromGate) : unproven.gates,
+        checks: gates.length ? gates.map(({ gate, executed, exitCode }) => ({ gate, executed, exitCode })) : unproven.checks,
+        work: Object.keys(work).length ? work : undefined,
+        reportStatus: "valid",
+      };
+    } catch (error) {
+      return { ...unproven, reportStatus: (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "invalid" };
     } finally {
-      // The gates are in the record now; leaving the file behind would accumulate one per
-      // tick on a host that runs a job every ten minutes.
       await rm(verdictPath, { force: true }).catch(() => {});
     }
   }
@@ -1338,8 +1353,22 @@ export class JobHost {
 
   private record(run: Omit<JobRun, "endedAt" | "verdict">): JobRun {
     const complete = this.seal(run);
-    this.opts.onRun?.(complete);
+    this.observeRun(complete);
     return complete;
+  }
+
+  private observeStart(base: RunBase, deadlineAt: number): void {
+    if (!this.opts.onStart) return;
+    base.deadlineAt = deadlineAt;
+    const { jobSlug, runId, trigger, startedAt } = base;
+    try {
+      Promise.resolve(this.opts.onStart?.({ jobSlug, runId, trigger, startedAt, admittedAt: Date.now(), deadlineAt })).catch(() => {});
+    } catch { /* Observers cannot change admission. */ }
+  }
+
+  private observeRun(run: JobRun): void {
+    try { Promise.resolve(this.opts.onRun?.(run)).catch(() => {}); }
+    catch { /* Observers cannot change settlement. */ }
   }
 
   /**

--- a/packages/core/src/work-events.ts
+++ b/packages/core/src/work-events.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+import type { JobHostOptions, JobRun } from "./job-host.ts";
+
+const identifier = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_.:/-]{0,255}$/);
+const slug = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/);
+const count = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const subject = z.object({
+  provider: slug,
+  kind: z.enum(["issue", "pull_request", "document", "artifact", "agent", "service", "job"]),
+  id: identifier,
+  scope: identifier.optional(),
+}).strict();
+const facts = {
+  observed_at: z.iso.datetime({ offset: true }).optional(),
+  related_to: subject.optional(),
+  next_actor: slug.optional(),
+};
+
+// Identifiers and measured facts only: never titles, prose, URLs, or diagnostics.
+// These are producer reports, not independently confirmed external outcomes.
+export const WorkReportSchema = z.object({
+  artifacts: z.array(z.object({
+    subject, ...facts,
+    action: z.enum(["created", "updated", "commented", "completed"]),
+  }).strict()).max(100).optional(),
+  work_observations: z.array(z.object({
+    subject, ...facts,
+    state: z.enum(["open", "in_progress", "waiting", "blocked", "completed", "closed", "unknown"]),
+  }).strict()).max(100).optional(),
+  usage: z.object({
+    model_calls: count.optional(),
+    input_tokens: count.optional(),
+    output_tokens: count.optional(),
+    cost_usd: z.number().nonnegative().optional(),
+    scanned: count.optional(),
+    candidates: count.optional(),
+    recommendations: count.optional(),
+    findings: count.optional(),
+    outputs: count.optional(),
+  }).strict().optional(),
+  health: z.array(z.object({
+    subject,
+    check: slug,
+    status: z.enum(["healthy", "degraded", "unhealthy", "unknown"]),
+    observed_at: z.iso.datetime({ offset: true }),
+  }).strict()).max(100).optional(),
+  partial: z.boolean().optional(),
+}).strict();
+export type WorkReport = z.infer<typeof WorkReportSchema>;
+
+// Preserve the strict gates-only transport, including historical free-form details.
+// Only the host mints verdicts; a producer-supplied `status` invalidates the file.
+export const VerdictArtifactSchema = WorkReportSchema.extend({
+  gates: z.array(z.object({
+    gate: z.string().min(1),
+    executed: z.boolean(),
+    exitCode: z.number().int().nullable(),
+    detail: z.string().optional(),
+  }).strict()),
+}).strict();
+export type WorkCheck = { gate: string; executed: boolean; exitCode: number | null };
+export type WorkStart = Pick<JobRun, "jobSlug" | "runId" | "trigger" | "startedAt"> & {
+  admittedAt: number;
+  deadlineAt: number;
+};
+
+// Includes the reserved wrapper and newline, below common container log buffers.
+export const MAX_WORK_EVENT_BYTES = 8 * 1024;
+export const MAX_WORK_REPORT_BYTES = 64 * 1024;
+
+export function workEventLine(event: Record<string, unknown>): string {
+  const bounded = { ...event };
+  const encode = () => JSON.stringify({ sageox_work_event: bounded }) + "\n";
+  let line = encode();
+  // Omit whole optional items, never truncate JSON or lose lifecycle identity/outcome.
+  for (const field of ["health", "work_observations", "artifacts", "checks", "usage"]) {
+    if (Buffer.byteLength(line) <= MAX_WORK_EVENT_BYTES) break;
+    bounded.partial = true;
+    const value = bounded[field];
+    if (Array.isArray(value)) {
+      const remaining = [...value];
+      bounded[field] = remaining;
+      do {
+        remaining.pop();
+        if (!remaining.length) delete bounded[field];
+        line = encode();
+      } while (remaining.length && Buffer.byteLength(line) > MAX_WORK_EVENT_BYTES);
+    } else {
+      delete bounded[field];
+      line = encode();
+    }
+  }
+  if (Buffer.byteLength(line) > MAX_WORK_EVENT_BYTES) throw new Error("work event identity exceeds byte limit");
+  return line;
+}
+
+const resumeAfterOutputError = () => { process.stdout.emit("drain"); };
+
+/** Output errors (including asynchronous EPIPE) are observation loss, never job failure. */
+function writeWorkLine(line: string): boolean {
+  try {
+    if (process.stdout.destroyed || !process.stdout.writable) return true;
+    if (!process.stdout.listeners("error").includes(resumeAfterOutputError)) {
+      process.stdout.on("error", resumeAfterOutputError);
+    }
+    return process.stdout.write(line);
+  } catch { return true; }
+}
+
+/** The stream is decoded as UTF-8 before calling this. Never parse diagnostic text. */
+export function writeJobDiagnostic(stream: "stdout" | "stderr" | "host", text: string): boolean {
+  let ready = true;
+  // 1,024 code units fit even at JSON's 6x escape expansion. Do not split a code point.
+  for (let offset = 0; offset < text.length;) {
+    let end = Math.min(text.length, offset + 1024);
+    if (end < text.length && /[\uD800-\uDBFF]/.test(text[end - 1]!)) end--;
+    ready = writeWorkLine(JSON.stringify({ job_diagnostic: { stream, text: text.slice(offset, end) } }) + "\n") && ready;
+    offset = end;
+  }
+  return ready;
+}
+
+/** Both CLI hosts bind this; logging is independent of any downstream reader. */
+export function jobWorkEvents(
+  agent: string,
+  env: NodeJS.ProcessEnv = process.env,
+  write: (line: string) => void = writeWorkLine,
+): Pick<JobHostOptions, "onStart" | "onRun" | "workEvents"> {
+  if (env.AGENT_WORK_EVENTS !== "1") return {};
+  const emit = (event: Record<string, unknown>) => {
+    try { Promise.resolve(write(workEventLine(event))).catch(() => {}); } catch { /* Best-effort observation only. */ }
+  };
+  const identity = (run: WorkStart | JobRun) => ({
+    schema_version: 1, agent, job: run.jobSlug, run_id: run.runId,
+    trigger: run.trigger, started_at: new Date(run.startedAt).toISOString(),
+    ...(run.deadlineAt === undefined ? {} : { deadline_at: new Date(run.deadlineAt).toISOString() }),
+  });
+  return {
+    workEvents: true,
+    onStart: (run) => emit({ ...identity(run), event: "run.started",
+      occurred_at: new Date(run.admittedAt).toISOString() }),
+    onRun: (run) => {
+      const report = WorkReportSchema.safeParse(run.work ?? {});
+      // Gate names are identifiers; historical free-text names are omitted, not copied.
+      const checks = (run.checks ?? []).map(({ gate, executed, exitCode }, index) => ({
+        gate, executed, exit_code: exitCode, source: index === 0 ? "host" : "producer",
+      })).filter((c) => /^[a-zA-Z0-9_.:-]{1,128}$/.test(c.gate));
+      emit({ ...identity(run), event: "run.completed", occurred_at: new Date(run.endedAt).toISOString(),
+        outcome: run.outcome, verdict: run.verdict.status, checks,
+        execution: run.execution,
+        report_status: run.reportStatus,
+        ...(report.success ? report.data : {}),
+        partial: !report.success || report.data.partial === true ||
+          (run.reportStatus !== undefined && run.reportStatus !== "valid") ||
+          run.checks === undefined || checks.length !== run.checks.length,
+      });
+    },
+  };
+}

--- a/packages/core/src/work-events.ts
+++ b/packages/core/src/work-events.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 import type { JobHostOptions, JobRun } from "./job-host.ts";
 
-const identifier = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_.:/-]{0,255}$/)
-  .refine((value) => !value.includes("://"), "expected an identifier, not a URL");
+const identifier = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_./-]{0,255}$/);
 const slug = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/);
 const count = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
 const subject = z.object({

--- a/packages/core/src/work-events.ts
+++ b/packages/core/src/work-events.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import type { JobHostOptions, JobRun } from "./job-host.ts";
 
-const identifier = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_.:/-]{0,255}$/);
+const identifier = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9_.:/-]{0,255}$/)
+  .refine((value) => !value.includes("://"), "expected an identifier, not a URL");
 const slug = z.string().regex(/^[a-z][a-z0-9-]{0,63}$/);
 const count = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
 const subject = z.object({
@@ -61,13 +62,14 @@ export const VerdictArtifactSchema = WorkReportSchema.extend({
 export type WorkCheck = { gate: string; executed: boolean; exitCode: number | null };
 export type WorkStart = Pick<JobRun, "jobSlug" | "runId" | "trigger" | "startedAt"> & {
   admittedAt: number;
-  deadlineAt: number;
+  deadlineMs: number;
 };
 
 // Includes the reserved wrapper and newline, below common container log buffers.
 export const MAX_WORK_EVENT_BYTES = 8 * 1024;
 export const MAX_WORK_REPORT_BYTES = 64 * 1024;
 
+/** Bound a JSONL record by dropping optional facts while preserving lifecycle identity. */
 export function workEventLine(event: Record<string, unknown>): string {
   const bounded = { ...event };
   const encode = () => JSON.stringify({ sageox_work_event: bounded }) + "\n";
@@ -133,7 +135,7 @@ export function jobWorkEvents(
   const identity = (run: WorkStart | JobRun) => ({
     schema_version: 1, agent, job: run.jobSlug, run_id: run.runId,
     trigger: run.trigger, started_at: new Date(run.startedAt).toISOString(),
-    ...(run.deadlineAt === undefined ? {} : { deadline_at: new Date(run.deadlineAt).toISOString() }),
+    ...(run.deadlineMs === undefined ? {} : { deadline_ms: run.deadlineMs }),
   });
   return {
     workEvents: true,

--- a/packages/core/test/job-dispatcher.test.ts
+++ b/packages/core/test/job-dispatcher.test.ts
@@ -649,3 +649,28 @@ it.each([false, true])("reads short verdict chunks completely while preserving t
     expect(reads.mock.calls.length).toBeGreaterThan(1);
   } finally { reads.mockRestore(); await rm(dir, { recursive: true, force: true }); }
 });
+
+it.each(["pending", "finished", "skipped-overlap"] as const)("reports external %s observation with its existing run ID despite throwing observers", async (state) => {
+  const { jobWorkEvents } = await import("../src/work-events.ts");
+  const job = manifest().jobs[0]!;
+  const remote = new ExternalJobs("http://unused", "unused");
+  const terminal = (req: ExternalRequest) => ({
+    runId: req.runId, jobSlug: req.jobSlug, startedAt: req.startedAt, endedAt: req.startedAt + 50,
+    state: "finished" as const, outcome: state === "skipped-overlap" ? "skipped-overlap" as const : "completed" as const,
+    ...(state === "skipped-overlap" ? {} : { result: { outcome: "completed" as const, counts: { PASS: 1, FAIL: 0, UNKNOWN: 0 } } }),
+  });
+  vi.spyOn(remote, "dispatch").mockImplementation(async (req) => state === "pending"
+    ? { runId: req.runId, jobSlug: req.jobSlug, startedAt: req.startedAt, state: "pending" }
+    : terminal(req));
+  vi.spyOn(remote, "wait").mockImplementation(async (req) => externalRun(req, terminal(req)));
+  const events: Array<Record<string, any>> = [];
+  const observer = jobWorkEvents("demo", { AGENT_WORK_EVENTS: "1" }, (line) => events.push(JSON.parse(line).sageox_work_event));
+  const host = new JobHost({ external: remote, ...observer,
+    onStart: (run) => { observer.onStart!(run); throw new Error("observer failed"); },
+    onRun: (run) => { observer.onRun!(run); throw new Error("observer failed"); },
+  });
+  const run = await host.request(job, { kind: "human", id: "owner" });
+  expect(events.map((e) => e.event)).toEqual(state === "pending" ? ["run.started", "run.completed"] : ["run.completed"]);
+  expect(events.at(-1)).toMatchObject({ run_id: run.runId, outcome: run.outcome, partial: true });
+  expect(events.every((e) => e.run_id === run.runId)).toBe(true);
+});

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -222,6 +222,7 @@ describe("bounding", () => {
     // it managed to say on the way out.
     expect(run.outcome).toBe("budget-bowout");
     expect(run.verdict.status).toBe("UNKNOWN");
+    expect(run.checks?.[0]).toEqual({ gate: "job:sweep", executed: true, exitCode: null });
   });
 
   it("stops what the body left behind when the body exits under its budget", async () => {
@@ -930,7 +931,7 @@ describe("structured work lifecycle", () => {
   it("emits admission before completion for both scheduled and requested runs", async () => {
     const events: string[] = [];
     const h = new JobHost({ workDir, env: { ...process.env, MARKER: marker },
-      onStart: (r) => { events.push(`start:${r.trigger}`); expect(r.deadlineAt).toBeGreaterThan(r.startedAt); },
+      onStart: (r) => { events.push(`start:${r.trigger}`); expect(r.deadlineMs).toBe(jobDeadlineMs(job())); },
       onRun: (r) => events.push(`end:${r.trigger}`), workEvents: true,
     });
     const report = { gates: [{ gate: "ci", executed: true, exitCode: 0 }],
@@ -988,7 +989,7 @@ it("reports refusal, overlap, failure and timeout without confusing admission wi
   for (const run of [failed, timeout]) {
     const own = events.filter((event) => event.run_id === run.runId);
     expect(own.map((event) => event.event)).toEqual(["run.started", "run.completed"]);
-    expect(own[1]).toMatchObject({ outcome: run.outcome, verdict: run.verdict.status, deadline_at: own[0]!.deadline_at });
+    expect(own[1]).toMatchObject({ outcome: run.outcome, verdict: run.verdict.status, deadline_ms: own[0]!.deadline_ms });
   }
   expect(failed.verdict.status).toBe("FAIL");
   expect(timeout.outcome).toBe("budget-bowout");
@@ -1042,4 +1043,22 @@ it("keeps running and releases single-flight when event and diagnostic output th
     }
     expect(spawns()).toBe(2);
   } finally { sink.mockRestore(); }
+});
+
+it.each([false, true])("gives the process its full budget after slow setup (events=%s)", async (enabled) => {
+  const { jobWorkEvents } = await import("../src/work-events.ts");
+  const h = new JobHost({ workDir, ...jobWorkEvents("worker", { AGENT_WORK_EVENTS: enabled ? "1" : "0" }, () => {}) });
+  vi.useFakeTimers({ toFake: ["Date"] });
+  // Advance setup time without sleeping; process timers remain real.
+  const setup = vi.spyOn(h as unknown as { workDir(): Promise<string> }, "workDir").mockImplementation(async () => {
+    vi.setSystemTime(Date.now() + 700);
+    return workDir;
+  });
+  try {
+    const run = await h.tick(body(`${WRITE}JSON.stringify({gates:[{gate:"ci",executed:true,exitCode:0}]}))`,
+      { budget: "{wallClockMs: 500, deadlineHeadroomMs: 100}" }));
+    expect(run.outcome).toBe("completed");
+    expect(run.verdict.status).toBe("PASS");
+    expect(run.deadlineMs).toBe(600);
+  } finally { setup.mockRestore(); vi.useRealTimers(); }
 });

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -924,4 +924,122 @@ describe("the status post", () => {
     expect(run.verdict.status).toBe("UNKNOWN");
     expect(posts).toEqual([]);
   });
+});
+
+describe("structured work lifecycle", () => {
+  it("emits admission before completion for both scheduled and requested runs", async () => {
+    const events: string[] = [];
+    const h = new JobHost({ workDir, env: { ...process.env, MARKER: marker },
+      onStart: (r) => { events.push(`start:${r.trigger}`); expect(r.deadlineAt).toBeGreaterThan(r.startedAt); },
+      onRun: (r) => events.push(`end:${r.trigger}`), workEvents: true,
+    });
+    const report = { gates: [{ gate: "ci", executed: true, exitCode: 0 }],
+      artifacts: [{ subject: { provider: "github", scope: "example/repo", kind: "issue", id: "42" }, action: "created" }] };
+    const script = `${WRITE}JSON.stringify(${JSON.stringify(report)}));`;
+    const scheduled = await h.tick(body(script));
+    const requested = await h.request(body(script), { kind: "system", id: "cli" });
+    expect(events).toEqual(["start:schedule", "end:schedule", "start:on-request", "end:on-request"]);
+    expect(scheduled.work?.artifacts).toEqual(report.artifacts);
+    expect(requested.work?.artifacts).toEqual(report.artifacts);
+    expect(requested.checks?.some((c) => c.gate === "ci" && c.executed && c.exitCode === 0)).toBe(true);
+  });
+
+  it("denied requests have a terminal record without a start", async () => {
+    const events: string[] = [];
+    const h = new JobHost({ workDir, onStart: () => events.push("start"), onRun: () => events.push("end") });
+    const result = await h.tick(job({ trigger: '{onRequest: true}' }));
+    expect(result.outcome).toBe("denied-trigger");
+    expect(events).toEqual(["end"]);
+  });
+
+  it("observer failures cannot prevent the job or its result", async () => {
+    const h = new JobHost({ workDir, env: { ...process.env, MARKER: marker },
+      onStart: () => { throw new Error("observer"); }, onRun: () => { throw new Error("observer"); } });
+    expect((await h.tick(body(PROVES))).outcome).toBe("completed");
+    expect(spawns()).toBe(1);
+  });
+
+  it("advertises report capability only when diagnostic isolation is enabled", async () => {
+    for (const enabled of [false, true]) {
+      const h = new JobHost({ workDir, workEvents: enabled });
+      const expected = enabled ? "1" : "";
+      const result = await h.tick(body(`if(process.env.JOB_WORK_SCHEMA_VERSION!==${JSON.stringify(expected)})process.exit(1);${WRITE}JSON.stringify({gates:[{gate:"capability",executed:true,exitCode:0}]}));`));
+      expect(result.verdict.status).toBe("PASS");
+    }
+  });
+});
+
+it("reports refusal, overlap, failure and timeout without confusing admission with execution", async () => {
+  const { jobWorkEvents } = await import("../src/work-events.ts");
+  const events: Array<Record<string, any>> = [];
+  const h = new JobHost({ workDir, ...jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" },
+    (line) => events.push(JSON.parse(line).sageox_work_event)) });
+  const slow = body('setTimeout(()=>process.exit(1),150)');
+  const first = h.tick(slow);
+  const overlap = await h.tick(slow);
+  const failed = await first;
+  const timeout = await h.tick(body('setInterval(()=>{},1000)', { budget: '{wallClockMs: 150, deadlineHeadroomMs: 100}' }));
+  const refused = await h.tick(job({ suspend: "true" }));
+  for (const run of [overlap, refused]) {
+    const own = events.filter((event) => event.run_id === run.runId);
+    expect(own).toHaveLength(1);
+    expect(own[0]).toMatchObject({ event: "run.completed", checks: [{ executed: false, exit_code: null }] });
+  }
+  for (const run of [failed, timeout]) {
+    const own = events.filter((event) => event.run_id === run.runId);
+    expect(own.map((event) => event.event)).toEqual(["run.started", "run.completed"]);
+    expect(own[1]).toMatchObject({ outcome: run.outcome, verdict: run.verdict.status, deadline_at: own[0]!.deadline_at });
+  }
+  expect(failed.verdict.status).toBe("FAIL");
+  expect(timeout.outcome).toBe("budget-bowout");
+  expect(timeout.execution?.state).toBe("timed-out");
+});
+
+it.each([
+  ["missing", ""],
+  ["invalid", `${WRITE}'{"gates":[],"summary":"private text"}')`],
+  ["invalid", `${WRITE}'{broken')`],
+  ["oversized", `${WRITE}' '.repeat(65537))`],
+])("does not invent work from a %s report", async (status, script) => {
+  const run = await new JobHost({ workDir }).tick(body(script));
+  expect(run.outcome).toBe("completed");
+  expect(run.verdict.status).toBe("UNKNOWN");
+  expect(run.reportStatus).toBe(status);
+  expect(run.work).toBeUndefined();
+  expect(run.checks).toEqual([{ gate: "job:sweep", executed: true, exitCode: 0 }]);
+});
+
+it("retains unknown subject health, zero counters, and partial work independently of passing gates", async () => {
+  const report = { gates: [{ gate: "monitor", executed: true, exitCode: 0 }],
+    health: [{ subject: { provider: "runtime", kind: "service", id: "api" }, check: "readiness", status: "unknown", observed_at: "2026-09-07T00:00:00Z" }],
+    usage: { scanned: 0 }, partial: true };
+  const run = await new JobHost({ workDir }).tick(body(`${WRITE}JSON.stringify(${JSON.stringify(report)}))`));
+  expect(run.verdict.status).toBe("PASS");
+  expect(run.work).toEqual({ health: report.health, usage: { scanned: 0 }, partial: true });
+  expect(run.work!.usage).not.toHaveProperty("model_calls");
+});
+
+it("settles setup failures and throwing asynchronous observers", async () => {
+  const runs: JobRun[] = [];
+  const h = new JobHost({ workDir: marker, onStart: async () => { throw new Error("observer"); },
+    onRun: async (run) => { runs.push(run); throw new Error("observer"); } });
+  await writeFile(marker, "not a directory");
+  const run = await h.tick(body(""));
+  expect(run.outcome).toBe("crashed");
+  expect(run.checks?.[0]?.executed).toBe(false);
+  expect(runs).toEqual([run]);
+});
+
+it("keeps running and releases single-flight when event and diagnostic output throws", async () => {
+  const { jobWorkEvents } = await import("../src/work-events.ts");
+  const h = new JobHost({ workDir, env: { ...process.env, MARKER: marker },
+    ...jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }) });
+  const sink = vi.spyOn(process.stdout, "write").mockImplementation(() => { throw new Error("sink unavailable"); });
+  try {
+    for (let i = 0; i < 2; i++) {
+      const run = await h.tick(body(`console.log("diagnostic");${PROVES}`));
+      expect(run.verdict.status).toBe("PASS");
+    }
+    expect(spawns()).toBe(2);
+  } finally { sink.mockRestore(); }
 });

--- a/packages/core/test/work-events.test.ts
+++ b/packages/core/test/work-events.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { jobWorkEvents, MAX_WORK_EVENT_BYTES, workEventLine, WorkReportSchema } from "../src/work-events.ts";
+import { verdictFromGate } from "../src/verdict.ts";
+import type { JobRun } from "../src/job-host.ts";
+
+const run: JobRun = {
+  jobSlug: "shift", runId: "opaque-upstream-run", trigger: "schedule", requestedBy: { kind: "human", id: "secret-requester" },
+  startedAt: 1000, endedAt: 2000, outcome: "completed", switch: null, bypassedSwitch: false,
+  parameters: { private: "secret-param" }, reason: "secret-reason", gates: [],
+  verdict: verdictFromGate({ gate: "ci", executed: true, exitCode: 0 }),
+  checks: [{ gate: "ci", executed: true, exitCode: 0 }],
+  work: { artifacts: [{ subject: { provider: "github", scope: "example/repo", kind: "pull_request", id: "42" }, action: "created" }] },
+};
+
+describe("work events", () => {
+  it("requires opt-in and drops free text while preserving facts", () => {
+    expect(jobWorkEvents("worker", {})).toEqual({});
+    const lines: string[] = [];
+    const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, (line) => lines.push(line));
+    opts.onStart!({ ...run, admittedAt: 1000, deadlineAt: 6000 });
+    opts.onRun!(run);
+    expect(lines).toHaveLength(2);
+    expect(lines.join("")).not.toContain("secret");
+    const event = JSON.parse(lines[1]!).sageox_work_event;
+    expect(event.artifacts[0].subject.id).toBe("42");
+    expect(event.checks).toEqual([{ gate: "ci", executed: true, exit_code: 0, source: "host" }]);
+    expect(event.verdict).toBe("PASS");
+    expect(event.partial).toBe(false);
+  });
+
+  it("rejects untyped fields and impossible counts", () => {
+    for (const value of [ { summary: "secret" }, { artifacts: [{ ...run.work!.artifacts![0], repository: "../repo" }] }, { usage: { model_calls: -1 } },
+      { artifacts: [{ ...run.work!.artifacts![0], title: "secret" }] },
+      { health: [{ coworker: "worker", pod: "fine", chat: "RUNNING", lanes: [] }] } ]) {
+      expect(WorkReportSchema.safeParse(value).success).toBe(false);
+    }
+  });
+
+  it("counts UTF-8 bytes including wrapper and newline at the exact boundary", () => {
+    const base = { run_id: "id", event: "run.completed", artifacts: ["🚀"] };
+    const overhead = Buffer.byteLength(workEventLine(base));
+    const exact = { ...base, artifacts: ["🚀" + "a".repeat(MAX_WORK_EVENT_BYTES - overhead)] };
+    expect(Buffer.byteLength(workEventLine(exact))).toBe(MAX_WORK_EVENT_BYTES);
+    const overflow = JSON.parse(workEventLine({ ...exact, artifacts: [exact.artifacts[0] + "a"] })).sageox_work_event;
+    expect(overflow).toEqual({ run_id: "id", event: "run.completed", partial: true });
+  });
+
+  it("marks omitted unsafe check names and report overflow as partial", () => {
+    const lines: string[] = [];
+    const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, (line) => lines.push(line));
+    opts.onRun!({ ...run, checks: [{ gate: "a secret sentence", executed: true, exitCode: 0 }] });
+    expect(JSON.parse(lines[0]!).sageox_work_event.partial).toBe(true);
+    expect(lines[0]).not.toContain("secret");
+    opts.onRun!({ ...run, work: { partial: true } });
+    expect(JSON.parse(lines[1]!).sageox_work_event.partial).toBe(true);
+  });
+});
+
+it("preserves zero versus absent usage and rejects free text in every work field", () => {
+  expect(WorkReportSchema.parse({ usage: { scanned: 0, cost_usd: 0 } })).toEqual({ usage: { scanned: 0, cost_usd: 0 } });
+  expect(WorkReportSchema.parse({})).not.toHaveProperty("usage");
+  for (const usage of [{ scanned: 0.5 }, { input_tokens: Infinity }, { outputs: Number.MAX_SAFE_INTEGER + 1 }, { cost_usd: -1 }]) {
+    expect(WorkReportSchema.safeParse({ usage }).success).toBe(false);
+  }
+  expect(WorkReportSchema.safeParse({ work_observations: [{ subject: { provider: "github", kind: "issue", id: "53", scope: "sageox/agent-toolkit" }, state: "unknown" }] }).success).toBe(true);
+});
+
+it("contains output failures and keeps identity/outcome when optional facts overflow", () => {
+  const opts = jobWorkEvents("Agent with a display name", { AGENT_WORK_EVENTS: "1" }, () => { throw new Error("sink offline"); });
+  expect(() => opts.onRun!(run)).not.toThrow();
+  const event = { schema_version: 1, agent: "worker", run_id: "opaque-id", event: "run.completed", outcome: "completed", verdict: "FAIL",
+    health: Array.from({ length: 100 }, () => ({ subject: "🚀".repeat(100) })) };
+  const line = workEventLine(event);
+  expect(Buffer.byteLength(line)).toBeLessThanOrEqual(MAX_WORK_EVENT_BYTES);
+  expect(JSON.parse(line).sageox_work_event).toMatchObject({ run_id: "opaque-id", event: "run.completed", outcome: "completed", verdict: "FAIL", partial: true });
+  expect(event.health).toHaveLength(100);
+});
+
+it("contains asynchronous sink failures", async () => {
+  const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, async () => { throw new Error("sink unavailable"); });
+  opts.onRun!(run);
+  await new Promise((resolve) => setImmediate(resolve));
+});

--- a/packages/core/test/work-events.test.ts
+++ b/packages/core/test/work-events.test.ts
@@ -87,9 +87,17 @@ it("contains asynchronous sink failures", async () => {
   expect(calls).toBe(1);
 });
 
-it.each(["id", "scope"])("rejects URL-shaped subject %s values", (field) => {
+it.each(["id", "scope"])("rejects URI delimiters in subject %s values", (field) => {
   const artifact = run.work!.artifacts![0]!;
-  expect(WorkReportSchema.safeParse({ artifacts: [{ ...artifact,
-    subject: { ...artifact.subject, [field]: "https://example.com/private-token" },
-  }] }).success).toBe(false);
+  for (const value of ["https://example.com/private-token", "mailto:private-token", "urn:private-token",
+    "file:/tmp/private-token", "FILE:/tmp/private-token", "issue:42"]) {
+    expect(WorkReportSchema.safeParse({ artifacts: [{ ...artifact,
+      subject: { ...artifact.subject, [field]: value },
+    }] }).success, value).toBe(false);
+  }
+  for (const value of ["42", "issue-42", "example/repo", "a_b.c"]) {
+    expect(WorkReportSchema.safeParse({ artifacts: [{ ...artifact,
+      subject: { ...artifact.subject, [field]: value },
+    }] }).success, value).toBe(true);
+  }
 });

--- a/packages/core/test/work-events.test.ts
+++ b/packages/core/test/work-events.test.ts
@@ -17,7 +17,7 @@ describe("work events", () => {
     expect(jobWorkEvents("worker", {})).toEqual({});
     const lines: string[] = [];
     const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, (line) => lines.push(line));
-    opts.onStart!({ ...run, admittedAt: 1000, deadlineAt: 6000 });
+    opts.onStart!({ ...run, admittedAt: 1000, deadlineMs: 6000 });
     opts.onRun!(run);
     expect(lines).toHaveLength(2);
     expect(lines.join("")).not.toContain("secret");
@@ -77,7 +77,19 @@ it("contains output failures and keeps identity/outcome when optional facts over
 });
 
 it("contains asynchronous sink failures", async () => {
-  const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, async () => { throw new Error("sink unavailable"); });
+  let calls = 0;
+  const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, async () => {
+    calls++;
+    throw new Error("sink unavailable");
+  });
   opts.onRun!(run);
   await new Promise((resolve) => setImmediate(resolve));
+  expect(calls).toBe(1);
+});
+
+it.each(["id", "scope"])("rejects URL-shaped subject %s values", (field) => {
+  const artifact = run.work!.artifacts![0]!;
+  expect(WorkReportSchema.safeParse({ artifacts: [{ ...artifact,
+    subject: { ...artifact.subject, [field]: "https://example.com/private-token" },
+  }] }).success).toBe(false);
 });


### PR DESCRIPTION
Operators can enable `AGENT_WORK_EVENTS=1` to correlate admitted starts and terminal job results across scheduled jobs and the live host's MCP job tool. The existing verdict file accepts optional artifact, subject-state, measured usage, and health observations through the `JOB_WORK_SCHEMA_VERSION=1` capability handshake, while preserving gate verdict semantics.

```mermaid
flowchart LR
    A[Admission] -->|accepted| B[Host start event]
    A -->|refused or overlap| D[Host terminal event]
    B --> C[Job body]
    C -->|settlement and validated report| D
    C -->|stdout and stderr| E[Diagnostic envelope]
```

Lifecycle records retain the existing run ID and outcome, exclude free-form details and private request fields, and fit within 8 KiB including the envelope and newline. UTF-8 diagnostics are wrapped separately so event-shaped child output cannot become a host event. Throwing observers and disconnected log consumers do not fail the job. Declared deadline duration is metadata; reporting does not shorten the process budget or convert a stopped process into a passing check.

External-dispatch events preserve existing admission-based deadlines and dispatcher facts and explicitly mark unavailable individual checks/work metadata as partial. The contract documents unmatched starts, producer-reported versus independently confirmed outcomes, and the versioned-release prerequisite before deployment enablement. No release or rollout is part of this PR.

Validation: `pnpm test --maxWorkers=2`, `pnpm typecheck`, and `git diff --check`. Regression coverage includes both CLI hosts, refusals/overlap, failure/timeout, missing/invalid/oversized reports, zero versus absent counters, unknown/partial observations, exact UTF-8 byte boundaries, forged events, and synchronous/asynchronous output failures, slow setup, and stopped bodies that exit zero during cleanup. The new lifecycle tests also fail against the original host implementation.

Implements #53.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in, versioned lifecycle events for scheduled and chat jobs.
  * Reports can include validated work artifacts, status, usage, health information, and diagnostics.
  * Added bounded output handling and partial-report indicators for incomplete or interrupted jobs.
  * Added structured work-reporting capability detection.
  * Reports filter sensitive information and distinguish job results from provider confirmations.

* **Documentation**
  * Documented event schemas, validation limits, outcomes, diagnostics, and trust boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->