### PR TITLE
Finalize SageOx recordings when Codex sessions end

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -22,6 +22,17 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v ox \u003e/dev/null 2\u003e\u00261; then AGENT_ENV=codex ox agent hook SessionEnd 2\u003e\u00261 || true; else echo 'This repo uses SageOx: install https://github.com/sageox/ox for optimized team context.'; fi"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Repository Codex hooks now notify SageOx on `SessionEnd`, allowing active recordings
+  to finalize when the session ends.
 - **Helm external workers cannot inherit invalid mounts or reuse scheduled-job
   credentials.** Dispatcher bundle staging now excludes gateway shared volumes, and chart
   validation rejects a worker Secret that is already used by any agent's gateway,


### PR DESCRIPTION
The repository's Codex hooks omitted `SessionEnd`, so normal session shutdown did not notify SageOx to finalize an active recording. Add the handler generated by `ox integrate install --codex` alongside the existing hooks, with a changelog entry.

Validation: `pnpm test` (1,441 tests) and `pnpm typecheck` pass. Validated the hook JSON and shell syntax, and verified that the command dispatches `AGENT_ENV=codex ox agent hook SessionEnd` using a stub `ox` executable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791510069&installation_model_id=433550&pr_number=64&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F64&signature=5c669ac80915dc15e2fcc3c2daa401c69848b649ed6ae0fd3486a720557fed98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic session-end notifications to SageOx, allowing active recordings to finalize when a session ends.
  * Added a fallback installation message when SageOx is not installed.

* **Documentation**
  * Documented the new session-end integration in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->