### PR TITLE
Prepare v0.4.1 release and Helm chart 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-08
+
+On publication, `ghcr.io/sageox/agent-base:0.4.1` takes `:latest` and advances `:0.4`.
+Pin the digest recorded on the GitHub Release in production. Existing manifests need
+no new fields; structured answers and work events are opt-in.
+
+Upgrade the gateway, dispatcher and worker images to the same toolkit release before
+enabling structured answers. Producers must check `JOB_OUTPUT_SCHEMA_VERSION` or
+`JOB_WORK_SCHEMA_VERSION` before emitting new artifact sections; older hosts reject
+unknown fields. Local verdict artifacts now also have a 64 KiB limit and must be
+regular UTF-8 files, not symlinks. Oversized or invalid reports yield unproven gates.
+
+- **Helm chart 0.12.1 adds `agents.<name>.workEvents` to enable structured job logs.**
+  Set it to `true` with toolkit 0.4.1 or newer to enable events on the Deployment and
+  scheduled job hosts. Omitted or `false` preserves ordinary logging. Structured answers
+  use the existing chart resources and need no new RBAC, Secrets or volumes.
 - Opt-in `AGENT_WORK_EVENTS=1` emits bounded, versioned job start/completion records
   from both scheduled and chat hosts. Job reports may include typed artifact,
   subject state, usage and health facts when `JOB_WORK_SCHEMA_VERSION=1` is present.

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Run one or more SageOx Agent Toolkit identities on Kubernetes
 type: application
-version: 0.12.0
+version: 0.12.1
 appVersion: "0.0.0"
 home: https://github.com/sageox/agent-toolkit
 sources:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -51,7 +51,7 @@ Or depend on it, and nest this chart's values under its name. Helm hands every s
 # Chart.yaml
 dependencies:
   - name: agent
-    version: 0.12.0
+    version: 0.12.1
     repository: "file://../agent-toolkit/deploy/helm"
 ```
 
@@ -62,6 +62,28 @@ agent:
   agents:
     harry: { ... }
 ```
