### PR TITLE
Fix daemon leaks in directory reconciliation tests

### DIFF
--- a/packages/cli/test/run-directory.test.ts
+++ b/packages/cli/test/run-directory.test.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -32,9 +33,19 @@ describe("run reconciles the directory record", () => {
   let relay: FakeRelay;
   let home: string;
   let agent: ChildProcess | undefined;
+  let agentClosed: Promise<unknown> | undefined;
 
   afterEach(async () => {
-    agent?.kill("SIGKILL");
+    if (agent?.pid) {
+      // tsx runs the daemon in a child; SIGKILL cannot be relayed by the wrapper.
+      try {
+        process.kill(-agent.pid, "SIGKILL");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+      }
+    }
+    // Wait for inherited stdio to close too, before removing the daemon's state.
+    await agentClosed;
     await relay?.stop();
     rmSync(home, { recursive: true, force: true });
   });
@@ -52,8 +63,10 @@ describe("run reconciles the directory record", () => {
 
     let output = "";
     agent = spawn(CLI, ["run", "--agent", "demo", "--secrets", secrets], {
+      detached: true,
       env: { ...process.env, AGENT_TOOLKIT_HOME: agentHome },
     });
+    agentClosed = once(agent, "close");
     agent.stdout?.on("data", (chunk) => (output += String(chunk)));
     agent.stderr?.on("data", (chunk) => (output += String(chunk)));
     return () => output;


### PR DESCRIPTION
The directory reconciliation tests killed only the `tsx` wrapper, leaving its daemon child running and periodically recreating the deleted temporary home. Spawn each test daemon in its own process group, kill the whole group during teardown, and wait for the child process and inherited stdio to close before removing its state.

Validation: `pnpm test` (1,441 tests) and `pnpm typecheck` pass. Temporarily restoring the wrapper-only kill makes teardown fail and leaves a daemon alive; restoring the fix leaves no directory-test daemons or temporary homes. The regression process was cleaned up.

Closes #62.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791508993&installation_model_id=433550&pr_number=63&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F63&signature=d121698bc36e79283a71cd31a8ef536c1fe876f16095960347e2147b7d8a55ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI test process cleanup to prevent lingering processes and temporary state.
  * Increased reliability when handling processes that have already exited.
  * Ensured inherited output streams close before cleanup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->