### PR TITLE
Admit managed Kubernetes versions at the external-worker floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **An external worker deploys on a managed Kubernetes cluster again.** The 1.34 floor
+  chart 0.13.0 introduced compared the server's version against `>=1.34.0`, and every
+  managed distribution reports a GitVersion carrying a build suffix — `v1.34.9-eks-bca9cf6`,
+  `v1.34.5-gke.1234` — which semver reads as a PRERELEASE and never matches a constraint
+  without one. The floor therefore refused every cluster it was meant to admit, including
+  ones well above it, and `helm upgrade` failed at render with `external worker requires
+  Kubernetes 1.34 or newer`. The constraint is now `>=1.34.0-0`, which admits a
+  prerelease-tagged version while still refusing a genuinely older cluster. The cases that
+  let this ship used bare versions, so they could not tell a working floor from one that
+  refuses everything; the suite now renders a suffixed version on both sides of the floor.
+
 ## [0.5.0] - 2026-09-10
 
 Everything below shipped after `v0.4.1`.

--- a/deploy/helm/templates/validate.yaml
+++ b/deploy/helm/templates/validate.yaml
@@ -146,7 +146,11 @@ SecretProviderClass, and renders a single object rather than two.
 {{- if not $agent.dispatcher -}}
 {{- fail (printf "%s/%s: external worker requires dispatcher.tokenSecret" $name $job.slug) -}}
 {{- end -}}
-{{- if not (semverCompare ">=1.34.0" $.Capabilities.KubeVersion.Version) -}}
+{{- /* `-0` is load-bearing: a managed distribution reports its GitVersion with a
+     build suffix (EKS v1.34.9-eks-bca9cf6, GKE v1.34.5-gke.1234), semver reads that
+     as a PRERELEASE, and a constraint carrying none never matches one. Without it
+     this floor refuses every managed cluster, including ones far above it. */}}
+{{- if not (semverCompare ">=1.34.0-0" $.Capabilities.KubeVersion.Version) -}}
 {{- fail (printf "%s/%s: external worker requires Kubernetes 1.34 or newer" $name $job.slug) -}}
 {{- end -}}
 {{- if hasKey $gatewayAccounts $job.worker.serviceAccountName -}}

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -354,6 +354,20 @@ refuses "external worker below the supported Kubernetes floor" \
 render --kube-version 1.33.0
 counted 2 'kind: CronJob'
 
+# THE FLOOR ON A REAL CLUSTER. Every managed distribution reports its GitVersion with a
+# build suffix, which semver reads as a prerelease; the cases above use bare versions and
+# so cannot tell a working floor from one that refuses every cluster it is meant to admit.
+refuses "external worker below the floor on a managed distribution" \
+  "harry/shift: external worker requires Kubernetes 1.34 or newer" \
+  --kube-version v1.33.9-eks-bca9cf6 \
+  --set agents.harry.dispatcher.tokenSecret=dispatcher-auth \
+  --set 'agents.harry.jobs[0].worker.serviceAccountName=task-worker'
+
+render --kube-version v1.34.9-eks-bca9cf6 \
+  --set agents.harry.dispatcher.tokenSecret=dispatcher-auth \
+  --set 'agents.harry.jobs[0].worker.serviceAccountName=task-worker'
+counted 2 'kind: CronJob'
+
 render --kube-version 1.34.0 \
   --set agents.harry.dispatcher.tokenSecret=dispatcher-auth \
   --set agents.harry.workEvents=true \


### PR DESCRIPTION
## Summary

An external worker deploys on a managed Kubernetes cluster again. Chart 0.13.0 added a
1.34 floor for external workers, and on every managed distribution that floor refuses the
cluster instead of admitting it — so `helm upgrade` fails at render, for a chart that
rendered fine seconds earlier under `helm template`.

**Root cause: `semverCompare ">=1.34.0"` is compared against the server's GitVersion, which on a managed distribution carries a build suffix (`v1.34.9-eks-bca9cf6`, `v1.34.5-gke.1234`); semver reads that as a PRERELEASE, and a constraint with no prerelease never matches one.**

**Fix: `>=1.34.0-0`, the standard idiom for admitting a prerelease-tagged version, which still refuses a genuinely older cluster.**

It is not a near-miss on the floor. `v1.35.0-eks-abcdef1` is refused just as flatly as
`v1.33.0`, so the guard rejects every managed cluster in existence at or above its own
minimum:

| constraint | vs `v1.34.9-eks-bca9cf6` |
|---|---|
| `">=1.34.0"` | **FAIL** |
| `">=1.34.0-0"` | PASS |

**Why CI was green.** `helm template` with no `--kube-version` renders against Helm's
compiled-in default — currently `v1.35.0`, bare, no suffix — which satisfies a constraint
no real cluster satisfies. The existing cases pin `1.33.0` and `1.34.0`, also bare. So
nothing in the suite could tell a working floor from one that refuses everything, and the
first place the difference appears is a deploy.

## What changed

| File | Change |
|---|---|
| `deploy/helm/templates/validate.yaml` | `>=1.34.0` → `>=1.34.0-0`, with a comment naming the two GitVersion shapes that made it necessary |
| `deploy/helm/tests/jobs.sh` | a refusal at `v1.33.9-eks-bca9cf6` and an acceptance at `v1.34.9-eks-bca9cf6` — the floor is now exercised with the version shape a cluster actually reports |
| `CHANGELOG.md` | entry under `[Unreleased]` |

## Test Plan

- [x] `pnpm test` — 1470 tests in 71 files pass
- [x] `pnpm typecheck` — clean
- [x] `bash deploy/helm/tests/jobs.sh` — `jobs.sh: ok`
- [x] **Fails without the change:** reverted the constraint to `>=1.34.0`, re-ran the suite,
      watched the new case go red with `harry/shift: external worker requires Kubernetes
      1.34 or newer`; restored the fix and watched it pass.
- [x] **Verified on a real consumer chart**, not just the test fixture: a chart with an
      external worker, rendered against `--kube-version v1.34.9-eks-bca9cf6`, fails before
      this change and renders after it — and still refuses `v1.33.9-eks-bca9cf6`, so the
      floor is fixed rather than defeated.

<details><summary>Why <code>-0</code> and not a version-string normalization</summary>

Stripping the suffix before comparing would work too, and is what a reader might reach for
first. `-0` is preferred because it is local to the one comparison, needs no helper, and is
the idiom Helm chart authors already recognize for this exact problem — a normalization
helper would have to be applied at every future capability gate to be worth anything, and
the one that gets forgotten fails in the same silent direction this did.

A lower floor was not considered: 1.34 is the documented minimum for external workers and
this change does not move it.
</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791672492&installation_model_id=433550&pr_number=74&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F74&signature=6e04132965e4a4363bcc5b056c5a8dd8cd3075c05300f21a51a44edd2531253f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - External workers now correctly recognize managed Kubernetes versions with provider-specific suffixes, such as those reported by EKS and GKE.
  - Kubernetes versions below 1.34 remain unsupported, while qualifying 1.34+ versions are accepted.

- **Tests**
  - Added coverage for both accepted and rejected suffixed Kubernetes versions to ensure version validation behaves consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->