+
+## Structured job logs
+
+With toolkit **0.4.1 or newer**, set `agents.<name>.workEvents: true` to enable
+`AGENT_WORK_EVENTS=1` on that agent's Deployment and CronJob hosts. Omitted or
+`false` preserves ordinary logging. Pin `imageRef` to the release's published digest.
+
+```yaml
+agents:
+  harry:
+    workEvents: true  # add to this agent's existing values
+```
+
+Collect `sageox_work_event` records from those containers' stdout. Child diagnostics
+use a separate envelope. External jobs report lifecycle and aggregate results from
+the launching host; their events remain partial because the dispatcher does not
+return individual worker checks or work metadata. See the
+[work event contract](../../docs/job-contract.md#structured-work-events-schema-1).
+
+Structured job answers need no chart setting: declare `output: {format: json}` in
+the bundle's `agent.yaml`, and use workers built from the same toolkit release as
+the gateway and dispatcher. See [structured answers](../../docs/external-jobs.md#structured-answers).
 
 ## Where a bundle comes from
 

--- a/deploy/helm/templates/cronjob.yaml
+++ b/deploy/helm/templates/cronjob.yaml
@@ -138,13 +138,19 @@ whole of what the second mount buys.
                 - --job-secrets
                 - {{ include "agent.jobSecretsMountPath" $context }}
                 {{- end }}
-              {{- if $job.worker }}
+              {{- if or $job.worker $agent.workEvents }}
               env:
+                {{- if $agent.workEvents }}
+                - name: AGENT_WORK_EVENTS
+                  value: "1"
+                {{- end }}
+                {{- if $job.worker }}
                 {{- include "agent.dispatcherEnv" $context | nindent 16 }}
                 - name: AGENT_JOB_REQUEST_ID
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.labels['batch.kubernetes.io/controller-uid']
+                {{- end }}
               {{- end }}
               resources:
                 {{- toYaml $agent.resources | nindent 16 }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
           env:
             - name: BRAIN_MCP_HOST
               value: 127.0.0.1
+            {{- if $agent.workEvents }}
+            - name: AGENT_WORK_EVENTS
+              value: "1"
+            {{- end }}
             {{- if $agent.dispatcher }}
             {{- include "agent.dispatcherEnv" $context | nindent 12 }}
             {{- end }}

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -40,6 +40,7 @@ trap 'rm -rf "$work"' EXIT
 # Three declared jobs across two agents: one scheduled, one on-request, one parked.
 render
 
+absent 'name: AGENT_WORK_EVENTS'
 counted 2 "kind: CronJob"
 # Anchored, because a separator swallowed into the end of the preceding line still reads as
 # `---` to a substring search while collapsing both objects into one document — of which
@@ -105,6 +106,26 @@ rendered=$(helm template agents "$chart" --values "$values" --show-only template
 present "claimName: agents-harry"
 present "claimName: agents-ida"
 absent "emptyDir"
+absent 'name: AGENT_WORK_EVENTS'
+
+# Work events reach both CLI hosts, only for the agent that opted in. This includes
+# local CronJobs, which otherwise have no env stanza at all.
+for template in deployment cronjob; do
+  rendered=$(helm template agents "$chart" --values "$values" \
+    --set agents.harry.workEvents=true --show-only "templates/$template.yaml")
+  counted 1 'name: AGENT_WORK_EVENTS'
+  if ! grep -A1 -F 'name: AGENT_WORK_EVENTS' <<<"$rendered" | grep -qF 'value: "1"'; then
+    fail "work events must use the runtime's exact opt-in value in $template"
+  fi
+  rendered=$(helm template agents "$chart" --values "$values" \
+    --set agents.harry.workEvents=false --show-only "templates/$template.yaml")
+  absent 'name: AGENT_WORK_EVENTS'
+done
+if helm template agents "$chart" --values "$values" \
+  --set-string agents.harry.workEvents=false >"$work/invalid" 2>&1; then
+  fail 'a string workEvents value was accepted instead of a boolean'
+fi
+grep -qF 'workEvents' "$work/invalid" || fail 'workEvents was refused for the wrong reason'
 
 # `persistence.jobCheckouts` mounts the one thing on the claim a scheduled run could not
 # cheaply build for itself: the checkouts the agent Pod clones and fast-forwards. Narrowed
@@ -293,6 +314,7 @@ grep -qF "harry/secrets and harry/jobSecrets" <<<"$out" \
 # External schedules are launchers: they retain admission credentials, but receive no
 # task credentials, mutable checkout, or Kubernetes token. One dispatcher serves all jobs.
 render --set agents.harry.dispatcher.tokenSecret=dispatcher-auth \
+  --set agents.harry.workEvents=true \
   --set 'agents.harry.jobs[0].worker.serviceAccountName=task-worker' \
   --set 'agents.harry.jobs[0].worker.secrets.TASK_TOKEN.name=task-credentials' \
   --set 'agents.harry.jobs[0].worker.secrets.TASK_TOKEN.key=token' \
@@ -302,6 +324,7 @@ render --set agents.harry.dispatcher.tokenSecret=dispatcher-auth \
   --set agents.harry.serviceAccount.automountJobToken=true
 present 'name: AGENT_JOB_DISPATCHER_URL'
 present 'name: AGENT_JOB_REQUEST_ID'
+counted 1 'name: AGENT_WORK_EVENTS'
 absent 'task-credentials'
 absent 'old-job-secrets'
 absent 'mountPath: /agents/harry/workspace/repos'

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -152,6 +152,10 @@
         "terminationGracePeriodSeconds", "resources", "sharedVolumes"
       ],
       "properties": {
+        "workEvents": {
+          "type": "boolean",
+          "description": "Opt in to structured job lifecycle events on the agent Deployment and scheduled job hosts. Omitted or false preserves ordinary logging. Requires toolkit 0.4.1 or newer."
+        },
         "dispatcher": {
           "type": "object",
           "additionalProperties": false,

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -37,4 +37,6 @@ networkPolicy:
 # Optional agents.<name>.dispatcher.tokenSecret enables external worker dispatch.
 # jobs[].worker supplies a separate serviceAccountName, declared Secret mappings and
 # resources. See docs/external-jobs.md; worker images remain in agent.yaml.
+# Optional agents.<name>.workEvents=true enables structured job lifecycle logs on the
+# Deployment and CronJobs with toolkit 0.4.1 or newer. Omitted or false keeps ordinary logs.
 agents: {}


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08228-8012-73eb-831d-a501786e2e65">Session</a>
<!-- /sageox:pr-header -->

## Summary

Prepare runtime v0.4.1 and Helm chart 0.12.1. The release includes structured job answers (#55) and opt-in lifecycle events (#56). Helm currently cannot enable those events; `agents.<name>.workEvents: true` now sets `AGENT_WORK_EVENTS=1` on that agent's Deployment and scheduled job hosts. Omitted or false preserves ordinary logging, and external launcher credentials remain intact.

Cut the changelog section and document matched gateway/dispatcher/worker versions, producer capability checks, and the new 64 KiB regular UTF-8 file requirement for local verdict artifacts. Structured answers reuse existing chart resources. External lifecycle events remain partial; the dispatcher does not return individual worker checks or work metadata.

## Test Plan

- `pnpm test --maxWorkers=2`: 69 files, 1,431 tests passed.
- `pnpm typecheck`: root and all packages passed.
- Strict Helm lint and all four chart test scripts passed.
- New work-event regression fails against the original templates; covers omitted/false/true settings, per-agent scope, external launchers and invalid value types.
- Terraform formatting, both module validations and the existing Terraform test passed.
- `git diff --check` passed. Main's source commit also passed CI, including amd64/arm64 image builds; this PR reruns CI for the release changes.

---
<details>
<summary>Checklist (expand if needed)</summary>

- [x] Regression tests added
- [x] Tests and typecheck green
- [x] Deployment checks run
- [x] CHANGELOG release section prepared
- [x] Compatibility and upgrade notes documented
- [x] Chart documentation updated

</details>

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a08228-8012-73eb-831d-a501786e2e65
