### PR TITLE
Chart 0.13.1 for the managed-Kubernetes floor fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prerelease-tagged version while still refusing a genuinely older cluster. The cases that
   let this ship used bare versions, so they could not tell a working floor from one that
   refuses everything; the suite now renders a suffixed version on both sides of the floor.
+  Chart 0.13.1. The runtime is untouched — this is a template comparison, so the published
+  image for 0.5.0 is already correct and no new one is needed.
 
 ## [0.5.0] - 2026-09-10
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Run one or more SageOx Agent Toolkit identities on Kubernetes
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: "0.0.0"
 home: https://github.com/sageox/agent-toolkit
 sources:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -51,7 +51,7 @@ Or depend on it, and nest this chart's values under its name. Helm hands every s
 # Chart.yaml
 dependencies:
   - name: agent
-    version: 0.13.0
+    version: 0.13.1
     repository: "file://../agent-toolkit/deploy/helm"
 ```
 


### PR DESCRIPTION
## Summary

Names the chart that carries #74's fix, so "0.13.0" keeps meaning one thing. A consumer
that vendors this chart pins the version as an exact constraint, and without this bump two
different chart bodies both answer to 0.13.0 — one that refuses every managed Kubernetes
cluster at the external-worker floor, and one that does not.

**No runtime release is needed and none is implied.** #74 changed a template comparison
(`deploy/helm/templates/validate.yaml`) and its test. Nothing in `packages/**` moved, and no
runtime code reads `deploy/helm`, so the image already published for 0.5.0 is correct.
Cutting 0.5.1 would republish a digest differing only by a file nothing reads.

## What changed

| File | Change |
|---|---|
| `deploy/helm/Chart.yaml` | `version: 0.13.0` → `0.13.1` |
| `CHANGELOG.md` | names the chart version on the existing `[Unreleased]` entry, and says the runtime is untouched |

## Test Plan

- [x] `helm lint --strict deploy/helm --values deploy/helm/examples/two-agents.values.yaml` — 0 failed (the exact CI invocation)
- [x] No template, values, or schema change — a version string only, so chart behaviour is byte-identical to #74

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791673286&installation_model_id=433550&pr_number=76&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F76&signature=b4210a2b62c4683eaef5806683a8255e1506c7df994bad8719562f187237f0eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the unreleased changelog to record Chart version 0.13.1.
  - Clarified that no runtime image update is required because image version 0.5.0 is already correct.
  - Updated the Helm dependency example to reference Chart version 0.13.1.

- **Chores**
  - Updated the Helm chart version from 0.13.0 to 0.13.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->