### PR TITLE
Let a consumer's CI parse a manifest, since the schema it must match is authored here

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A repository that authors `agent.yaml` files can check them in CI.** `sageox-agent
+  validate <path…>` parses each file against the schema `run` loads at startup and exits
+  non-zero if any is invalid, naming the field path and the expectation for each problem.
+  It takes paths and nothing else: no agent home, no credentials, no network, and it
+  writes nothing. Reachable without a checkout through the runtime image, whose entry
+  point is the CLI — `docker run --rm -v "$PWD:/w" ghcr.io/sageox/agent-base:<tag>
+  validate /w/agent.yaml`. `doctor` still answers the rest, and a parked job is still
+  validated with the file it sits in. See
+  [the deployment contract](docs/deployment-contract.md#validating-a-manifest-before-it-merges).
+
 ## [0.4.1] - 2026-09-08
 
 On publication, `ghcr.io/sageox/agent-base:0.4.1` takes `:latest` and advances `:0.4`.

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -20,6 +20,35 @@ The runtime does not need an inbound port: Buzz and Slack use outbound connectio
 therefore should not create a Service or Ingress unless a future surface explicitly needs
 one.
 
+## Validating a manifest before it merges
+
+`sageox-agent validate <path…>` parses each file against the same schema `run` loads at
+startup and exits non-zero if any is invalid. It takes paths and nothing else — no agent
+home, no credentials, no network — so a repository that authors `agent.yaml` files can gate
+them in CI. The runtime image is the entry point, and its `validate` is the same code this
+repository's `./bin/sageox-agent validate` runs:
+
+```bash
+# The same tag the deployment runs: the gate is only worth having if it holds the schema
+# the runtime about to load this file holds.
+docker run --rm -v "$PWD:/w" ghcr.io/sageox/agent-base:0.4 validate /w/agent.yaml
+```
+
+Two properties make this worth a CI step rather than a later `doctor` run:
+
+- **A parked job is validated with the rest.** The manifest parses as a unit, so a job
+  carrying `suspend: true` and a missing required field takes down every job beside it.
+- **The failure is time-shifted, not silent.** Without the gate it merges green, deploys,
+  and arrives as an unrelated job's failure on its next tick.
+
+`doctor` remains the pre-flight for a configured agent — it also reads `.env`, resolves
+every declared `secretRef`, and checks the policy and the directory record. `validate`
+answers only the manifest half, which is the half a checkout can answer.
+
+**Do not mirror the schema downstream.** A hand-kept copy validates today's required fields
+and goes quiet the moment this repository adds one, reporting green on exactly the manifest
+the runtime will refuse.
+
 ## Jobs
 
 `jobs[]` declares an agent's scheduled work — a trigger, a hard switch, a bound, and the

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,6 +9,7 @@ import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { dirname, resolve, join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { z } from "zod";
 import {
   Gateway,
   MockBrain,
@@ -2144,6 +2145,59 @@ function manifestRespondToLabel(respondTo: string): string {
   return respondTo === "nobody" ? "nobody (it answers no one)" : respondTo;
 }
 
+/**
+ * `validate <path…>` — will the runtime load this file?
+ *
+ * `doctor` already answers that, through the same `loadManifest` the gateway calls at
+ * startup, but it asks more beside it: it reads `.env`, resolves every declared `secretRef`,
+ * and reads the agent's directory record off the relay. So it needs an agent home and a
+ * credential, and a repository that only *authors* `agent.yaml` files has neither. This
+ * takes paths, touches nothing else, and exits non-zero — the shape a CI step can hold.
+ *
+ * The schema is authored here, so the only alternative was a hand-kept copy downstream,
+ * which reports green on exactly the manifest this one refuses one release later.
+ *
+ * Every path is reported rather than stopping at the first failure: the manifest parses as
+ * a unit, so one job's missing field takes the whole file down, and an author fixing it
+ * wants the rest of the run's findings in the same output.
+ */
+function validateCmd(argv: string[]): boolean {
+  if (!argv.length) {
+    process.stderr.write("validate needs a path: `sageox-agent validate agent.yaml [more.yaml…]`\n");
+    return false;
+  }
+
+  let invalid = 0;
+  for (const path of argv) {
+    try {
+      // Named apart from a parse failure, because a glob that matched nothing and a manifest
+      // that does not load are different things to go fix, and `readFileSync` reports the
+      // second one's shape for both.
+      if (!existsSync(path)) throw new Error("no such file");
+      const manifest = loadManifest(readFileSync(path, "utf8"));
+      process.stdout.write(
+        `  ok    ${path} — ${manifest.name}, ${manifest.surfaces.length} surface(s), ` +
+          `${manifest.jobs.length} job(s)\n`,
+      );
+    } catch (error) {
+      invalid++;
+      // Zod's own rendering, because its default `message` is the whole issue list as JSON:
+      // true, and a screen of it for the two fields a reviewer has to fix. A zod that ever
+      // differs between this package and core falls through to that raw message.
+      const detail = error instanceof z.ZodError ? z.prettifyError(error) : errorText(error);
+      process.stdout.write(`  FAIL  ${path}\n`);
+      for (const line of detail.split("\n")) process.stdout.write(`        ${line}\n`);
+    }
+  }
+
+  if (invalid) {
+    process.stderr.write(`\n${invalid} of ${argv.length} file(s) invalid.\n`);
+    return false;
+  }
+  process.stdout.write(`\n${argv.length} file(s) valid.\n`);
+  return true;
+}
+
 async function doctorCmd(argv: string[]): Promise<boolean> {
   const agent = await agentFrom(argv);
   loadDotEnv(agent.env);
@@ -2745,6 +2799,10 @@ checking a relay:
   probe --relay <url> [--agent x]  connect read-only and report what it actually serves
 
 running it:
+  validate <path…>             parse each agent.yaml against the schema the runtime loads,
+                               and exit non-zero if any is invalid. No agent home, no
+                               credentials, no network — the one command a repository that
+                               authors manifests can run against a checkout in CI
   doctor [--bundle <dir>]      check config, credentials, and policy before running
   run [--bundle <dir>]         run every configured surface locally (Ctrl+C to stop)
   job run <slug> [--trigger schedule|on-request|webhook]
@@ -2789,6 +2847,9 @@ const commands: Record<string, (argv: string[]) => Promise<void> | void> = {
   probe: probeCmd,
   repos: reposCmd,
   mcp: mcpAddCmd,
+  validate: (argv) => {
+    if (!validateCmd(argv)) process.exit(1);
+  },
   doctor: async (argv) => {
     if (!await doctorCmd(argv)) process.exit(1);
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2148,11 +2148,11 @@ function manifestRespondToLabel(respondTo: string): string {
 /**
  * `validate <path…>` — will the runtime load this file?
  *
- * `doctor` already answers that, through the same `loadManifest` the gateway calls at
- * startup, but it asks more beside it: it reads `.env`, resolves every declared `secretRef`,
- * and reads the agent's directory record off the relay. So it needs an agent home and a
- * credential, and a repository that only *authors* `agent.yaml` files has neither. This
- * takes paths, touches nothing else, and exits non-zero — the shape a CI step can hold.
+ * `doctor` already answers that, through the same `readManifest` `run` calls at startup, but
+ * it asks more beside it: it reads `.env`, resolves every declared `secretRef`, and reads the
+ * agent's directory record off the relay. So it needs an agent home and a credential, and a
+ * repository that only *authors* `agent.yaml` files has neither. This takes paths, touches
+ * nothing else, and exits non-zero — the shape a CI step can hold.
  *
  * The schema is authored here, so the only alternative was a hand-kept copy downstream,
  * which reports green on exactly the manifest this one refuses one release later.
@@ -2171,10 +2171,16 @@ function validateCmd(argv: string[]): boolean {
   for (const path of argv) {
     try {
       // Named apart from a parse failure, because a glob that matched nothing and a manifest
-      // that does not load are different things to go fix, and `readFileSync` reports the
-      // second one's shape for both.
+      // that does not load are different things to go fix. This is also why `readManifest`'s
+      // own absent-file message never fires here: it tells the reader to run `init`, which
+      // is not what a CI step pointed at the wrong path should do.
       if (!existsSync(path)) throw new Error("no such file");
-      const manifest = loadManifest(readFileSync(path, "utf8"));
+      // `readManifest`, not `loadManifest`: `run` normalizes `owner`, `allowlist` and
+      // `killSwitchParkBy` after the schema passes, and `toHexPubkey` throws on a mistyped
+      // npub or an nsec written where a public key belongs. The schema admits both as
+      // strings, so validating one rung below the runtime would pass a file the runtime
+      // refuses at startup — this command's own failure mode.
+      const manifest = readManifest(path);
       process.stdout.write(
         `  ok    ${path} — ${manifest.name}, ${manifest.surfaces.length} surface(s), ` +
           `${manifest.jobs.length} job(s)\n`,
@@ -2847,8 +2853,10 @@ const commands: Record<string, (argv: string[]) => Promise<void> | void> = {
   probe: probeCmd,
   repos: reposCmd,
   mcp: mcpAddCmd,
+  // `exitCode`, not `exit`: a report of any size reaches a pipe whole. `process.exit`
+  // discards pending stdout writes, and a piped stdout is where every CI run reads this.
   validate: (argv) => {
-    if (!validateCmd(argv)) process.exit(1);
+    if (!validateCmd(argv)) process.exitCode = 1;
   },
   doctor: async (argv) => {
     if (!await doctorCmd(argv)) process.exit(1);

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -1,0 +1,121 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AGENT_YAML } from "../src/init.ts";
+import { CLI } from "./cli-harness.ts";
+
+/**
+ * `validate` exists to be run where `doctor` cannot: a repository that authors `agent.yaml`
+ * files, with no agent home, no credential, and no relay. So every test here supplies a bare
+ * file and nothing else, and the exit code is the assertion that matters — it is the whole
+ * of what a CI step reads.
+ */
+function validate(
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((done) => {
+    execFile(CLI, ["validate", ...args], { env: { ...process.env, ...env } }, (error, stdout, stderr) => {
+      done({ code: error ? ((error as { code?: number }).code ?? 1) : 0, stdout, stderr });
+    });
+  });
+}
+
+/** The manifest from the issue: a second job that omits two required fields. */
+const MISSING_FIELDS =
+  "jobs:\n" +
+  "  - slug: sweep\n" +
+  "    trigger: {schedule: '0 2 * * *'}\n" +
+  "    budget: {wallClockMs: 4000}\n" +
+  "    run: {command: ./body.sh, args: []}\n";
+
+describe("sageox-agent validate", () => {
+  let dir: string;
+  const write = (name: string, yaml: string) => {
+    const path = join(dir, name);
+    writeFileSync(path, yaml);
+    return path;
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sageox-agent-validate-"));
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("accepts a manifest and says what it holds", async () => {
+    const path = write("agent.yaml", AGENT_YAML("demo"));
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain(`ok    ${path} — demo, 1 surface(s), 0 job(s)`);
+    expect(stdout).toContain("1 file(s) valid.");
+  });
+
+  it("names the field paths of an invalid job and exits non-zero", async () => {
+    const path = write("agent.yaml", AGENT_YAML("demo") + MISSING_FIELDS);
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain(`FAIL  ${path}`);
+    expect(stdout).toContain("jobs[0].archetype");
+    expect(stdout).toContain("jobs[0].description");
+    // Zod's default `message` is the issue list as JSON, which is what this renders instead
+    // of: a reviewer reading a diff should not have to parse it.
+    expect(stdout).not.toContain('"code":');
+  });
+
+  it("refuses a parked job too, since the manifest parses as a unit", async () => {
+    const path = write("agent.yaml", AGENT_YAML("demo") + MISSING_FIELDS + "    suspend: true\n");
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain("jobs[0].archetype");
+  });
+
+  it("reports every path rather than stopping at the first failure", async () => {
+    const good = write("good.yaml", AGENT_YAML("good"));
+    const bad = write("bad.yaml", AGENT_YAML("bad") + MISSING_FIELDS);
+    const last = write("last.yaml", AGENT_YAML("last"));
+
+    const { code, stdout, stderr } = await validate([good, bad, last]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain(`ok    ${good}`);
+    expect(stdout).toContain(`FAIL  ${bad}`);
+    expect(stdout).toContain(`ok    ${last}`);
+    expect(stderr).toContain("1 of 3 file(s) invalid");
+  });
+
+  it("fails a file it cannot read without claiming it validated", async () => {
+    const { code, stdout } = await validate([join(dir, "absent.yaml")]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain("FAIL  ");
+    expect(stdout).not.toContain("ok    ");
+  });
+
+  it("asks for a path instead of validating nothing", async () => {
+    const { code, stderr } = await validate([]);
+
+    expect(code).not.toBe(0);
+    expect(stderr).toContain("validate needs a path");
+  });
+
+  it("passes with no agent home to read and creates none", async () => {
+    const path = write("agent.yaml", AGENT_YAML("demo"));
+    const home = join(dir, "absent-home");
+    const before = readdirSync(dir);
+
+    const { code } = await validate([path], { AGENT_TOOLKIT_HOME: home });
+
+    expect(code).toBe(0);
+    expect(existsSync(home)).toBe(false);
+    expect(readdirSync(dir)).toEqual(before);
+  });
+});

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -98,6 +98,43 @@ describe("sageox-agent validate", () => {
     expect(code).not.toBe(0);
     expect(stdout).toContain("FAIL  ");
     expect(stdout).not.toContain("ok    ");
+  });
+
+  it("fails a path that exists but is not a file", async () => {
+    const bundle = join(dir, "bundle");
+    mkdirSync(bundle);
+
+    const { code, stdout } = await validate([bundle]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain(`FAIL  ${bundle}`);
+    expect(stdout).not.toContain("ok    ");
+  });
+
+  /**
+   * The gap that would make this command worse than nothing: the schema takes these as
+   * plain strings, and `run` converts them afterwards — so validating one rung below the
+   * runtime would report green on a file the runtime refuses at startup.
+   */
+  it("refuses an owner the runtime could not resolve to a key", async () => {
+    const path = write("agent.yaml", AGENT_YAML("demo") + "owner:\n  - npub1nothing\n");
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain(`FAIL  ${path}`);
+  });
+
+  it("refuses a secret key written where a public one belongs", async () => {
+    const path = write(
+      "agent.yaml",
+      `${AGENT_YAML("demo")}owner:\n  - ${"nsec1" + "q".repeat(58)}\n`,
+    );
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain("secret key");
   });
 
   it("asks for a path instead of validating nothing", async () => {


### PR DESCRIPTION
<!-- sageox:pr-header v1 -->
> <sub>guided&nbsp;by</sub><br><picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="18" align="middle" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08267-5b1d-70da-8870-31891e361d79">Session</a>
<!-- /sageox:pr-header -->

Closes #25.

## What was needed

`doctor` is already the authoritative answer to "will this manifest load?" — it reaches
`ManifestSchema.parse` through the same `loadManifest` the gateway calls at startup. But
it asks more beside it: it reads `.env`, resolves every declared `secretRef`, and reads
the agent's directory record off the relay. **A repository that only *authors*
`agent.yaml` files has none of those**, so it had no way to run the validator at all.

The cost is in the issue: a second job merged with `archetype` and `description` missing,
and because the manifest parses as a unit it took the agent's *other*, unrelated job down
at every scheduled run — ~25 minutes after merge, with nothing linking the failure to the
change that caused it. The job was `suspend: true`; a parked job is validated with the
file it sits in.

The only alternative was a hand-kept copy of the schema downstream, which is the same bug
one release later: it validates today's required fields and reports green on exactly the
manifest the runtime will refuse.

## What this ships

**`sageox-agent validate <path…>`** — paths and nothing else. No agent home, no
credentials, no network, nothing written. Non-zero exit if any file is invalid.

```console
$ sageox-agent validate good.yaml bad.yaml missing.yaml
  ok    good.yaml — heisenberg, 1 surface(s), 0 job(s)
  FAIL  bad.yaml
        ✖ Invalid option: expected one of "watch"|"shift"|"sweep"|"queue"
          → at jobs[0].archetype
        ✖ Invalid input: expected string, received undefined
          → at jobs[0].description
  FAIL  missing.yaml
        no such file

2 of 3 file(s) invalid.
$ echo $?
1
```

Every path is reported rather than stopping at the first failure — one job's missing field
takes the whole file down, so an author fixing it wants the rest in the same run. The
rendering is zod's own `prettifyError`; its default `message` is the entire issue list as
JSON, which is true and unreadable in a diff.

## On option (1) — publishing to npm

**Not done, deliberately, and the issue does not need it.** The issue lists three ways to
close it and rules that (1)+(2) is the combination that works, because (2) is unreachable
without (1). That premise holds for npm and only for npm:

```mermaid
flowchart LR
  S["ManifestSchema<br/>packages/core"] --> C["sageox-agent validate"]
  C --> I["ghcr.io/sageox/agent-base<br/>ENTRYPOINT is this CLI"]
  I --> G["consumer CI:<br/>docker run … validate /w/agent.yaml"]
```

The reachability half is already solved by an artifact this repository is *required* to
ship. `release.yml` opens by saying so — "Everything else — the chart, the examples, the
CLI — is optional; the runtime image is not" — the image's `ENTRYPOINT` is
`/app/bin/sageox-agent`, and GHCR was chosen specifically so it pulls anonymously. So a
consumer's CI step exists today:

```bash
docker run --rm -v "$PWD:/w" ghcr.io/sageox/agent-base:0.4 validate /w/agent.yaml
```

Publishing to npm would buy `npx` over `docker run` and cost: a build step for five
packages that currently have none (`bin` points at `./src/cli.ts`), `exports`/`types`/
`files` maps, version synchronisation against the git tag, npm org access and registry
credentials in `release.yml` — and permanently, a second distribution channel that has to
stay in step with the image. That is a real change with a real owner decision behind it,
not release plumbing, and it needs registry access I do not have. **Say the word and I'll
open it as its own PR** — the `validate` command lands on npm unchanged if you do.

Option (3), a generated JSON Schema artifact, stays open on the same reasoning: it is a
second representation, worth adding when a consumer validating from Python or Go asks.

## Test Plan

- [x] `pnpm test` — 70 files, 1,441 tests passed. `pnpm typecheck` — root and every
      package passed. (CI's first run on the second commit hit
      `buzz.test.ts > re-signs the same id when asked again within the same second`, which
      the test's own comment explains is only true within a one-second `created_at` bucket;
      it passes in isolation and on re-run, and this PR touches neither package.)
- [x] `packages/cli/test/validate.test.ts` — 10 tests, each failing without the change:
      a valid manifest and its counts; the issue's exact missing-`archetype`/`description`
      job, asserting the field paths appear and zod's JSON dump does not; a `suspend: true`
      job refused with the rest; every path reported rather than the first failure only; an
      absent path; a path that exists but is a directory, which reaches the read failure
      rather than the absent-path branch; a mistyped `npub` and an `nsec` in `owner`, both
      of which the schema admits and `run` refuses; no arguments; and a run with
      `AGENT_TOOLKIT_HOME` pointing at a directory that does not exist, asserting it still
      passes and creates nothing.
- [x] Ran the command by hand against valid, invalid, absent, and directory paths.

Not verified by hand: the `docker run` line. It follows from the unchanged `ENTRYPOINT`
and the new subcommand, but the image carrying `validate` is the next release's.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a08267-5b1d-70da-8870-31891e361d79

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791487358&installation_model_id=433550&pr_number=59&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F59&signature=7e55a22643a1c95809d27ea2ad690de772837373351d70233c628e034394ac2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `validate` command for checking one or more `agent.yaml` files against the runtime schema.
  * Reports detailed field-level errors, continues processing multiple files, and exits with a failure status if any file is invalid.
  * Runs without network access or credentials and does not write files.
  * Available through the runtime image and Docker entry point.

* **Documentation**
  * Added guidance for using manifest validation in pre-merge and CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
