### PR TITLE
Prepare v0.5.0 release and Helm chart 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,16 @@ On publication, `ghcr.io/sageox/agent-base:0.5.0` takes `:latest` and `:0.5`. `:
 on 0.4.1. Before 1.0.0 a minor release may break configuration, so no `:0` tag is
 published. Pin the digest recorded on the GitHub Release in production.
 
-**Upgrade the dispatcher before the gateway and the scheduled launchers.** A host on this
-release sends `switch.value` on every armed external job, and the request schema is
-strict, so a dispatcher still on 0.4.1 rejects those requests. The chart gives the gateway
-and the dispatcher the same `imageRef` and rolls their Deployments independently, so an
-in-place `helm upgrade` leaves a window in which armed external jobs fail to dispatch.
-Deployments with no external jobs are unaffected.
+**A `helm upgrade` has a window in which armed external jobs fail to dispatch, and the
+chart cannot order it away.** A host on this release sends `switch.value` on every armed
+external job, and the request schema is strict, so a dispatcher still on 0.4.1 rejects
+those requests. One `imageRef` covers the gateway, the dispatcher and the scheduled
+launchers, and their workloads roll independently — there is no values setting that takes
+the dispatcher to the new image first. Nothing is wedged by the window: it ends when the
+dispatcher Pod is replaced, a requested run that failed in it can be asked for again, and
+a scheduled one fails a tick and takes the next. To skip it, park each armed external job
+before the upgrade with `sageox-agent job park <slug>` and arm it after. Deployments with
+no external jobs are unaffected.
 
 **Two values files that rendered under chart 0.12.1 now fail.** An external worker below
 Kubernetes 1.34 is refused at render rather than shipped to a cluster that cannot run it —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-09-10
+
+Everything below shipped after `v0.4.1`.
+
+On publication, `ghcr.io/sageox/agent-base:0.5.0` takes `:latest` and `:0.5`. `:0.4` stays
+on 0.4.1. Before 1.0.0 a minor release may break configuration, so no `:0` tag is
+published. Pin the digest recorded on the GitHub Release in production.
+
+**Upgrade the dispatcher before the gateway and the scheduled launchers.** A host on this
+release sends `switch.value` on every armed external job, and the request schema is
+strict, so a dispatcher still on 0.4.1 rejects those requests. The chart gives the gateway
+and the dispatcher the same `imageRef` and rolls their Deployments independently, so an
+in-place `helm upgrade` leaves a window in which armed external jobs fail to dispatch.
+Deployments with no external jobs are unaffected.
+
+**Two values files that rendered under chart 0.12.1 now fail.** An external worker below
+Kubernetes 1.34 is refused at render rather than shipped to a cluster that cannot run it —
+1.34 has been the documented floor since external workers shipped — and a worker Secret
+that an agent's `jobSecrets` already mounts is refused as a shared credential.
+
+Everything else is additive: existing manifests need no new fields, and `report.history`,
+the `admission` section on work events and `sageox-agent validate` are each opt-in.
+
 - **A job can announce something once without keeping any state.** A job that declares
   `report.history: true` beside `report.probe: true` gets a fourth verb on its per-run
   channel, `channel_history`: the recent messages in the one channel `report` names, oldest
@@ -45,10 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to be repeated verbatim. Worker completion never claims an application side effect.
 - Repository Codex hooks now notify SageOx on `SessionEnd`, allowing active recordings
   to finalize when the session ends.
-- **Helm external workers cannot inherit invalid mounts or reuse scheduled-job
-  credentials.** Dispatcher bundle staging now excludes gateway shared volumes, and chart
-  validation rejects a worker Secret that is already used by any agent's gateway,
-  dispatcher, or scheduled jobs.
+- **Helm chart 0.13.0 keeps an external worker off every credential and cluster it must
+  not reach.** Dispatcher bundle staging now excludes gateway shared volumes. Chart
+  validation rejects a worker Secret already used by any agent's gateway, dispatcher, or
+  `jobSecrets`, and refuses an external worker rendered for a cluster older than
+  Kubernetes 1.34 — the floor
+  [the external jobs guide](docs/external-jobs.md) already named.
 - **A repository that authors `agent.yaml` files can check them in CI.** `sageox-agent
   validate <path…>` parses each file against the schema `run` loads at startup and exits
   non-zero if any is invalid, naming the field path and the expectation for each problem.

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Run one or more SageOx Agent Toolkit identities on Kubernetes
 type: application
-version: 0.12.1
+version: 0.13.0
 appVersion: "0.0.0"
 home: https://github.com/sageox/agent-toolkit
 sources:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -51,7 +51,7 @@ Or depend on it, and nest this chart's values under its name. Helm hands every s
 # Chart.yaml
 dependencies:
   - name: agent
-    version: 0.12.1
+    version: 0.13.0
     repository: "file://../agent-toolkit/deploy/helm"
 ```
 
