### PR TITLE
fix(core): conversational job replies without stale narration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Chat replies keep the final ACP answer without replaying narration superseded by
+  tool calls. Detached jobs reply to their requester in plain language; diagnostic
+  IDs, timings, gate details and raw failure reports stay in operator records/reports.
+  Tool guidance preserves outcome and uncertainty without requiring diagnostic prose
+  to be repeated verbatim. Worker completion never claims an application side effect.
 - Repository Codex hooks now notify SageOx on `SessionEnd`, allowing active recordings
   to finalize when the session ends.
 - **Helm external workers cannot inherit invalid mounts or reuse scheduled-job

--- a/packages/core/src/brain-acp.ts
+++ b/packages/core/src/brain-acp.ts
@@ -268,6 +268,7 @@ export class ClaudeAcpBrain implements Brain {
   }
 }
 
+/** ACP's convenience reader joins progress and final text, producing contradictory replies. */
 async function readFinalText(session: ChannelSession["session"]): Promise<string> {
   let text = "";
   for (;;) {

--- a/packages/core/src/brain-acp.ts
+++ b/packages/core/src/brain-acp.ts
@@ -199,9 +199,10 @@ export class ClaudeAcpBrain implements Brain {
       // it in context, and repeating it every message would waste tokens and read as
       // the agent being re-briefed mid-conversation.
       await session.prompt(assembleTurnPrompt(event, ctx, { steer: !existing }));
-      let text = await session.readText();
+      let text = await readFinalText(session);
 
       for (let retries = 0; ; retries++) {
+        if (!text.trim()) return;
         // Where the reply lands is the adapter's call — upstream keeps threads flat — so
         // the brain returns text and says nothing about threading.
         const feedback = yield { type: "reply", msg: { text } };
@@ -209,7 +210,7 @@ export class ClaudeAcpBrain implements Brain {
         if (retries >= maxRetries) return;
 
         await session.prompt(refusalPrompt(feedback));
-        text = await session.readText();
+        text = await readFinalText(session);
       }
     } finally {
       // The session stays open — it is this channel's memory. Closing happens on
@@ -264,6 +265,21 @@ export class ClaudeAcpBrain implements Brain {
       Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,
       Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>,
     );
+  }
+}
+
+async function readFinalText(session: ChannelSession["session"]): Promise<string> {
+  let text = "";
+  for (;;) {
+    const message = await session.nextUpdate();
+    if (message.kind === "stop") return text;
+    const { update } = message;
+    // ACP readText concatenates narration across tool calls. A new call supersedes
+    // that narration; a late tool_call_update must not erase the final answer.
+    if (update.sessionUpdate === "tool_call") text = "";
+    if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
+      text += update.content.text;
+    }
   }
 }
 

--- a/packages/core/src/job-server.ts
+++ b/packages/core/src/job-server.ts
@@ -405,6 +405,7 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
   });
 }
 
