### PR TITLE
feat(core): preserve kill-switch admission diagnostics in work events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A monitor can tell a deliberately parked job from one nobody meant to stop.** Every
+  `run.completed` work event now carries a host-minted `admission` section: the switch
+  reading this run took (`state`, `origin`, bounded `failure`), what its stored value was
+  recognized as (`arming`, `parking`, `unrecognized`, or `unavailable` from a switch source
+  that predates the classification), and `bypassed_switch` for a human's run of a parked
+  job. `switch: null` means the record holds no reading — the job declares none, or the run
+  was refused before one was read. Unrecognized values still park the job, and only
+  `value: "parking"` is evidence anyone chose that: a scheduled job denied every run
+  because its key was never written no longer reads the same as one somebody parked. No
+  stored value, annotation, requester or backend error text is emitted. Existing manifests
+  and custom `SwitchSource` implementations need no change; consumers must treat a missing
+  `admission` as unknown, never as parked. See
+  [the job contract](docs/job-contract.md#admission-diagnostics-on-the-terminal-record).
 - Chat replies keep the final ACP answer without replaying narration superseded by
   tool calls. Detached jobs reply to their requester in plain language; diagnostic
   IDs, timings, gate details and raw failure reports stay in operator records/reports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stored value, annotation, requester or backend error text is emitted. Existing manifests
   and custom `SwitchSource` implementations need no change; consumers must treat a missing
   `admission` as unknown, never as parked. External-dispatch requests gain the same
-  optional field, which a dispatcher parses strictly: bring the dispatcher to this release
-  before the gateway, or a worker job fails to dispatch for as long as the gateway is
-  ahead of it. See
+  optional field, which a dispatcher parses strictly. A request carries it whenever the
+  switch key holds a value, which is every armed job: bring the dispatcher to this release
+  before the gateway, or those jobs fail to dispatch while the gateway is ahead of it. See
   [the job contract](docs/job-contract.md#admission-diagnostics-on-the-terminal-record).
 - Chat replies keep the final ACP answer without replaying narration superseded by
   tool calls. Detached jobs reply to their requester in plain language; diagnostic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   because its key was never written no longer reads the same as one somebody parked. No
   stored value, annotation, requester or backend error text is emitted. Existing manifests
   and custom `SwitchSource` implementations need no change; consumers must treat a missing
-  `admission` as unknown, never as parked. See
+  `admission` as unknown, never as parked. External-dispatch requests gain the same
+  optional field, which a dispatcher parses strictly: bring the dispatcher to this release
+  before the gateway, or a worker job fails to dispatch for as long as the gateway is
+  ahead of it. See
   [the job contract](docs/job-contract.md#admission-diagnostics-on-the-terminal-record).
 - Chat replies keep the final ACP answer without replaying narration superseded by
   tool calls. Detached jobs reply to their requester in plain language; diagnostic

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -510,8 +510,8 @@ must not send fields simply because they hope a host will ignore them.
 
 Every structured record is at most **8,192 UTF-8 bytes**, including its wrapper
 and trailing newline. If optional facts do not fit, whole items are omitted and
-`partial` becomes true. The run identity, timestamps, outcome and combined verdict
-are preserved. An identity that cannot itself fit is an emission failure; execution
+`partial` becomes true. The run identity, timestamps, outcome, combined verdict and
+`admission` are preserved. An identity that cannot itself fit is an emission failure; execution
 still proceeds. Identifier-unsafe historical gate names are omitted and also mark
 the event partial. Gate details, requester identity, parameters, reasons/raw errors,
 model output, transcripts, and credentials are not structured work fields.

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -358,7 +358,7 @@ named fleets. Consumers must ignore unsupported schema versions.
 
 ```jsonl
 {"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_ms":300000,"event":"run.started","occurred_at":"2026-09-07T03:00:00.010Z"}}
-{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_ms":300000,"event":"run.completed","occurred_at":"2026-09-07T03:00:12.000Z","outcome":"completed","verdict":"PASS","checks":[{"gate":"job:triage","executed":true,"exit_code":0,"source":"host"},{"gate":"ci","executed":true,"exit_code":0,"source":"producer"}],"report_status":"valid","partial":false}}
+{"sageox_work_event":{"schema_version":1,"agent":"reviewer","job":"triage","run_id":"opaque-run-id","trigger":"schedule","started_at":"2026-09-07T03:00:00.000Z","deadline_ms":300000,"event":"run.completed","occurred_at":"2026-09-07T03:00:12.000Z","outcome":"completed","verdict":"PASS","checks":[{"gate":"job:triage","executed":true,"exit_code":0,"source":"host"},{"gate":"ci","executed":true,"exit_code":0,"source":"producer"}],"report_status":"valid","admission":{"bypassed_switch":false,"switch":{"state":"on","origin":"set","value":"arming"}},"partial":false}}
 ```
 
 `started_at` records the attempt; the start event's `occurred_at` records admission.
@@ -395,6 +395,49 @@ contract does not expand the worker's termination-log protocol or cloud policies
 A killed host can leave a start with **no terminal record**. Absence is not proof
 of success or failure. Observer/output failures are best-effort losses and never
 change job admission or settlement. There is no durable event queue or replay.
+
+### Admission diagnostics on the terminal record
+
+`admission` is host-minted and appears on every `run.completed` record. It answers
+why the run was allowed to start, or was not, without carrying the stored value.
+
+`switch` is the reading this run's job took, or `null`. A `null` means this record
+holds no reading: the job declares no kill switch, or — on a `denied-trigger` or
+`skipped-overlap` outcome — the run was refused before one was read, which the
+`outcome` already names. Otherwise:
+
+| Field | Values | Present |
+|---|---|---|
+| `state` | `on`, `off` | always — after the job's `failDirection` is applied |
+| `origin` | `set`, `never-set`, `unreadable` | always |
+| `value` | `arming`, `parking`, `unrecognized`, `unavailable` | when `origin` is `set` |
+| `failure` | one of the bounded lookup failure codes | when `origin` is `unreadable` |
+
+`value` is what the stored text was recognized as, classified before the text was
+discarded. `arming` is one of `on`, `true`, `yes`, `1`, `enabled`, `armed`;
+`parking` is one of `off`, `false`, `no`, `0`, `disabled`, `parked`; both are
+compared after trimming and lowercasing. Everything else is `unrecognized` and
+still parks the job — including an annotated form such as `off — back Monday`, and
+including a typo of an arming value such as `onn`. `sageox-agent job park` writes a
+bare `off`. `unavailable` means a value was retrieved by a switch source that
+predates this classification. **Only `value: "parking"` is evidence that somebody
+parked the job on purpose. `origin: "set"` alone is not.**
+
+`bypassed_switch` is `true` when a human's `on-request` run was admitted while the
+job was parked. That run is manual execution and is not evidence that scheduled
+admission works: a consumer counting admissions must read `trigger` alongside it.
+
+A monitor watching for a job that is never admitted can suppress
+`value: "parking"` without also suppressing `never-set`, `unreadable`,
+`unrecognized`, or `unavailable`. Records from a toolkit release before this
+contract carry no `admission` key at all; treat its absence as unknown, never as
+parked.
+
+Custom `SwitchSource` implementations keep working unchanged and report
+`value: "unavailable"`. To classify, return the `value` field on a `set` lookup —
+`interpretSwitchValue` from core produces it, and is what the Buzz engram source
+uses. External-dispatch requests carry the same optional field, so a gateway and a
+dispatcher on different toolkit releases still dispatch.
 
 ### Optional facts in the existing verdict file
 

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -443,8 +443,9 @@ parsed strictly: a reader rejects a field it does not recognize. An added option
 field is therefore compatible in one direction only. A gateway older than the
 dispatcher it sends to omits `value`, the dispatcher accepts the request, and the
 run reports `unavailable`. The reverse does not hold — a dispatcher older than its
-gateway rejects the request, and the worker job does not start. Never run a
-dispatcher behind the gateway that dispatches to it.
+gateway rejects any request carrying `value`, and that worker job does not start.
+A request carries `value` whenever the switch key holds a value, so this reaches
+every armed job. Never run a dispatcher behind the gateway that dispatches to it.
 
 ### Optional facts in the existing verdict file
 

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -436,8 +436,15 @@ parked.
 Custom `SwitchSource` implementations keep working unchanged and report
 `value: "unavailable"`. To classify, return the `value` field on a `set` lookup —
 `interpretSwitchValue` from core produces it, and is what the Buzz engram source
-uses. External-dispatch requests carry the same optional field, so a gateway and a
-dispatcher on different toolkit releases still dispatch.
+uses.
+
+External-dispatch requests carry the same optional field, and that request is
+parsed strictly: a reader rejects a field it does not recognize. An added optional
+field is therefore compatible in one direction only. A gateway older than the
+dispatcher it sends to omits `value`, the dispatcher accepts the request, and the
+run reports `unavailable`. The reverse does not hold — a dispatcher older than its
+gateway rejects the request, and the worker job does not start. Never run a
+dispatcher behind the gateway that dispatches to it.
 
 ### Optional facts in the existing verdict file
 

--- a/packages/adapter-buzz/test/kill-switch.test.ts
+++ b/packages/adapter-buzz/test/kill-switch.test.ts
@@ -70,7 +70,7 @@ describe("the remote half of the kill switch", () => {
 
     // Fail-open, so nothing but a value somebody wrote could have stopped this job.
     expect(admission).toMatchObject({ admitted: false, outcome: "denied-switch" });
-    expect(admission.switch).toEqual({ state: "off", origin: "set" });
+    expect(admission.switch).toEqual({ state: "off", origin: "set", value: "parking" });
     // Admission reads. A run never writes the posture it just read — not to arm it, and
     // not to "confirm" it.
     expect(relay.published.length).toBe(written);
@@ -86,7 +86,7 @@ describe("the remote half of the kill switch", () => {
       engramSwitchSource(config),
     );
     expect(admission).toMatchObject({ admitted: true, bypassedSwitch: false });
-    expect(admission.switch).toEqual({ state: "on", origin: "set" });
+    expect(admission.switch).toEqual({ state: "on", origin: "set", value: "arming" });
   });
 
   it("calls an untouched key never-set, which is not the same as off", async () => {

--- a/packages/cli/test/job-run.test.ts
+++ b/packages/cli/test/job-run.test.ts
@@ -406,6 +406,10 @@ it("isolates forged child envelopes from host records for both trigger paths", a
       expect(events.map((event) => event.event)).toEqual(["run.started", "run.completed"]);
       expect(events.every((event) => event.trigger === trigger)).toBe(true);
       expect(json.some((line) => line.job_diagnostic?.text.includes("forged"))).toBe(true);
+      // This bundle has no private brain, so `shift` really cannot read the switch it
+      // declares. Fails open, runs, and the record says which of those two it was.
+      expect(events[1].admission).toEqual({ bypassed_switch: false,
+        switch: { state: "on", origin: "unreadable", failure: "backend-missing" } });
     }
   } finally { vi.unstubAllEnvs(); }
 });
@@ -466,6 +470,9 @@ require("readline").createInterface({input:process.stdin}).on("line",async line=
     const events = records.filter((r) => r.sageox_work_event).map((r) => r.sageox_work_event);
     expect(events.map((e) => e.event)).toEqual(["run.started", "run.completed"]);
     expect(events[1]).toMatchObject({ run_id: events[0].run_id, agent: "demo", job: "shift", trigger: "on-request", verdict: "PASS" });
+    // The gateway host carries the same admission contract the `job run` host does. This
+    // job declares no kill switch, which is a different record from one that read parked.
+    expect(events[1].admission).toEqual({ bypassed_switch: false, switch: null });
     expect(records.some((r) => r.job_diagnostic?.text.includes("forged"))).toBe(true);
   } finally {
     child.kill("SIGTERM");

--- a/packages/cli/test/job-run.test.ts
+++ b/packages/cli/test/job-run.test.ts
@@ -407,7 +407,8 @@ it("isolates forged child envelopes from host records for both trigger paths", a
       expect(events.every((event) => event.trigger === trigger)).toBe(true);
       expect(json.some((line) => line.job_diagnostic?.text.includes("forged"))).toBe(true);
       // This bundle has no private brain, so `shift` really cannot read the switch it
-      // declares. Fails open, runs, and the record says which of those two it was.
+      // declares. It runs because `failDirection: open` says to, and `origin: "unreadable"`
+      // keeps that distinct from a run somebody armed.
       expect(events[1].admission).toEqual({ bypassed_switch: false,
         switch: { state: "on", origin: "unreadable", failure: "backend-missing" } });
     }

--- a/packages/core/src/external-jobs.ts
+++ b/packages/core/src/external-jobs.ts
@@ -18,8 +18,10 @@ export const ExternalRequestSchema = z.object({
   switch: z.object({
     state: z.enum(["on", "off"]),
     origin: z.enum(["set", "never-set", "unreadable"]),
-    // Optional so a gateway that predates the classification still dispatches. Its absence
-    // is carried through to the work event as `unavailable`, never as deliberate parking.
+    // Optional so a gateway that predates the classification still dispatches, and its
+    // absence reaches the work event as `unavailable`, never as deliberate parking. That
+    // is the only compatible direction: this object is strict, so a dispatcher older than
+    // its gateway rejects every request carrying `value`.
     value: z.enum(["arming", "parking", "unrecognized"]).optional(),
     failure: z.enum(["no-signing-key", "no-owner", "backend-missing", "timeout", "unreachable", "auth-failed", "backend-error"]).optional(),
   }).strict().nullable(),

--- a/packages/core/src/external-jobs.ts
+++ b/packages/core/src/external-jobs.ts
@@ -18,6 +18,9 @@ export const ExternalRequestSchema = z.object({
   switch: z.object({
     state: z.enum(["on", "off"]),
     origin: z.enum(["set", "never-set", "unreadable"]),
+    // Optional so a gateway that predates the classification still dispatches. Its absence
+    // is carried through to the work event as `unavailable`, never as deliberate parking.
+    value: z.enum(["arming", "parking", "unrecognized"]).optional(),
     failure: z.enum(["no-signing-key", "no-owner", "backend-missing", "timeout", "unreachable", "auth-failed", "backend-error"]).optional(),
   }).strict().nullable(),
   bypassedSwitch: z.boolean(),

--- a/packages/core/src/job-dispatcher.ts
+++ b/packages/core/src/job-dispatcher.ts
@@ -151,7 +151,9 @@ export class JobDispatcher {
     // No caller of the model-facing tool can set either this reading or requestedBy.
     const admission = await admitJob(job, request, async () => {
       const reading = request.switch;
-      if (reading?.origin === "set") return { origin: "set", state: reading.state };
+      if (reading?.origin === "set") {
+        return { origin: "set", state: reading.state, ...(reading.value ? { value: reading.value } : {}) };
+      }
       if (reading?.origin === "never-set") return { origin: "never-set" };
       return { origin: "unreadable", failure: reading?.failure ?? "backend-missing" };
     });

--- a/packages/core/src/kill-switch.ts
+++ b/packages/core/src/kill-switch.ts
@@ -32,6 +32,17 @@ export type SwitchFailure =
 export type SwitchState = "on" | "off";
 
 /**
+ * What a retrieved value was recognized as, decided while the raw text is still in hand.
+ *
+ * Every value that does not arm parks, so `state` alone cannot say whether a human chose
+ * `off` or fat-fingered `onn`. A monitor watching for a job that is never admitted has to
+ * tell those apart: the first is somebody's decision and must not page anyone, the second
+ * is a job nobody meant to stop. Recorded rather than re-derived because the value itself
+ * never leaves this function — it is the operator's text, and events carry none of it.
+ */
+export type SwitchValueClass = "arming" | "parking" | "unrecognized";
+
+/**
  * What the backend said, before any job's fail-direction interprets it.
  *
  * Separate from {@link SwitchReading} because the two answer different questions: this one
@@ -39,7 +50,7 @@ export type SwitchState = "on" | "off";
  * of opposite fail-direction turn the same lookup into opposite readings.
  */
 export type SwitchLookup =
-  | { origin: "set"; state: SwitchState }
+  | { origin: "set"; state: SwitchState; value?: SwitchValueClass }
   | { origin: "never-set" }
   | { origin: "unreadable"; failure: SwitchFailure };
 
@@ -47,6 +58,12 @@ export type SwitchLookup =
 export interface SwitchReading {
   state: SwitchState;
   origin: SwitchOrigin;
+  /**
+   * Only ever set when `origin` is `set` — the other two origins never reached a value.
+   * Absent from a source written before this existed, which is why nothing may read a bare
+   * `origin: "set"` as evidence that somebody deliberately parked the job.
+   */
+  value?: SwitchValueClass;
   /**
    * Only ever set when `origin` is `unreadable` — a never-set reading is a fact about the
    * key, and hanging a "why it failed" off it would invent one.
@@ -102,16 +119,33 @@ export interface JobAdmission {
 const ARMING_VALUES = new Set(["on", "true", "yes", "1", "enabled", "armed"]);
 
 /**
+ * The values that are recognized as somebody having parked the job on purpose.
+ *
+ * It changes no outcome — everything outside {@link ARMING_VALUES} parks either way — so it
+ * is safe for it to be a closed list where the arming one has to be. What it decides is
+ * whether a denial is worth telling anyone about, and only an exact spelling settles that:
+ * an annotated `off — back Monday` is a sentence, and admitting sentences here would make
+ * `on — back Monday` (which parks, and which nobody intended to) look deliberate too.
+ * `sageox-agent job park` writes a bare `off` for exactly this reason.
+ */
+const PARKING_VALUES = new Set(["off", "false", "no", "0", "disabled", "parked"]);
+
+/**
  * What one stored value means. The vocabulary is the switch's, not any transport's.
  *
  * Always `set` — a value in hand is evidence of intent, whatever it says. The other two
  * origins are facts about a read that did not reach one, which is why the transport builds
  * them and this never does.
  */
-export function interpretSwitchValue(raw: string): { origin: "set"; state: SwitchState } {
+export function interpretSwitchValue(
+  raw: string,
+): { origin: "set"; state: SwitchState; value: SwitchValueClass } {
+  const value = raw.trim().toLowerCase();
+  if (ARMING_VALUES.has(value)) return { origin: "set", state: "on", value: "arming" };
   return {
     origin: "set",
-    state: ARMING_VALUES.has(raw.trim().toLowerCase()) ? "on" : "off",
+    state: "off",
+    value: PARKING_VALUES.has(value) ? "parking" : "unrecognized",
   };
 }
 
@@ -206,7 +240,11 @@ function resolveSwitchReading(
   lookup: SwitchLookup,
   failDirection: "open" | "closed",
 ): SwitchReading {
-  if (lookup.origin === "set") return { state: lookup.state, origin: "set" };
+  if (lookup.origin === "set") {
+    // Omitted rather than guessed when the source did not classify: a reader that saw
+    // `value: "parking"` here would be reading this line's default, not the stored value.
+    return { state: lookup.state, origin: "set", ...(lookup.value ? { value: lookup.value } : {}) };
+  }
   const state: SwitchState = failDirection === "open" ? "on" : "off";
   return lookup.origin === "never-set"
     ? { state, origin: "never-set" }

--- a/packages/core/src/kill-switch.ts
+++ b/packages/core/src/kill-switch.ts
@@ -37,8 +37,8 @@ export type SwitchState = "on" | "off";
  * Every value that does not arm parks, so `state` alone cannot say whether a human chose
  * `off` or fat-fingered `onn`. A monitor watching for a job that is never admitted has to
  * tell those apart: the first is somebody's decision and must not page anyone, the second
- * is a job nobody meant to stop. Recorded rather than re-derived because the value itself
- * never leaves this function — it is the operator's text, and events carry none of it.
+ * is a job nobody meant to stop. Classified here rather than downstream because the raw
+ * text stops here — it is the operator's, and no record this produces carries it.
  */
 export type SwitchValueClass = "arming" | "parking" | "unrecognized";
 

--- a/packages/core/src/work-events.ts
+++ b/packages/core/src/work-events.ts
@@ -66,6 +66,31 @@ export type WorkStart = Pick<JobRun, "jobSlug" | "runId" | "trigger" | "startedA
   deadlineMs: number;
 };
 
+/**
+ * Why the host let this run start, or did not. Host-minted, from the reading `admitJob`
+ * took — never from the verdict file, which `WorkReportSchema` would reject this key from
+ * anyway, and which is spread before this in {@link jobWorkEvents} so that it cannot win.
+ *
+ * `switch: null` means this record carries no reading: the job declares no kill switch, or
+ * — on a `denied-trigger` or `skipped-overlap` outcome — the run was refused before one was
+ * read. `value: "unavailable"` means a value was retrieved by a source that predates the
+ * classification, which is not the same as, and must never be counted as, `parking`.
+ *
+ * None of it is derived from `outcome`: a run denied by `suspend` still reports the switch
+ * it read, because "parked twice" and "parked once" send an operator to different files.
+ */
+function admission(run: JobRun): Record<string, unknown> {
+  return {
+    bypassed_switch: run.bypassedSwitch,
+    switch: run.switch && {
+      state: run.switch.state,
+      origin: run.switch.origin,
+      ...(run.switch.origin === "set" ? { value: run.switch.value ?? "unavailable" } : {}),
+      ...(run.switch.failure ? { failure: run.switch.failure } : {}),
+    },
+  };
+}
+
 // Includes the reserved wrapper and newline, below common container log buffers.
 export const MAX_WORK_EVENT_BYTES = 8 * 1024;
 export { JOB_ARTIFACT_LIMIT_BYTES as MAX_WORK_REPORT_BYTES } from "./job-output.ts";
@@ -153,6 +178,8 @@ export function jobWorkEvents(
         execution: run.execution,
         report_status: run.reportStatus,
         ...(report.success ? report.data : {}),
+        // After the report, so a producer key that ever became valid still loses to the host.
+        admission: admission(run),
         partial: !report.success || report.data.partial === true ||
           (run.reportStatus !== undefined && run.reportStatus !== "valid") ||
           run.checks === undefined || checks.length !== run.checks.length,

--- a/packages/core/src/work-events.ts
+++ b/packages/core/src/work-events.ts
@@ -68,8 +68,9 @@ export type WorkStart = Pick<JobRun, "jobSlug" | "runId" | "trigger" | "startedA
 
 /**
  * Why the host let this run start, or did not. Host-minted, from the reading `admitJob`
- * took — never from the verdict file, which `WorkReportSchema` would reject this key from
- * anyway, and which is spread before this in {@link jobWorkEvents} so that it cannot win.
+ * took — never from the verdict file. `WorkReportSchema` is strict and rejects this key,
+ * and {@link jobWorkEvents} spreads the report ahead of this so that a report which ever
+ * did carry one would still lose to the host's.
  *
  * `switch: null` means this record carries no reading: the job declares no kill switch, or
  * — on a `denied-trigger` or `skipped-overlap` outcome — the run was refused before one was
@@ -77,7 +78,8 @@ export type WorkStart = Pick<JobRun, "jobSlug" | "runId" | "trigger" | "startedA
  * classification, which is not the same as, and must never be counted as, `parking`.
  *
  * None of it is derived from `outcome`: a run denied by `suspend` still reports the switch
- * it read, because "parked twice" and "parked once" send an operator to different files.
+ * it read, because lifting `suspend` takes a reviewed manifest diff and clearing the switch
+ * takes a key write — an operator meeting a denial has to know which one is holding it.
  */
 function admission(run: JobRun): Record<string, unknown> {
   return {

--- a/packages/core/test/job-dispatcher.test.ts
+++ b/packages/core/test/job-dispatcher.test.ts
@@ -896,7 +896,8 @@ it.each([false, true])("reads short verdict chunks completely while preserving t
 it.each([
   ["a classified value", "parking" as const, "parking"],
   // The compatible direction, and the only one there is: the request schema is strict, so
-  // a dispatcher older than its gateway rejects `value` outright and nothing dispatches.
+  // a dispatcher older than its gateway rejects every request that carries `value` — which
+  // is every armed job, since a reading only has one when the switch key holds a value.
   ["a gateway that predates the classification", undefined, "unavailable"],
 ])("carries %s across the dispatch wire", async (_case, value, reported) => {
   const { jobWorkEvents } = await import("../src/work-events.ts");

--- a/packages/core/test/job-dispatcher.test.ts
+++ b/packages/core/test/job-dispatcher.test.ts
@@ -893,6 +893,30 @@ it.each([false, true])("reads short verdict chunks completely while preserving t
   } finally { reads.mockRestore(); await rm(dir, { recursive: true, force: true }); }
 });
 
+it.each([
+  ["a classified value", "parking" as const, "parking"],
+  // The compatible direction, and the only one there is: the request schema is strict, so
+  // a dispatcher older than its gateway rejects `value` outright and nothing dispatches.
+  ["a gateway that predates the classification", undefined, "unavailable"],
+])("carries %s across the dispatch wire", async (_case, value, reported) => {
+  const { jobWorkEvents } = await import("../src/work-events.ts");
+  const api = new Cluster(), dispatch = dispatcher(api), job = manifest().jobs[0]!;
+  const req: ExternalRequest = { ...request(job),
+    switch: { origin: "set", state: "off", ...(value ? { value } : {}) } };
+
+  const status = await dispatch.dispatch(req);
+  expect(status.state).toBe("pending");
+  const stored: ExternalRequest = JSON.parse(api.objects.get(`configmaps/${runName(req.runId)}`)!.data!.run!).request;
+  expect(stored.switch).toEqual(req.switch);
+
+  const events: Array<Record<string, any>> = [];
+  jobWorkEvents("demo", { AGENT_WORK_EVENTS: "1" }, (line) => events.push(JSON.parse(line).sageox_work_event))
+    .onRun!(externalRun(req, { ...status, state: "finished", endedAt: req.startedAt + 50,
+      outcome: "completed", result: { outcome: "completed", counts: { PASS: 1, FAIL: 0, UNKNOWN: 0 } } }));
+  expect(events[0]!.admission).toEqual({ bypassed_switch: true,
+    switch: { state: "off", origin: "set", value: reported } });
+});
+
 it.each(["pending", "finished", "skipped-overlap"] as const)("reports external %s observation with its existing run ID despite throwing observers", async (state) => {
   const { jobWorkEvents } = await import("../src/work-events.ts");
   const job = manifest().jobs[0]!;

--- a/packages/core/test/job-dispatcher.test.ts
+++ b/packages/core/test/job-dispatcher.test.ts
@@ -911,7 +911,7 @@ it.each([
 
   const events: Array<Record<string, any>> = [];
   jobWorkEvents("demo", { AGENT_WORK_EVENTS: "1" }, (line) => events.push(JSON.parse(line).sageox_work_event))
-    .onRun!(externalRun(req, { ...status, state: "finished", endedAt: req.startedAt + 50,
+    .onRun!(externalRun(stored, { ...status, state: "finished", endedAt: req.startedAt + 50,
       outcome: "completed", result: { outcome: "completed", counts: { PASS: 1, FAIL: 0, UNKNOWN: 0 } } }));
   expect(events[0]!.admission).toEqual({ bypassed_switch: true,
     switch: { state: "off", origin: "set", value: reported } });

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -13,7 +13,7 @@ import {
   type JobRun,
 } from "../src/job-host.ts";
 import type { EventRef } from "../src/events.ts";
-import type { SwitchLookup, SwitchSource } from "../src/kill-switch.ts";
+import { interpretSwitchValue, type SwitchLookup, type SwitchSource } from "../src/kill-switch.ts";
 import { loadManifest, type JobAnnounce, type JobConfig } from "../src/manifest.ts";
 import { combineVerdicts, describeVerdict, type ProvenVoice } from "../src/verdict.ts";
 import { collectJobOutput, JOB_OUTPUT_LIMIT_BYTES, type FinalJobOutput } from "../src/job-output.ts";
@@ -1075,6 +1075,92 @@ describe("structured work lifecycle", () => {
       const result = await h.tick(body(`if(process.env.JOB_WORK_SCHEMA_VERSION!==${JSON.stringify(expected)})process.exit(1);${WRITE}JSON.stringify({gates:[{gate:"capability",executed:true,exitCode:0}]}));`));
       expect(result.verdict.status).toBe("PASS");
     }
+  });
+});
+
+describe("admission diagnostics on the terminal event", () => {
+  /** One run through a real host and a real switch source, and the record it wrote out. */
+  const terminal = async (
+    start: (host: JobHost, declared: JobConfig) => Promise<JobRun>,
+    source?: SwitchSource,
+    over: Record<string, string | undefined> = {},
+    script = PROVES,
+  ) => {
+    const { jobWorkEvents } = await import("../src/work-events.ts");
+    const events: Array<Record<string, any>> = [];
+    const h = new JobHost({
+      workDir, switchSource: source, env: { ...process.env, MARKER: marker },
+      ...jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" },
+        (line) => events.push(JSON.parse(line).sageox_work_event)),
+    });
+    const run = await start(h, body(script, over));
+    const own = events.filter((event) => event.run_id === run.runId && event.event === "run.completed");
+    expect(own).toHaveLength(1);
+    return { run, event: own[0]! };
+  };
+
+  /** A backend holding one value, classified by the same parser every real source uses. */
+  const stored = (value: string): SwitchSource => async () => interpretSwitchValue(value);
+  const unreadable = answers({ origin: "unreadable", failure: "timeout" });
+
+  it.each([
+    ["a value somebody armed", stored("on"), "closed", { state: "on", origin: "set", value: "arming" }],
+    ["a value somebody parked", stored("off"), "closed", { state: "off", origin: "set", value: "parking" }],
+    ["an annotated arming value", stored("on — operator annotation"), "closed",
+      { state: "off", origin: "set", value: "unrecognized" }],
+    ["a key nobody has written", answers({ origin: "never-set" }), "closed",
+      { state: "off", origin: "never-set" }],
+    ["a lookup that failed", unreadable, "closed",
+      { state: "off", origin: "unreadable", failure: "timeout" }],
+    ["the same failure on a fail-open job", unreadable, "open",
+      { state: "on", origin: "unreadable", failure: "timeout" }],
+    // The compatibility path: a source written before the classification existed returns
+    // the state and nothing else, and must never be read as somebody's decision to park.
+    ["a source that cannot classify", answers({ origin: "set", state: "off" }), "closed",
+      { state: "off", origin: "set", value: "unavailable" }],
+  ])("tells %s apart on a scheduled run", async (_case, source, failDirection, reading) => {
+    const { run, event } = await terminal((h, declared) => h.tick(declared), source,
+      { killSwitch: `{failDirection: ${failDirection}}` });
+    expect(event.admission).toEqual({ bypassed_switch: false, switch: reading });
+    expect(run.outcome).toBe(reading.state === "on" ? "completed" : "denied-switch");
+    // The operator's text is what the classification was derived from, and the only place
+    // it is allowed to exist. Nothing carries it onto a log line.
+    expect(JSON.stringify(event)).not.toContain("annotation");
+  });
+
+  it("says a job with no kill switch has no reading, rather than one that reads parked", async () => {
+    const { run, event } = await terminal(
+      (h, declared) => h.request(declared, { kind: "human", id: "owner" }), undefined,
+      { killSwitch: undefined, trigger: "{onRequest: true}" });
+    expect(run.outcome).toBe("completed");
+    expect(event.admission).toEqual({ bypassed_switch: false, switch: null });
+  });
+
+  it("keeps a human's bypass out of the scheduled admission history", async () => {
+    const parked = { state: "off", origin: "set", value: "parking" };
+    const denied = await terminal((h, declared) => h.tick(declared), stored("off"));
+    const bypass = await terminal(
+      (h, declared) => h.request(declared, { kind: "human", id: "owner" }), stored("off"));
+
+    // Same switch, same reading, opposite outcomes — and the one that ran says so, so a
+    // monitor counting scheduled admissions cannot mistake it for the job being armed.
+    expect(denied.event).toMatchObject({ trigger: "schedule", outcome: "denied-switch",
+      admission: { bypassed_switch: false, switch: parked } });
+    expect(bypass.event).toMatchObject({ trigger: "on-request", outcome: "completed",
+      admission: { bypassed_switch: true, switch: parked } });
+    expect(spawns()).toBe(1);
+  });
+
+  it("keeps the host's admission over a report that claims its own", async () => {
+    const forged = { bypassed_switch: false, switch: { state: "on", origin: "set", value: "arming" } };
+    const { run, event } = await terminal(
+      (h, declared) => h.request(declared, { kind: "human", id: "owner" }), stored("off"), {},
+      `${WRITE}JSON.stringify({gates:[{gate:"ci",executed:true,exitCode:0}],admission:${JSON.stringify(forged)}}))`);
+
+    expect(run.reportStatus).toBe("invalid");
+    expect(event.admission).toEqual(
+      { bypassed_switch: true, switch: { state: "off", origin: "set", value: "parking" } });
+    expect(event.partial).toBe(true);
   });
 });
 

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -1123,8 +1123,8 @@ describe("admission diagnostics on the terminal event", () => {
       { killSwitch: `{failDirection: ${failDirection}}` });
     expect(event.admission).toEqual({ bypassed_switch: false, switch: reading });
     expect(run.outcome).toBe(reading.state === "on" ? "completed" : "denied-switch");
-    // The operator's text is what the classification was derived from, and the only place
-    // it is allowed to exist. Nothing carries it onto a log line.
+    // The classification is derived from the operator's text, and the event carries no
+    // part of that text — which is why an annotated value is `unrecognized`, never quoted.
     expect(JSON.stringify(event)).not.toContain("annotation");
   });
 

--- a/packages/core/test/kill-switch.test.ts
+++ b/packages/core/test/kill-switch.test.ts
@@ -43,7 +43,7 @@ const tick: JobRequest = { trigger: "schedule" };
 describe("switch values", () => {
   it("arms only on a value that says so, in any of the spellings a human writes", () => {
     for (const value of ["on", "ON", " true ", "yes", "1", "enabled", "armed"]) {
-      expect(interpretSwitchValue(value)).toEqual({ origin: "set", state: "on" });
+      expect(interpretSwitchValue(value)).toEqual({ origin: "set", state: "on", value: "arming" });
     }
   });
 
@@ -52,8 +52,25 @@ describe("switch values", () => {
     // typo in the arming direction costs idle time somebody notices, while a typo in the
     // parking direction leaves automation running that somebody was trying to stop.
     for (const value of ["off", "false", "no", "0", "onn", "", "paused until Monday"]) {
-      expect(interpretSwitchValue(value)).toEqual({ origin: "set", state: "off" });
+      expect(interpretSwitchValue(value)).toMatchObject({ origin: "set", state: "off" });
     }
+  });
+
+  it("recognizes the parking spellings, and calls everything else parked but unrecognized", () => {
+    // Both halves park, and only the first is evidence that anyone meant to. A monitor
+    // watching a job that is never admitted suppresses `parking` and nothing else, so the
+    // list has to be exact: `off — back Monday` is a sentence, and admitting sentences
+    // would make `on — back Monday` — which parks, and which nobody intended to — look
+    // like somebody's decision. `sageox-agent job park` writes the bare `off`.
+    for (const value of ["off", "OFF", " false ", "no", "0", "disabled", "parked"]) {
+      expect(interpretSwitchValue(value).value, value).toBe("parking");
+    }
+    for (const value of ["onn", "", " ", "paused until Monday", "off — back Monday", "off_"]) {
+      expect(interpretSwitchValue(value).value, value).toBe("unrecognized");
+    }
+    // The arming direction stays strict, so an annotated `on` is denied and is not parking.
+    expect(interpretSwitchValue("on — operator annotation"))
+      .toEqual({ origin: "set", state: "off", value: "unrecognized" });
   });
 });
 

--- a/packages/core/test/work-events.test.ts
+++ b/packages/core/test/work-events.test.ts
@@ -76,6 +76,26 @@ it("contains output failures and keeps identity/outcome when optional facts over
   expect(event.health).toHaveLength(100);
 });
 
+it("keeps host admission facts when a valid report overflows the line", () => {
+  const lines: string[] = [];
+  const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, (line) => lines.push(line));
+  const health = Array.from({ length: 100 }, (_, index) => ({
+    subject: { provider: "runtime", kind: "service" as const, id: `${index}${"a".repeat(200)}` },
+    check: "readiness", status: "unknown" as const, observed_at: "2026-09-07T00:00:00Z",
+  }));
+  opts.onRun!({ ...run, work: { health },
+    switch: { state: "off", origin: "unreadable", failure: "timeout" } });
+
+  // `admission` is not in the list `workEventLine` sheds from, and it is small enough that
+  // it never has to be: shedding it would leave a denial with nothing that says why.
+  const event = JSON.parse(lines[0]!).sageox_work_event;
+  expect(Buffer.byteLength(lines[0]!)).toBeLessThanOrEqual(MAX_WORK_EVENT_BYTES);
+  expect(event.health.length).toBeLessThan(health.length);
+  expect(event.partial).toBe(true);
+  expect(event.admission).toEqual({ bypassed_switch: false,
+    switch: { state: "off", origin: "unreadable", failure: "timeout" } });
+});
+
 it("contains asynchronous sink failures", async () => {
   let calls = 0;
   const opts = jobWorkEvents("worker", { AGENT_WORK_EVENTS: "1" }, async () => {


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a089d6-cb0c-755b-a22d-a55debc1300a">Session</a>
<!-- /sageox:pr-header -->

Closes #68.

## The gap

A scheduled job can fire on time, exit cleanly, and be denied by its kill switch on every
run. `outcome: "denied-switch"` is all a work-event consumer gets, and it cannot say
whether the switch was deliberately parked, never configured, unreadable, or set to
something nobody can interpret. So a monitor cannot alert on a job that is never admitted
without also paging whoever parked one on purpose.

Two things were being dropped:

- `jobWorkEvents()` omitted `JobRun.switch` and `bypassedSwitch` from terminal records.
- `interpretSwitchValue()` returned `{state: "off", origin: "set"}` for both `"off"` and
  `"on — operator annotation"`, so exposing `origin` alone would have left a malformed
  arming value indistinguishable from valid parking.

## What changed

**`interpretSwitchValue` classifies the value while its text is still in hand** —
`arming`, `parking`, or `unrecognized` — against an explicit parking allow-list (`off`,
`false`, `no`, `0`, `disabled`, `parked`, trimmed and lowercased). The arming allow-list
and the fail direction are untouched: everything unrecognized still parks the job. Only
the classification is new, and it changes no outcome.

The parking list is closed and exact for a reason worth stating: admitting an annotated
`off — back Monday` would mean admitting sentences, and then `on — back Monday` — which
parks, and which nobody intended to — would look deliberate too. `sageox-agent job park`
writes a bare `off`.

**Every `run.completed` event carries a host-minted `admission` section:**

```json
"admission": {
  "bypassed_switch": false,
  "switch": { "state": "off", "origin": "set", "value": "parking" }
}
```

| Input | `state` | `origin` | `value` |
|---|---|---|---|
| `"on"` | on | set | arming |
| `"off"` | off | set | parking |
| `"on — operator annotation"` | off | set | unrecognized |
| Missing key, fail-closed | off | never-set | — |
| Failed lookup, fail-closed | off | unreadable | — (plus bounded `failure`) |
| Value from a source that cannot classify | off | set | unavailable |

`switch: null` means the record holds no reading: the job declares no kill switch, or — on
a `denied-trigger` or `skipped-overlap` outcome — the run was refused before one was read,
which the `outcome` already names.

**Only `value: "parking"` is evidence anyone chose to park the job.** A downstream monitor
suppresses that and nothing else; `never-set`, `unreadable`, `unrecognized`, and
`unavailable` all stay alertable. `origin: "set"` alone is never enough.

**Host-owned and unforgeable.** `admission` is spread *after* the producer report, so a
verdict file that claims its own loses to the host (`WorkReportSchema` is strict and
rejects the key anyway — the ordering is the structural guarantee, not the schema). It is
outside the list `workEventLine` sheds from when a line overflows, so a denial never loses
the fields that say why. No stored value, annotation, requester identity, or backend error
text is emitted.

**Compatibility.** `SwitchLookup.value` and the external-dispatch request field are both
optional. A custom `SwitchSource` or a gateway on an older release keeps working unchanged
and reports `value: "unavailable"`. Records from a toolkit release before this contract
carry no `admission` key at all; consumers must treat its absence as unknown, never as
parked.

## Scope

This is the producer contract only. Consecutive-denial thresholds, alert deduplication and
routing belong to the consumer — see sageox/sageox-monorepo#4315, where ~1,150 consecutive
denied scheduled runs went unnoticed.

The `admission` fields are documented in
[`docs/job-contract.md`](docs/job-contract.md#admission-diagnostics-on-the-terminal-record)
and land under `## [Unreleased]`; shipping them to downstream consumers still needs a
version cut, which is a separate change.

## Tests

`pnpm test` (70 files, 1462 tests) and `pnpm typecheck` are green.

- `packages/core/test/kill-switch.test.ts` — the parking spellings, and that arbitrary
  text, a typo of `on`, and an annotated `on` are all `unrecognized`.
- `packages/core/test/job-host.test.ts` — a real host and a real switch source over all
  five cases plus fail-open, no declared switch, and a source that cannot classify; a
  human's bypass reported without being counted as a scheduled admission; a report that
  claims its own `admission` losing to the host's.
- `packages/core/test/work-events.test.ts` — `admission` survives a valid report that
  overflows the 8 KiB line.
- `packages/cli/test/job-run.test.ts` — the same contract end-to-end from both host entry
  points (`job run` and the gateway's MCP tool), alongside the existing forged-envelope
  isolation checks.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a089d6-cb0c-755b-a22d-a55debc1300a

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791611939&installation_model_id=433550&pr_number=69&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F69&signature=c305f4441cf5ef189c05da2d44a3d694b1538782220e43ea4f8cacb51b35d9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `run.completed` events now include admission diagnostics, including switch state, origin, value classification, lookup failures, and human bypass status.
  - Switch values are classified as `arming`, `parking`, or `unrecognized`; missing values remain distinct from deliberate parking.
  - External job requests support optional switch classifications while remaining compatible with requests that omit them.
  - Admission details are preserved for partially recorded reports, while untrusted report-supplied admission data is rejected.

- **Documentation**
  - Added guidance covering admission fields, compatibility behavior, custom switch sources, and external dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->