@@ -79,11 +79,11 @@ Collect `sageox_work_event` records from those containers' stdout. Child diagnos
 use a separate envelope. External jobs report lifecycle and aggregate results from
 the launching host; their events remain partial because the dispatcher does not
 return individual worker checks or work metadata. See the
-[work event contract](https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/job-contract.md#structured-work-events-schema-1).
+[work event contract](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#structured-work-events-schema-1).
 
 Structured job answers need no chart setting: declare `output: {format: json}` in
 the bundle's `agent.yaml`, and use workers built from the same toolkit release as
-the gateway and dispatcher. See [structured answers](https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/external-jobs.md#structured-answers).
+the gateway and dispatcher. See [structured answers](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md#structured-answers).
 
 ## Where a bundle comes from
 
@@ -397,7 +397,7 @@ agents:
 
 A body then finds `workspace/repos/<owner>--<repo>` under its working directory, where a run
 started from chat already finds it
-([the job body contract](https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/job-contract.md#what-a-body-finds-on-disk)).
+([the job body contract](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#what-a-body-finds-on-disk)).
 
 Three things this deliberately does not do.
 
@@ -490,7 +490,7 @@ These gateway/scheduled-Pod mount rules apply to local jobs. An external `worker
 instead maps each `run.secrets` and `run.jobSecrets` ref through
 `agents.<agent>.jobs[].worker.secrets`.
 That worker-only credential path supports both requested and scheduled runs, without
-mounting the credential in the gateway. See [external jobs](https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/external-jobs.md).
+mounting the credential in the gateway. See [external jobs](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md).
 
 Two consequences worth knowing before you split a local job credential out:
 
@@ -518,4 +518,4 @@ rule that reads as a control and is not.
 
 ## External job workers
 
-For on-demand jobs with their own runtime image, use [the external jobs guide](https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/external-jobs.md). It covers the worker image, per-job ServiceAccount and Secret mappings, the shared dispatcher, scheduled triggers, durable results and cancellation. The gateway image does not need the task runtime.
+For on-demand jobs with their own runtime image, use [the external jobs guide](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md). It covers the worker image, per-job ServiceAccount and Secret mappings, the shared dispatcher, scheduled triggers, durable results and cancellation. The gateway image does not need the task runtime.

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -58,13 +58,13 @@ readme="$copied_chart/README.md"
 if grep -Eq '\.\./\.\./docs/(job-contract|external-jobs)\.md' "$readme"; then
   fail 'copied chart README contains a repository-relative job documentation link'
 fi
-contract_link_count=$(grep -oE 'https://github\.com/sageox/agent-toolkit/blob/v0\.4\.1/docs/(job-contract|external-jobs)\.md(#[^)[:space:]]+)?' "$readme" | wc -l | tr -d ' ')
+contract_link_count=$(grep -oE 'https://github\.com/sageox/agent-toolkit/blob/v0\.5\.0/docs/(job-contract|external-jobs)\.md(#[^)[:space:]]+)?' "$readme" | wc -l | tr -d ' ')
 [ "$contract_link_count" = 5 ] || fail "expected 5 pinned job documentation links, found $contract_link_count"
 for link in \
-  'https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/job-contract.md#structured-work-events-schema-1' \
-  'https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/external-jobs.md#structured-answers' \
-  'https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/job-contract.md#what-a-body-finds-on-disk' \
-  'https://github.com/sageox/agent-toolkit/blob/v0.4.1/docs/external-jobs.md'
+  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#structured-work-events-schema-1' \
+  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md#structured-answers' \
+  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#what-a-body-finds-on-disk' \
+  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md'
 do
   grep -qF "$link" "$readme" || fail "copied chart README is missing pinned link: $link"
 done

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -58,16 +58,23 @@ readme="$copied_chart/README.md"
 if grep -Eq '\.\./\.\./docs/(job-contract|external-jobs)\.md' "$readme"; then
   fail 'copied chart README contains a repository-relative job documentation link'
 fi
-contract_link_count=$(grep -oE 'https://github\.com/sageox/agent-toolkit/blob/v0\.5\.0/docs/(job-contract|external-jobs)\.md(#[^)[:space:]]+)?' "$readme" | wc -l | tr -d ' ')
-[ "$contract_link_count" = 5 ] || fail "expected 5 pinned job documentation links, found $contract_link_count"
-for link in \
-  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#structured-work-events-schema-1' \
-  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md#structured-answers' \
-  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#what-a-body-finds-on-disk' \
-  'https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md'
-do
-  grep -qF "$link" "$readme" || fail "copied chart README is missing pinned link: $link"
-done
+# The exact multiset, not a total plus the set of distinct values: `external-jobs.md` is
+# linked twice, so a count alone still passes when one of those two is replaced by a copy
+# of another pinned link. Matched at any tag rather than at this release's, so a link left
+# behind on the previous one is reported as the stale link it is.
+release_docs='https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs'
+expected=$(printf '%s\n' \
+  "$release_docs/external-jobs.md" \
+  "$release_docs/external-jobs.md" \
+  "$release_docs/external-jobs.md#structured-answers" \
+  "$release_docs/job-contract.md#structured-work-events-schema-1" \
+  "$release_docs/job-contract.md#what-a-body-finds-on-disk" | sort)
+# Assigned rather than piped into the comparison: under `pipefail` a `grep` that matches
+# nothing fails the assignment, and `set -e` would then kill the script before the
+# assertion below could name what was wrong.
+found=$(grep -oE 'https://github\.com/sageox/agent-toolkit/blob/[^/]+/docs/(job-contract|external-jobs)\.md(#[^)[:space:]]+)?' "$readme" | sort) || found=''
+[ "$found" = "$expected" ] || fail "pinned job documentation links in the copied chart README do not match the release:
+$(diff <(printf '%s\n' "$expected") <(printf '%s\n' "$found") | sed 's/^/  /')"
 
 # Three declared jobs across two agents: one scheduled, one on-request, one parked.
 render


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08cf1-5514-73d4-85c3-96518c370fe6">Session</a>
<!-- /sageox:pr-header -->

Cuts the CHANGELOG section for **0.5.0** and moves the Helm chart to **0.13.0**. No code
changes — every entry under the new heading already merged. Tag `v0.5.0` after this lands.

## Why minor, not patch

`.github/workflows/release.yml` publishes no `:0`, so `:0.4` is the ref an operator tracks
and a patch would move it forward — the signal that this is safe to pick up without
reading anything. That is false here.

A gateway on this release sends `switch.value` on **every armed** external job
(`packages/core/src/external-jobs.ts:21`), and `ExternalRequestSchema` is `.strict()`, so a
dispatcher still on 0.4.1 rejects those requests. The chart gives the gateway and the
dispatcher the same `imageRef` and rolls their Deployments independently, so an in-place
`helm upgrade` on a floating tag leaves a window in which armed external jobs fail to
dispatch — with no way for the operator to order the two. The 0.4.1 → 0.5.0 preamble states
that ordering; a patch is a promise nobody has to read it.

Everything else is additive: `report.history`, the `admission` section on work events, and
`sageox-agent validate` are each opt-in, and existing manifests need no new fields.

## Why the chart moves, and moves a minor

`deploy/helm/templates/` changed, which is the trigger — a code-only release leaves
`Chart.yaml` alone, as 0.3.1 did. Two values files that rendered under 0.12.1 now `fail`:

- an external worker rendered for a cluster below Kubernetes 1.34 (`validate.yaml:149`).
  1.34 has been the documented floor in `docs/external-jobs.md:7` since external workers
  shipped; the chart only now enforces it.
- a worker Secret that an agent's `jobSecrets` already mounts. 0.12.1 protected `secrets`
  and `dispatcher.tokenSecret` only.

That refusal is why 0.13.0 rather than 0.12.2, and it matches every prior release: the
chart's minor has tracked the toolkit's minor at 0.10.0/0.2.0, 0.11.0/0.3.0, 0.12.0/0.4.0.

## Files

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `## [0.5.0] - 2026-09-10`, with the tag consequences and the two upgrade actions. The Helm entry gains the Kubernetes 1.34 refusal, which #61 implemented but did not record. |
| `deploy/helm/Chart.yaml` | `0.12.1` → `0.13.0` |
| `deploy/helm/README.md` | five pinned `docs/*.md` links `blob/v0.4.1` → `blob/v0.5.0`, and the `dependencies:` example to `0.13.0` |
| `deploy/helm/tests/jobs.sh` | the same tag, which this test hardcodes |

The chart README pins its documentation links at the released tag rather than relatively,
because the chart is consumed as a standalone directory where `../../docs` does not
resolve — so the pin is release state, and `jobs.sh` and `consume.sh` guard it.

## Validation

| | |
|---|---|
| `pnpm test` | pass |
| `pnpm typecheck` | pass |
| `helm lint --strict deploy/helm --values deploy/helm/examples/two-agents.values.yaml` | pass |
| `deploy/helm/tests/{jobs,consume,bundle,networkpolicy}.sh` | pass |

`jobs.sh` and `consume.sh` both failed before the tag re-pin, which is what caught it.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a08cf1-5514-73d4-85c3-96518c370fe6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791665470&installation_model_id=433550&pr_number=72&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F72&signature=0134aef60a8730aa4afbe04c70784011b6f834e02f95c185bf6d4c3e89d623ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 0.5.0, covering upgrade ordering, compatibility requirements, Kubernetes 1.34 requirements, credential validation, and opt-in features.
  - Clarified external-worker Kubernetes requirements and credential handling for scheduled jobs and job secrets.
  - Updated Helm documentation, dependency references, and toolkit links to version 0.5.0.

- **Chores**
  - Updated the Helm chart version from 0.12.1 to 0.13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->