+/** Chat needs a bounded outcome; operator diagnostics may contain private worker text. */
 function describeChatCompletion(run: JobRun): string {
   const subject = `The ${run.jobSlug.replaceAll("-", " ")} job`;
   if (run.outcome === "abandoned") {
@@ -421,6 +422,9 @@ function describeChatCompletion(run: JobRun): string {
   }
   if (run.outcome === "crashed" || run.verdict.status === "FAIL") {
     return `${subject} did not finish successfully. An operator can inspect its saved result.`;
+  }
+  if (run.outcome === "skipped-overlap") {
+    return `${subject} was skipped because another run was already active.`;
   }
   if (run.outcome !== "completed") {
     return `${subject} did not run. An operator can check why it was refused.`;

--- a/packages/core/src/job-server.ts
+++ b/packages/core/src/job-server.ts
@@ -231,8 +231,11 @@ function tools(jobs: readonly JobConfig[], turnTimeoutMs: number): unknown[] {
         "Run one of this agent's declared jobs now. You choose which job; the job's own " +
         "declaration decides what runs, for how long, and with what arguments. A job short " +
         "enough to finish inside one turn is waited for, and this tool answers with the " +
-        "verdict it minted — report that verdict exactly as it is returned, because a job " +
-        "that proved nothing did not pass. A job whose budget is longer than a turn is " +
+        "verdict it minted. Explain the outcome in your conversational voice, preserving " +
+        "failure and uncertainty: a job that proved nothing did not pass. Do not copy " +
+        "diagnostic IDs, gate counts, timings or exit codes into an ordinary chat reply. " +
+        "A completed job is not proof of an application change; read its declared output " +
+        "before claiming one. A job whose budget is longer than a turn is " +
         "started rather than waited for, and the answer says only that it is running and " +
         "where its result will be posted: there is no verdict in it, so say it is running " +
         "and report the result when it lands. A parked job runs when the message you are " +
@@ -373,13 +376,12 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
       // quoted; one that cannot is started, and answers where it declared it would.
       if (job.worker || jobDeadlineMs(job) > turnTimeoutMs) {
         // Read now, not when the run lands: by then the turn is over and the gateway has
-        // forgotten which message it was answering. The verdict goes back as the same text
-        // a waited-for call returns, so the two shapes read alike where they arrive.
+        // forgotten which message it was answering. Chat gets a bounded human summary;
+        // diagnostic prose stays in tool results and the declared operator reports.
         const home = answering?.() ?? null;
         if (job.worker && !home) throw new Error("external job requests require an unambiguous originating message; ask from a chat conversation");
         const answer =
-          home && reply ? (run: JobRun, failureReport?: string) =>
-            reply(home, describeRun(run, job) + (failureReport ? `\n${failureReport}\n` : "")) : undefined;
+          home && reply ? (run: JobRun) => reply(home, describeChatCompletion(run)) : undefined;
         const start = await host.startRequest(
           job,
           requester(agentName, answering, owner),
@@ -401,6 +403,33 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
       );
     },
   });
+}
+
+function describeChatCompletion(run: JobRun): string {
+  const subject = `The ${run.jobSlug.replaceAll("-", " ")} job`;
+  if (run.outcome === "abandoned") {
+    return `${subject} was interrupted. Check its result before trying again.`;
+  }
+  if (run.outcome === "cancelled") {
+    return `${subject} was cancelled; any changes already made remain. Check its result before trying again.`;
+  }
+  if (run.outcome === "unknown") {
+    return `${subject}'s outcome is uncertain. Check its result before trying again.`;
+  }
+  if (run.outcome === "budget-bowout") {
+    return `${subject} ran out of time. Check its result before trying again.`;
+  }
+  if (run.outcome === "crashed" || run.verdict.status === "FAIL") {
+    return `${subject} did not finish successfully. An operator can inspect its saved result.`;
+  }
+  if (run.outcome !== "completed") {
+    return `${subject} did not run. An operator can check why it was refused.`;
+  }
+  // PASS proves the worker's checks, not an invitation, deployment or other side
+  // effect. Only the declared application output can establish that outcome.
+  return run.verdict.status === "PASS"
+    ? `${subject} finished. Its result is ready to review.`
+    : `${subject} finished, but its result could not be verified.`;
 }
 
 /** A finished run, plus the one thing about a refusal the brain can do something with. */

--- a/packages/core/test/brain-acp.test.ts
+++ b/packages/core/test/brain-acp.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { agent, AGENT_METHODS, CLIENT_METHODS, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
-import type { AgentApp } from "@agentclientprotocol/sdk";
+import type { AgentApp, SessionUpdate } from "@agentclientprotocol/sdk";
 import { ClaudeAcpBrain } from "../src/brain-acp.ts";
 import { loadToolPolicy } from "../src/tool-policy.ts";
 import type { GuardFeedback } from "../src/brain.ts";
@@ -20,7 +20,7 @@ const ev = (text: string): InboundEvent => ({
 
 /** A fake ACP agent: replies with the next canned string per prompt. */
 function fakeAgent(
-  replies: string[],
+  replies: (string | SessionUpdate[])[],
   opts: { askPermission?: boolean; supportsClose?: boolean; permissionTool?: string } = {},
 ) {
   const prompts: string[] = [];
@@ -67,13 +67,16 @@ function fakeAgent(
         permissionOutcomes.push(res.outcome);
       }
 
-      await ctx.client.notify(CLIENT_METHODS.session_update, {
-        sessionId: ctx.params.sessionId,
-        update: {
-          sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: replies[i++] ?? "" },
-        },
-      });
+      const reply = replies[i++] ?? "";
+      const updates: SessionUpdate[] = typeof reply === "string"
+        ? [{ sessionUpdate: "agent_message_chunk", content: { type: "text", text: reply } }]
+        : reply;
+      for (const update of updates) {
+        await ctx.client.notify(CLIENT_METHODS.session_update, {
+          sessionId: ctx.params.sessionId,
+          update,
+        });
+      }
       return { stopReason: "end_turn" as const };
     });
 
@@ -105,6 +108,48 @@ async function drain(
 }
 
 describe("ClaudeAcpBrain", () => {
+  it("keeps final answer chunks but drops narration superseded by tool calls", async () => {
+    const f = fakeAgent([[
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Still running — checking back." } },
+      { sessionUpdate: "tool_call", toolCallId: "status", title: "Check status", status: "in_progress" },
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Already has access. " } },
+      // A late status update is not a new tool call or a new answer.
+      { sessionUpdate: "tool_call_update", toolCallId: "status", status: "completed" },
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "No invitation sent." } },
+    ]]);
+    const brain = new ClaudeAcpBrain({ target: f.app });
+    try {
+      expect(await drain(brain, ev("check access"), () => undefined))
+        .toEqual(["Already has access. No invitation sent."]);
+    } finally { await brain.stop(); }
+  });
+
+  it("does not replay pre-tool narration when the agent supplies no final answer", async () => {
+    const f = fakeAgent([[
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Checking now." } },
+      { sessionUpdate: "tool_call", toolCallId: "status", title: "Check status", status: "in_progress" },
+      { sessionUpdate: "tool_call_update", toolCallId: "status", status: "completed" },
+    ]]);
+    const brain = new ClaudeAcpBrain({ target: f.app });
+    try {
+      expect(await drain(brain, ev("check access"), () => undefined)).toEqual([]);
+    } finally { await brain.stop(); }
+  });
+
+  it("also drops superseded narration when rewriting a refused reply", async () => {
+    const f = fakeAgent(["private details", [
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Let me check again." } },
+      { sessionUpdate: "tool_call", toolCallId: "status", title: "Check status", status: "in_progress" },
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "No invitation sent." } },
+    ]]);
+    const brain = new ClaudeAcpBrain({ target: f.app });
+    try {
+      expect(await drain(brain, ev("status"), (text) => text === "private details"
+        ? { blocked: true, rule: "publicChannel", reason: "private information" } : undefined))
+        .toEqual(["private details", "No invitation sent."]);
+    } finally { await brain.stop(); }
+  });
+
   it("yields the agent's reply from a real ACP round-trip", async () => {
     const f = fakeAgent(["the deploy is green"]);
     const brain = new ClaudeAcpBrain({ target: f.app });

--- a/packages/core/test/job-dispatcher.test.ts
+++ b/packages/core/test/job-dispatcher.test.ts
@@ -723,7 +723,8 @@ it.each(["buzz", "slack"])("automatically explains an uncaught script error in t
     expect(JSON.stringify(posts)).not.toContain("worker-secret");
     expect(reply).toHaveBeenCalledTimes(1);
     expect(reply.mock.calls[0]![0]).toBe(home);
-    expect(reply.mock.calls[0]![1]).toContain("Error: synthetic worker exception: [REDACTED]");
+    expect(reply.mock.calls[0]![1]).toContain("did not finish successfully");
+    expect(reply.mock.calls[0]![1]).not.toMatch(/synthetic worker exception|run id|process exited|FAILED:/);
     expect(reply.mock.calls[0]![1]).not.toContain("worker-secret");
     expect(JSON.stringify(onRun.mock.calls)).not.toContain("synthetic worker exception");
     const modelStatus = JSON.stringify(await handler({ method: "tools/call", params: { name: "job_status", arguments: { job: job.slug, runId: start.runId } } }));

--- a/packages/core/test/job-server.test.ts
+++ b/packages/core/test/job-server.test.ts
@@ -626,15 +626,48 @@ describe("a job that outlasts a turn", () => {
     expect(text).toContain("posted back into this conversation");
 
     await vi.waitFor(() => expect(answers).toHaveLength(1), { timeout: 5000 });
-    // The same text a waited-for call returns, into the very message that asked.
-    expect(answers[0].text).toContain("job shift completed");
-    expect(answers[0].text).toContain("PROVEN: ci passed");
+    expect(answers[0].text).toBe("The shift job finished. Its result is ready to review.");
+    expect(answers[0].text).not.toMatch(/PROVEN|PASS|gate|run id|exit|[0-9]+ms/);
     expect(answers[0].home.id).toEqual({ surface: "buzz", nativeId: "m1" });
     // Answered where it was asked, so the channel is spared a clean verdict — exactly as
     // it is for a run whose caller waited.
     await vi.waitFor(() => expect(runs).toHaveLength(1), { timeout: 5000 });
     expect(posts).toEqual([]);
   });
+
+  it.each([
+    [SILENT, "The shift job finished, but its result could not be verified."],
+    [RECORD + "process.exit(1)", "The shift job did not finish successfully. An operator can inspect its saved result."],
+  ])("keeps failed or unverified results honest in chat (%s)", async (body, expected) => {
+    const answers: string[] = [];
+    await call([withBody(jobs(REPORTING)[0], body)], { job: "shift" }, {
+      ...impatient, answering: turnAuthor({ id: "npub1ryan" }),
+      reply: async (_home, text) => { answers.push(text); },
+    });
+    await vi.waitFor(() => expect(answers).toEqual([expected]), { timeout: 5000 });
+    expect(runs[0].verdict.status).not.toBe("PASS");
+  });
+
+  it.each(["cancelled", "unknown", "budget-bowout"] as const)(
+    "never says an uncertain %s run had no side effects", async (outcome) => {
+      const host = jobHost();
+      const job = withBody(jobs(REPORTING)[0], SILENT);
+      await call([job], { job: "shift" }, { host });
+      const run: JobRun = { ...runs[0], outcome };
+      vi.spyOn(host, "startRequest").mockImplementation(async (_job, _requester, _params, answer) => {
+        await answer!(run);
+        return { runId: run.runId, refused: null };
+      });
+      const answers: string[] = [];
+      await call([job], { job: "shift" }, {
+        ...impatient, host, answering: turnAuthor({ id: "npub1ryan" }),
+        reply: async (_home, text) => { answers.push(text); },
+      });
+      expect(answers).toHaveLength(1);
+      expect(answers[0]).toContain("Check its result before trying again.");
+      expect(answers[0]).not.toMatch(/did not run|ready to review|PROVEN|run id/);
+    },
+  );
 
   it("lets the status post carry a verdict the asker could not be given", async () => {
     const reply = async () => {
@@ -669,8 +702,7 @@ describe("a job that outlasts a turn", () => {
     await host.abandon();
     // Settled inside the shutdown's own wait, not after it.
     expect(answers).toHaveLength(1);
-    expect(answers[0]).toContain("job shift abandoned");
-    expect(answers[0]).toContain("NOT PROVEN");
+    expect(answers[0]).toBe("The shift job was interrupted. Check its result before trying again.");
   });
 
   it("promises no answer when the gateway can name no one conversation", async () => {

--- a/packages/core/test/job-server.test.ts
+++ b/packages/core/test/job-server.test.ts
@@ -640,16 +640,24 @@ describe("a job that outlasts a turn", () => {
     [RECORD + "process.exit(1)", "The shift job did not finish successfully. An operator can inspect its saved result."],
   ])("keeps failed or unverified results honest in chat (%s)", async (body, expected) => {
     const answers: string[] = [];
+    let resolveReply!: () => void;
+    const replied = new Promise<void>((resolve) => { resolveReply = resolve; });
     await call([withBody(jobs(REPORTING)[0], body)], { job: "shift" }, {
       ...impatient, answering: turnAuthor({ id: "npub1ryan" }),
-      reply: async (_home, text) => { answers.push(text); },
+      reply: async (_home, text) => { answers.push(text); resolveReply(); },
     });
-    await vi.waitFor(() => expect(answers).toEqual([expected]), { timeout: 5000 });
+    await replied;
+    expect(answers).toEqual([expected]);
     expect(runs[0].verdict.status).not.toBe("PASS");
   });
 
-  it.each(["cancelled", "unknown", "budget-bowout"] as const)(
-    "never says an uncertain %s run had no side effects", async (outcome) => {
+  it.each([
+    ["cancelled", "Check its result before trying again."],
+    ["unknown", "Check its result before trying again."],
+    ["budget-bowout", "Check its result before trying again."],
+    ["skipped-overlap", "The shift job was skipped because another run was already active."],
+  ] as const)(
+    "describes a %s outcome without implying success or refusal", async (outcome, expected) => {
       const host = jobHost();
       const job = withBody(jobs(REPORTING)[0], SILENT);
       await call([job], { job: "shift" }, { host });
@@ -664,8 +672,8 @@ describe("a job that outlasts a turn", () => {
         reply: async (_home, text) => { answers.push(text); },
       });
       expect(answers).toHaveLength(1);
-      expect(answers[0]).toContain("Check its result before trying again.");
-      expect(answers[0]).not.toMatch(/did not run|ready to review|PROVEN|run id/);
+      expect(answers[0]).toContain(expected);
+      expect(answers[0]).not.toMatch(/did not run|refused|ready to review|PROVEN|run id/);
     },
   );
 


### PR DESCRIPTION
## Summary

Job requests can produce diagnostic-heavy chat messages followed by a final answer that still includes an earlier “still running” update.

**Root cause:** detached job callbacks send the same diagnostic rendering used by tools, while ACP `readText()` concatenates message chunks across tool calls.
**Fix:** render requester-facing job completion in plain language and keep reply text after the latest tool call, preserving failure and uncertainty.

| Area | Change |
|---|---|
| `job-server.ts` | Summarize completion from host-owned outcomes/verdicts; keep diagnostics out of ordinary replies; ask the brain to explain results naturally without treating worker completion as proof of an application change. |
| `brain-acp.ts` | Discard narration superseded by a new tool call, preserve final chunks across late tool-status updates, and use the same extraction for guard retries. Do not send an empty reply or replay stale narration when no final answer was produced. |
| Core tests | Exercise real ACP notifications, requester routing, failure/unknown/cancelled/interrupted outcomes, and retained operator diagnostics on Buzz and Slack. |
| `CHANGELOG.md` | Describe the user-visible presentation changes under Unreleased. |

For example, automatic completion becomes “The audit job finished. Its result is ready to review.” A passing worker does not claim that an invitation, deployment or other application change succeeded; that requires its declared output. Failed and uncertain runs remain explicit, and cancellation does not imply rollback.

## Test Plan

- [x] Red-first verification: 11 changed/new behavior cases failed before their fixes (9 initial failures, then 2 cancellation/unknown failures).
- [x] `pnpm test --maxWorkers=2` — 70 files, 1,450 tests passed, including 9 added cases.
- [x] `pnpm typecheck` — root and package checks passed.
- [x] Review regression: an overlapping run produced the old refusal message before the fix; the new case requires an explicit overlap explanation. The async completion test now awaits its reply callback instead of polling.
- [x] `git diff --check` — passed.

<details>
<summary>Scope and validation notes</summary>

The initial default-concurrency full run had three failures in unchanged relay/socket and 300ms shell-timeout fixtures. The complete run with two workers passed; no timeout settings or unrelated implementation were changed. The review correction also passed the complete two-worker suite and typechecking.

This changes presentation at the existing guarded reply boundary. The brain receives no new credential or write path. Tool results, declared operator reports, retained diagnostics, and application-output reader/conversation binding remain intact. Automatic summaries do not interpolate worker-written error text or application output. No new configuration, dependency, service or chart changes are required. Existing deployments receive the change after a toolkit release and runtime image update.

</details>

---
<details>
<summary>Checklist</summary>

- [x] Tests added: 9 new cases plus updated completion and diagnostic expectations
- [x] `pnpm typecheck` and the full test suite green
- [x] Deployment checks: N/A — `deploy/` unchanged
- [x] CHANGELOG entry added
- [x] Compatibility: requester-facing wording changes; no API or manifest changes
- [x] Behavior documented above and in CHANGELOG; no configuration changes

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of streamed assistant responses, including replies interrupted by tool activity and rewritten responses.
  - Empty assistant responses are no longer displayed.
  - Detached job updates now provide concise, human-readable statuses for success, failure, cancellation, interruption, timeout, refusal, and uncertain outcomes.
  - Diagnostic details are no longer copied into user-facing replies.
  - Completion messages no longer imply that application changes were successfully applied; uncertain results direct users to the saved result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->