### PR TITLE
Let a job's body be a prompt: scheduled brain turns under the existing jobs[] contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A job's body may be a prompt, so an agent can do light scheduled work only its brain
+  can do.** Work started in exactly two ways before this: a turn, when a message mentioned
+  the agent, and a job, which spawns a process with no brain, no tool broker, and no second
+  surface. So nothing could read channel A on surface X, summarize it, and post to channel B
+  on surface Y — and nothing could happen at 18:00 unless somebody posted a mention at
+  18:00. Every workaround put the clock outside the agent, where its kill switch, `suspend`,
+  `doctor` and work events cannot see it. A `jobs[]` entry now declares exactly one body:
+  `run` for a process in a pod of its own, or the new `prompt` for a brain turn in the
+  gateway process. Everything around it is the envelope that was already there — `slug`,
+  `archetype`, `trigger.schedules` and `trigger.timezone`, `killSwitch`, `suspend`,
+  `report`, `announce`, the work events, `doctor` and `validate` — which is why this is one
+  list and not a second block. `prompt` takes an inline string for a one-liner or
+  `{ file: ./path.md }` for anything longer, resolved against the agent directory exactly as
+  `persona` is, read at load and refused there if it is missing, over 64 KiB, or not UTF-8.
+  The file is shaped like a skill (frontmatter `name` and `description`, then the body the
+  tick sends), so the day a skill can be offered to the chat face, "run the digest now"
+  asked by a person is this prompt invoked on request with no second declaration.
+
+  The tick admits in the job host's order — kill switch, `suspend`, then the gateway's own
+  turn caps — and a refused tick is recorded and posts nothing. It then enters the turn path
+  as a synthetic inbound event: the author is `schedule:<slug>`, an id no surface issues, so
+  the author gate is skipped because there is nobody to weigh, and nothing else about the
+  turn changes. The reply is a top-level post in `report.channel` through the same guarded
+  chokepoint the brain's own `post_message` clears; an empty reply posts nothing. The prompt
+  comes from the reviewed bundle and nowhere else — no channel text can start one of these
+  turns, edit its prompt, or claim to be one. Ticks that fall while the gateway is down are
+  not replayed, and the in-process clock computes the next fire in `trigger.timezone`: a
+  local time a spring-forward deletes does not run that day, and the hour a fall-back
+  repeats fires once. `doctor` and `validate` print each prompt job's resolved file, its
+  size, and its next fire time; `job run` refuses one, and `job park` still stops it. Chart
+  0.14.0 mirrors a prompt job as `{slug, suspend, trigger, prompt: true}` with no `budget`
+  and renders no CronJob for it. See
+  [the job body contract](docs/job-contract.md#a-job-that-is-a-turn).
+
 - **An external worker deploys on a managed Kubernetes cluster again.** The 1.34 floor
   chart 0.13.0 introduced compared the server's version against `>=1.34.0`, and every
   managed distribution reports a GitVersion carrying a build suffix — `v1.34.9-eks-bca9cf6`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gateway process. Everything around it is the envelope that was already there — `slug`,
   `archetype`, `trigger.schedules` and `trigger.timezone`, `killSwitch`, `suspend`,
   `report`, `announce`, the work events, `doctor` and `validate` — which is why this is one
-  list and not a second block. `prompt` takes an inline string for a one-liner or
-  `{ skill: <name> }` for anything longer — **a skill**, at `skills/<name>/SKILL.md` in the
-  bundle, which is the layout every agent runtime already uses for a page of instructions an
-  agent reads and follows. Named rather than pointed at, because a name is what a person
+  list and not a second block. `prompt` takes either an inline string or
+  `{ skill: <name> }` — **a skill**, at `skills/<name>/SKILL.md` in the bundle, which is the
+  layout every agent runtime already uses for a page of instructions an agent reads and
+  follows. Inline is for something short and the schema does not enforce that; a page of
+  prompt inside a YAML block scalar is a page nobody reviews. Named rather than pointed at, because a name is what a person
   says and what a tool argument carries: the day a skill can be invoked from the chat face,
   "run the digest now" resolves the same name through the same lookup, with no second
   declaration and no file moved. The frontmatter `name` must match the directory. The root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repeats fires once. `doctor` and `validate` print where each prompt job's words came from
   — a resolved path for a file-backed prompt, `inline` for a one-liner — their size, and
   its next fire time; `job run` refuses one, and `job park` still stops it. Chart
-  0.14.0 mirrors a prompt job as `{slug, suspend, trigger, prompt: true}` with no `budget`
-  and renders no CronJob for it. See
+  0.14.0 mirrors a prompt job as `{slug, suspend, trigger, prompt: true}` with no `budget`,
+  renders no CronJob for it, and refuses a `sharedVolumes` claim mounted inside
+  `/agents/<name>` — the runtime cannot tell a mount point from a directory, so a target
+  that can place one over the bundle owes that refusal. See
   [the job body contract](docs/job-contract.md#a-job-that-is-a-turn).
 
 - **An external worker deploys on a managed Kubernetes cluster again.** The 1.34 floor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turns, edit its prompt, or claim to be one. Ticks that fall while the gateway is down are
   not replayed, and the in-process clock computes the next fire in `trigger.timezone`: a
   local time a spring-forward deletes does not run that day, and the hour a fall-back
-  repeats fires once. `doctor` and `validate` print each prompt job's resolved file, its
-  size, and its next fire time; `job run` refuses one, and `job park` still stops it. Chart
+  repeats fires once. `doctor` and `validate` print where each prompt job's words came from
+  — a resolved path for a file-backed prompt, `inline` for a one-liner — their size, and
+  its next fire time; `job run` refuses one, and `job park` still stops it. Chart
   0.14.0 mirrors a prompt job as `{slug, suspend, trigger, prompt: true}` with no `budget`
   and renders no CronJob for it. See
   [the job body contract](docs/job-contract.md#a-job-that-is-a-turn).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `archetype`, `trigger.schedules` and `trigger.timezone`, `killSwitch`, `suspend`,
   `report`, `announce`, the work events, `doctor` and `validate` — which is why this is one
   list and not a second block. `prompt` takes an inline string for a one-liner or
-  `{ file: ./path.md }` for anything longer, resolved against the agent directory exactly as
-  `persona` is, read at load and refused there if it is missing, over 64 KiB, not UTF-8, or
-  lands outside that directory by path or through a symlink, or under `workspace/`, where
-  the runtime keeps repository checkouts refreshed from their remotes — the words reach the
-  brain as steering rather than as fenced data, and the reason they may is that they came
-  out of the reviewed bundle.
-  The file is shaped like a skill (frontmatter `name` and `description`, then the body the
-  tick sends), so the day a skill can be offered to the chat face, "run the digest now"
-  asked by a person is this prompt invoked on request with no second declaration.
+  `{ skill: <name> }` for anything longer — **a skill**, at `skills/<name>/SKILL.md` in the
+  bundle, which is the layout every agent runtime already uses for a page of instructions an
+  agent reads and follows. Named rather than pointed at, because a name is what a person
+  says and what a tool argument carries: the day a skill can be invoked from the chat face,
+  "run the digest now" resolves the same name through the same lookup, with no second
+  declaration and no file moved. The frontmatter `name` must match the directory. The root
+  is the bundle's own `skills/` rather than a harness's discovery directory, which is
+  `docs/naming.md` applied to a layout. Read at load and refused there if the skill is
+  missing, over 64 KiB, not UTF-8, not a regular file, or really lands outside the bundle's
+  `skills/` tree — the words reach the brain as steering rather than as fenced data, and the
+  reason they may is that they came out of the reviewed bundle. A name cannot be absolute,
+  cannot traverse, and cannot reach the runtime's own `workspace/`, so those are not doors
+  this closes one at a time.
 
   The tick admits in the job host's order — kill switch, `suspend`, then the gateway's own
   turn caps — and a refused tick is recorded and posts nothing. It then enters the turn path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list and not a second block. `prompt` takes an inline string for a one-liner or
   `{ file: ./path.md }` for anything longer, resolved against the agent directory exactly as
   `persona` is, read at load and refused there if it is missing, over 64 KiB, not UTF-8, or
-  resolves outside that directory — the words reach the brain as steering rather than as
-  fenced data, and the reason they may is that they came out of the reviewed bundle.
+  lands outside that directory by path or through a symlink — the words reach the brain as
+  steering rather than as fenced data, and the reason they may is that they came out of the
+  reviewed bundle.
   The file is shaped like a skill (frontmatter `name` and `description`, then the body the
   tick sends), so the day a skill can be offered to the chat face, "run the digest now"
   asked by a person is this prompt invoked on request with no second declaration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `report`, `announce`, the work events, `doctor` and `validate` — which is why this is one
   list and not a second block. `prompt` takes an inline string for a one-liner or
   `{ file: ./path.md }` for anything longer, resolved against the agent directory exactly as
-  `persona` is, read at load and refused there if it is missing, over 64 KiB, or not UTF-8.
+  `persona` is, read at load and refused there if it is missing, over 64 KiB, not UTF-8, or
+  resolves outside that directory — the words reach the brain as steering rather than as
+  fenced data, and the reason they may is that they came out of the reviewed bundle.
   The file is shaped like a skill (frontmatter `name` and `description`, then the body the
   tick sends), so the day a skill can be offered to the chat face, "run the digest now"
   asked by a person is this prompt invoked on request with no second declaration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list and not a second block. `prompt` takes an inline string for a one-liner or
   `{ file: ./path.md }` for anything longer, resolved against the agent directory exactly as
   `persona` is, read at load and refused there if it is missing, over 64 KiB, not UTF-8, or
-  lands outside that directory by path or through a symlink — the words reach the brain as
-  steering rather than as fenced data, and the reason they may is that they came out of the
-  reviewed bundle.
+  lands outside that directory by path or through a symlink, or under `workspace/`, where
+  the runtime keeps repository checkouts refreshed from their remotes — the words reach the
+  brain as steering rather than as fenced data, and the reason they may is that they came
+  out of the reviewed bundle.
   The file is shaped like a skill (frontmatter `name` and `description`, then the body the
   tick sends), so the day a skill can be offered to the chat face, "run the digest now"
   asked by a person is this prompt invoked on request with no second declaration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comes from the reviewed bundle and nowhere else — no channel text can start one of these
   turns, edit its prompt, or claim to be one. Ticks that fall while the gateway is down are
   not replayed, and the in-process clock computes the next fire in `trigger.timezone`: a
-  local time a spring-forward deletes does not run that day, and the hour a fall-back
-  repeats fires once. `doctor` and `validate` print where each prompt job's words came from
+  local time a spring-forward deletes runs at the next real instant, and the hour a
+  fall-back repeats fires once. `doctor` and `validate` print where each prompt job's words came from
   — a resolved path for a file-backed prompt, `inline` for a one-liner — their size, and
   its next fire time; `job run` refuses one, and `job park` still stops it. Chart
   0.14.0 mirrors a prompt job as `{slug, suspend, trigger, prompt: true}` with no `budget`,

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Run one or more SageOx Agent Toolkit identities on Kubernetes
 type: application
-version: 0.13.1
+version: 0.14.0
 appVersion: "0.0.0"
 home: https://github.com/sageox/agent-toolkit
 sources:

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -363,9 +363,9 @@ and it is the one kind that renders none while declaring a schedule. Its body is
 turn, held on a clock inside the gateway process, so there is no command for a Pod to run.
 Mirror it as `{slug, suspend, trigger, prompt: true}` and state no `budget`; the chart
 refuses one, because nothing here would bound it. It also refuses a `sharedVolumes` claim
-mounted inside `/agents/<name>`: a prompt job's words are read from that directory and go to
-the brain as steering rather than as fenced data, so the bundle has to be the only thing
-that can supply them. The runtime cannot see this one — a mount point is an ordinary
+mounted inside `/agents/<name>`: a prompt job's words are read from `skills/<name>/SKILL.md`
+under that directory and go to the brain as steering rather than as fenced data, so the
+bundle has to be the only thing that can supply them. The runtime cannot see this one — a mount point is an ordinary
 directory to `realpath` — which is why the refusal belongs where the mount is made. `sageox-agent doctor` prints each one's
 next fire time, and `sageox-agent job park <slug>` stops it without a deploy.
 

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -362,7 +362,11 @@ A job whose `agent.yaml` body is `prompt:` rather than `run:` renders no `CronJo
 and it is the one kind that renders none while declaring a schedule. Its body is a brain
 turn, held on a clock inside the gateway process, so there is no command for a Pod to run.
 Mirror it as `{slug, suspend, trigger, prompt: true}` and state no `budget`; the chart
-refuses one, because nothing here would bound it. `sageox-agent doctor` prints each one's
+refuses one, because nothing here would bound it. It also refuses a `sharedVolumes` claim
+mounted inside `/agents/<name>`: a prompt job's words are read from that directory and go to
+the brain as steering rather than as fenced data, so the bundle has to be the only thing
+that can supply them. The runtime cannot see this one — a mount point is an ordinary
+directory to `realpath` — which is why the refusal belongs where the mount is made. `sageox-agent doctor` prints each one's
 next fire time, and `sageox-agent job park <slug>` stops it without a deploy.
 
 Each Job execs `sageox-agent job run <slug> --trigger schedule` against the same bundle the

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -51,7 +51,7 @@ Or depend on it, and nest this chart's values under its name. Helm hands every s
 # Chart.yaml
 dependencies:
   - name: agent
-    version: 0.13.1
+    version: 0.14.0
     repository: "file://../agent-toolkit/deploy/helm"
 ```
 
@@ -357,6 +357,13 @@ own SIGTERM at the budget and SIGKILL at the deadline always land first. A job w
 schedule renders no scheduled object, which is the correct rendering of an on-request job —
 start one by hand with `sageox-agent job run <slug> --trigger on-request`. `timeZone` needs
 Kubernetes 1.27 or newer.
+
+A job whose `agent.yaml` body is `prompt:` rather than `run:` renders no `CronJob` either,
+and it is the one kind that renders none while declaring a schedule. Its body is a brain
+turn, held on a clock inside the gateway process, so there is no command for a Pod to run.
+Mirror it as `{slug, suspend, trigger, prompt: true}` and state no `budget`; the chart
+refuses one, because nothing here would bound it. `sageox-agent doctor` prints each one's
+next fire time, and `sageox-agent job park <slug>` stops it without a deploy.
 
 Each Job execs `sageox-agent job run <slug> --trigger schedule` against the same bundle the
 Deployment runs, so the envelope is the host's: admission past both switches, single-flight,

--- a/deploy/helm/examples/two-agents.values.yaml
+++ b/deploy/helm/examples/two-agents.values.yaml
@@ -36,6 +36,15 @@ agents:
         suspend: false
         trigger: { schedules: [], timezone: UTC }
         budget: { wallClockMs: 600000, deadlineHeadroomMs: 300000 }
+      # A job whose body is a prompt: the gateway runs its turn in process on its own
+      # clock, so it renders no CronJob and states no budget. Mirrored anyway, by the same
+      # rule as `inbox` above.
+      - slug: daily-digest
+        suspend: false
+        prompt: true
+        trigger:
+          schedules: ["0 18 * * *"]
+          timezone: America/New_York
     terminationGracePeriodSeconds: 130
     resources:
       requests:

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -102,6 +102,30 @@ scheduled run is lost.
     {{- end }}
 {{- end -}}
 
+{{/*
+Refuses a shared claim mounted inside an agent's own bundle directory.
+
+A `prompt` job's words are read from `/agents/<name>` and handed to the brain as steering
+rather than as fenced data, and the whole argument for that is that they came out of the
+reviewed bundle. A claim mounted under that path breaks it without tripping any check the
+runtime can make: the file is genuinely inside the agent directory, and its content is
+another workload's to change after the bundle was reviewed.
+
+Refused here because this is where the mount is made. The runtime cannot see it — a mount
+point is an ordinary directory to `realpath` — so the target that creates one owes the
+refusal. Mount shared claims anywhere else; nothing about them needs to live under the
+bundle.
+*/}}
+{{- define "agent.assertSharedVolumes" -}}
+{{- $root := printf "/agents/%s" .name -}}
+{{- range $volume := .agent.sharedVolumes }}
+{{- $path := $volume.mountPath | trimSuffix "/" }}
+{{- if or (eq $path $root) (hasPrefix (printf "%s/" $root) $path) }}
+{{- fail (printf "agents.%s.sharedVolumes[%s].mountPath is %s, inside that agent's own bundle directory %s. A prompt job reads its words from there and they reach the brain as steering, so the bundle is the only thing allowed to supply them. Mount the claim outside %s." $.name $volume.name $volume.mountPath $root $root) }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "agent.agentVolumeMounts" -}}
 - name: agent-data
   mountPath: /agents

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -105,9 +105,9 @@ scheduled run is lost.
 {{/*
 Refuses a shared claim mounted inside an agent's own bundle directory.
 
-A `prompt` job's words are read from `/agents/<name>` and handed to the brain as steering
-rather than as fenced data, and the whole argument for that is that they came out of the
-reviewed bundle. A claim mounted under that path breaks it without tripping any check the
+A `prompt` job's words are read from `skills/<name>/SKILL.md` under `/agents/<name>` and
+handed to the brain as steering rather than as fenced data, and the whole argument for that
+is that they came out of the reviewed bundle. A claim mounted under that path breaks it without tripping any check the
 runtime can make: the file is genuinely inside the agent directory, and its content is
 another workload's to change after the bundle was reviewed.
 

--- a/deploy/helm/templates/cronjob.yaml
+++ b/deploy/helm/templates/cronjob.yaml
@@ -14,7 +14,13 @@ values and native references. Nothing below knows it is on any particular cloud.
 */}}
 {{- range $name, $agent := .Values.agents }}
 {{- range $job := $agent.jobs }}
-{{- $schedules := $job.trigger.schedules -}}
+{{/*
+A job whose body is a prompt runs as a brain turn inside the gateway process, on a clock the
+gateway holds — so there is no command for a Pod to run and no CronJob to render. It is still
+mirrored, carrying `prompt: true` and no `budget`, because the mirror's own rule is that
+every declared job appears: one left out reads exactly like an agent that declared none.
+*/}}
+{{- $schedules := ternary (list) $job.trigger.schedules (hasKey $job "prompt") -}}
 {{- range $index, $schedule := $schedules }}
 {{- $context := dict "root" $ "name" $name "agent" $agent "job" $job "index" $index "total" (len $schedules) -}}
 ---

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- range $name, $agent := .Values.agents }}
 {{- $context := dict "root" $ "name" $name "agent" $agent -}}
+{{- include "agent.assertSharedVolumes" $context }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -76,7 +76,8 @@ found=$(grep -oE 'https://github\.com/sageox/agent-toolkit/blob/[^/]+/docs/(job-
 [ "$found" = "$expected" ] || fail "pinned job documentation links in the copied chart README do not match the release:
 $(diff <(printf '%s\n' "$expected") <(printf '%s\n' "$found") | sed 's/^/  /')"
 
-# Three declared jobs across two agents: one scheduled, one on-request, one parked.
+# Four declared jobs across two agents: one scheduled, one on-request, one parked, and one
+# whose body is a prompt.
 render
 
 absent 'name: AGENT_WORK_EVENTS'
@@ -89,6 +90,18 @@ present "name: agents-harry-shift"
 present "name: agents-ida-sweep"
 # An on-request job declares no schedule and so renders no scheduled object.
 absent "inbox"
+# Neither does a job whose body is a prompt, and this one does declare a schedule: the
+# gateway holds that clock in its own process, and the CronJob this would otherwise render
+# would exec `job run daily-digest` against a job that has no command to run.
+absent "daily-digest"
+
+# The mirror still has to carry it — and refuse the two shapes that would make it a lie: a
+# prompt job stating a budget nothing here bounds, and a mirrored `prompt: false`, which
+# would read as a declaration that this job is not one.
+refuses 'a mirrored prompt job with a budget' 'budget' \
+  --set 'agents.harry.jobs[2].budget.wallClockMs=1000' \
+  --set 'agents.harry.jobs[2].budget.deadlineHeadroomMs=1000'
+refuses 'a mirrored prompt job marked false' 'prompt' --set 'agents.harry.jobs[2].prompt=false'
 
 present 'schedule: "0 */4 * * 1-5"'
 present 'timeZone: "America/New_York"'

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -103,6 +103,19 @@ refuses 'a mirrored prompt job with a budget' 'budget' \
   --set 'agents.harry.jobs[2].budget.deadlineHeadroomMs=1000'
 refuses 'a mirrored prompt job marked false' 'prompt' --set 'agents.harry.jobs[2].prompt=false'
 
+# A shared claim mounted inside the bundle. The runtime cannot see this one — a mount point
+# is an ordinary directory to `realpath`, so the prompt file is genuinely inside the agent
+# directory — which is why the refusal has to be here, where the mount is made.
+shared="--set agents.harry.sharedVolumes[0].name=shared --set agents.harry.sharedVolumes[0].claimName=team-share"
+refuses 'a shared claim mounted over the bundle' 'inside that agent'"'"'s own bundle directory' \
+  $shared --set 'agents.harry.sharedVolumes[0].mountPath=/agents/harry/shared'
+refuses 'a shared claim mounted at the bundle root' 'inside that agent'"'"'s own bundle directory' \
+  $shared --set 'agents.harry.sharedVolumes[0].mountPath=/agents/harry/'
+# And anywhere else still renders, mounted in both the Deployment and the scheduled Pods.
+rendered=$(helm template agents "$chart" --values "$values" $shared \
+  --set 'agents.harry.sharedVolumes[0].mountPath=/srv/shared' --show-only templates/cronjob.yaml)
+present 'mountPath: "/srv/shared"'
+
 present 'schedule: "0 */4 * * 1-5"'
 present 'timeZone: "America/New_York"'
 present 'schedule: "0 3 * * 0"'

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -70,7 +70,10 @@
     "job": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["slug", "suspend", "trigger", "budget"],
+      "required": ["slug", "suspend", "trigger"],
+      "if": { "required": ["prompt"] },
+      "then": { "properties": { "budget": false } },
+      "else": { "required": ["budget"] },
       "properties": {
         "worker": {
           "type": "object",
@@ -119,6 +122,7 @@
           }
         },
         "slug": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "prompt": { "const": true },
         "suspend": { "type": "boolean" },
         "trigger": {
           "type": "object",

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -34,6 +34,9 @@ networkPolicy:
 # declares — never the job body's argv, which `job run` reads from the manifest — because
 # Helm cannot read a bundle at render time. Mirror every declared job: one left
 # out renders no schedule, and nothing here can tell that apart from an agent with no jobs.
+# A job whose agent.yaml body is `prompt:` is mirrored as `{slug, suspend, trigger,
+# prompt: true}` and no `budget`: its turn runs inside the gateway on a clock the gateway
+# holds, so it renders no CronJob.
 # Optional agents.<name>.dispatcher.tokenSecret enables external worker dispatch.
 # jobs[].worker supplies a separate serviceAccountName, declared Secret mappings and
 # resources. See docs/external-jobs.md; worker images remain in agent.yaml.

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -203,8 +203,8 @@ is mirrored as `{slug, suspend, trigger, prompt: true}` and states no budget —
 refuses one, since nothing there would bound it — and the marker is what keeps a job left
 out of the mirror distinguishable from one the mirror says renders nothing. The chart also
 refuses a `sharedVolumes` claim mounted inside `/agents/<name>`: a prompt job's words are
-read from the bundle directory and reach the brain as steering, so a mount that could supply
-them from somewhere else is refused where it is made. The runtime cannot catch that one — a
+read from `skills/<name>/SKILL.md` under that directory and reach the brain as steering, so a
+mount that could supply them from somewhere else is refused where it is made. The runtime cannot catch that one — a
 mount point is an ordinary directory to `realpath`.
 [The chart's README](../deploy/helm/README.md#jobs) has the rendered shape and what a job
 Pod does not share by default — the agent's `ReadWriteOnce` claim, which ties its placement

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -14,7 +14,7 @@ around it. A deployment target must preserve this contract instead of translatin
 | Identity | Run exactly one replica for an agent identity. Two replicas would answer twice and race on one cursor. |
 | Shutdown | Allow longer than `limits.turnTimeoutMs` between `SIGTERM` and `SIGKILL`. |
 | Warmup | Connect first. Repository clone/fetch, indexing, cache fills, and other recoverable warmup never gate the agent process. The runtime enforces its half: only a precondition decides whether `run` starts, and no capability health ever does. See [Startup and readiness](startup-and-readiness.md). |
-| Jobs | Run every `jobs[]` entry that declares a `run` body on its declared schedule, under a deadline derived from its budget, without overlap and without retry. An entry declaring a `prompt` body is a turn on the agent's own clock: no scheduled object, no deadline to derive. An agent whose declared jobs render nothing deploys looking healthy with no scheduled work. See [Jobs](#jobs). |
+| Jobs | Run every `jobs[]` entry that declares a `run` body on its declared schedule, under a deadline derived from its budget, without overlap and without retry. An entry declaring a `prompt` body is a turn on the agent's own clock: no scheduled object, no deadline to derive, and rendering nothing for one is correct rather than a symptom. A `run` job left unrendered is the symptom — it deploys looking healthy with no scheduled work, and nothing at the target can tell that from an agent that declared none. See [Jobs](#jobs). |
 
 The runtime does not need an inbound port: Buzz and Slack use outbound connections. A target
 therefore should not create a Service or Ingress unless a future surface explicitly needs

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -63,7 +63,7 @@ renders a job with no clause to implement decides the deadline, the retry policy
 overlap rule inside its own template, which is the second configuration model this contract
 exists to prevent.
 
-A target that supports jobs owes each declared job:
+A target that supports jobs owes each job that declares a **`run`** body:
 
 | Per declared job | From |
 |---|---|
@@ -73,6 +73,15 @@ A target that supports jobs owes each declared job:
 | Single-flight — a run that would overlap a running one is refused, never queued | — |
 | No platform retry — a failed run is a failed run | — |
 | A writable bundle directory and somewhere the verdict artifact lands — durable between runs is not owed | `Agent definition`, above |
+
+A job that declares a **`prompt`** body instead is owed nothing here, and a target must
+render no scheduled object for one. Its body is a brain turn, held on a clock inside the
+agent process the target already deploys — there is no command to run, no budget to derive
+a deadline from, and a scheduled object would exec `job run` against a job with no argv.
+Mirroring it is still the target's to do where a target mirrors jobs at all, so that a job
+left out of the mirror stays distinguishable from one the mirror says renders nothing; the
+chart's marker is `prompt: true`. See
+[the job body contract](job-contract.md#a-job-that-is-a-turn).
 
 `run.command` and `run.args` are a list, and the list is the whole interface: no shell
 string, so nothing can be word-split or interpolated into one.

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -51,8 +51,9 @@ the runtime will refuse.
 
 ## Jobs
 
-`jobs[]` declares an agent's scheduled work — a trigger, a hard switch, a bound, and the
-process to run ([the jobs RFC](design/2026-08-19-jobs-rfc.md)). It lives in `agent.yaml`
+`jobs[]` declares an agent's scheduled work — a trigger, a hard switch, and a body: either
+a process to run and the bound to run it under, or a prompt the agent's own gateway runs as
+a turn ([the jobs RFC](design/2026-08-19-jobs-rfc.md)). It lives in `agent.yaml`
 for the reason at the top of this file: a job declared in a target's own values is the
 second configuration model, and that is how a fleet arrives at twelve jobs described in six
 different charts.
@@ -86,11 +87,12 @@ chart's marker is `prompt: true`. See
 `run.command` and `run.args` are a list, and the list is the whole interface: no shell
 string, so nothing can be word-split or interpolated into one.
 
-`suspend` parks the clock, not the job. A human may still start a parked job on request,
-and that run is the runtime's to admit — it arrives through the agent process the target
-already deploys, never through a scheduled object
-([RFC §6.3](design/2026-08-19-jobs-rfc.md#63-the-switch-parks-automation-not-the-job)). What
-a target owes is that the schedule itself does not fire.
+`suspend` parks the clock, not the job. A human may still start a parked **`run`** job on
+request, and that run is the runtime's to admit — it arrives through the agent process the
+target already deploys, never through a scheduled object
+([RFC §6.3](design/2026-08-19-jobs-rfc.md#63-the-switch-parks-automation-not-the-job)). A
+parked `prompt` job has no such door: nothing may ask for one, so it stays parked until the
+switch is armed. What a target owes either way is that the schedule itself does not fire.
 
 The deadline is derived, never a setting of its own. An operator who can set it independently
 will eventually set it below the budget, and the job is then SIGKILLed inside the window

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -188,15 +188,24 @@ ServiceAccount with token automount disabled, file-mounted secrets, and its own
 `ReadWriteOnce` PVC. One release may contain many such workloads. Configuration changes
 restart only the affected identity.
 
-Jobs render as one `CronJob` per declared schedule, carrying the schedule, the zone, the
-hard switch, the derived deadline, single-flight, and no retry — the whole of the clause
-above and nothing beyond it. Each Job execs `sageox-agent job run <slug> --trigger schedule`
-against the bundle the Deployment already runs, so the rest of the envelope stays where the
-clause puts it: the host reads the job's own argv, admits it past both switches, bows out at
-the budget, and mints the verdict. The declaration reaches the chart as a mirror of `jobs[]`
-in that agent's values, because Helm cannot read an operator-supplied bundle at render
-time; the mirror carries the clock and the bound only — not the argv, not the switch —
-so it cannot become a second place a job is decided.
+A **`run`** job renders as one `CronJob` per declared schedule, carrying the schedule, the
+zone, the hard switch, the derived deadline, single-flight, and no retry — the whole of the
+clause above and nothing beyond it. Each Job execs `sageox-agent job run <slug> --trigger
+schedule` against the bundle the Deployment already runs, so the rest of the envelope stays
+where the clause puts it: the host reads the job's own argv, admits it past both switches,
+bows out at the budget, and mints the verdict. The declaration reaches the chart as a mirror
+of `jobs[]` in that agent's values, because Helm cannot read an operator-supplied bundle at
+render time; the mirror carries the clock and the bound only — not the argv, not the switch
+— so it cannot become a second place a job is decided.
+
+A **`prompt`** job renders no `CronJob`, because the Deployment already runs its clock. It
+is mirrored as `{slug, suspend, trigger, prompt: true}` and states no budget — the chart
+refuses one, since nothing there would bound it — and the marker is what keeps a job left
+out of the mirror distinguishable from one the mirror says renders nothing. The chart also
+refuses a `sharedVolumes` claim mounted inside `/agents/<name>`: a prompt job's words are
+read from the bundle directory and reach the brain as steering, so a mount that could supply
+them from somewhere else is refused where it is made. The runtime cannot catch that one — a
+mount point is an ordinary directory to `realpath`.
 [The chart's README](../deploy/helm/README.md#jobs) has the rendered shape and what a job
 Pod does not share by default — the agent's `ReadWriteOnce` claim, which ties its placement
 to the agent's node. It stages its bundle onto an `emptyDir` of its own instead.

--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -14,7 +14,7 @@ around it. A deployment target must preserve this contract instead of translatin
 | Identity | Run exactly one replica for an agent identity. Two replicas would answer twice and race on one cursor. |
 | Shutdown | Allow longer than `limits.turnTimeoutMs` between `SIGTERM` and `SIGKILL`. |
 | Warmup | Connect first. Repository clone/fetch, indexing, cache fills, and other recoverable warmup never gate the agent process. The runtime enforces its half: only a precondition decides whether `run` starts, and no capability health ever does. See [Startup and readiness](startup-and-readiness.md). |
-| Jobs | Run every entry in `jobs[]` on its declared schedule, under a deadline derived from its budget, without overlap and without retry. An agent whose declared jobs render nothing deploys looking healthy with no scheduled work. See [Jobs](#jobs). |
+| Jobs | Run every `jobs[]` entry that declares a `run` body on its declared schedule, under a deadline derived from its budget, without overlap and without retry. An entry declaring a `prompt` body is a turn on the agent's own clock: no scheduled object, no deadline to derive. An agent whose declared jobs render nothing deploys looking healthy with no scheduled work. See [Jobs](#jobs). |
 
 The runtime does not need an inbound port: Buzz and Slack use outbound connections. A target
 therefore should not create a Service or Ingress unless a future surface explicitly needs
@@ -93,6 +93,10 @@ target already deploys, never through a scheduled object
 ([RFC §6.3](design/2026-08-19-jobs-rfc.md#63-the-switch-parks-automation-not-the-job)). A
 parked `prompt` job has no such door: nothing may ask for one, so it stays parked until the
 switch is armed. What a target owes either way is that the schedule itself does not fire.
+
+The two paragraphs below are a `run` body's. A `prompt` body has no budget to derive a
+deadline from and no scheduled object to hold single-flight over — the gateway's own clock
+runs it, one turn at a time, inside the process the target already deploys.
 
 The deadline is derived, never a setting of its own. An operator who can set it independently
 will eventually set it below the budget, and the job is then SIGKILLed inside the window

--- a/docs/design/2026-08-12-multi-surface-agent-toolkit-design.md
+++ b/docs/design/2026-08-12-multi-surface-agent-toolkit-design.md
@@ -820,13 +820,19 @@ A cron-based agent is fully supported — pick the tier by weight:
 | Runs in | the **gateway process** (Loop A machinery) | a **separate pod** (its own zone) |
 | Credentials | none (brain zone) | **write-scoped** |
 | Good for | daily summary, reminder, "check X and post it" | file issues, open PRs, multi-step write work |
-| Declared as | `schedules:` in the agent spec | `jobs:` in the agent spec |
+| Declared as | `jobs[].prompt` in the agent spec | `jobs[].run` in the agent spec |
 
 The key idea: **a cron tick is just another inbound event.** It enters the
 gateway as a synthetic `InboundEvent` (author = the internal clock), so it flows
 through the exact same brain → guard → egress path — no new machinery. It
 **skips the author gate** (there is no channel author) but is still subject to the
-guard, the rate/turn caps, and the kill switch. Both tiers are
+guard, the rate/turn caps, and the kill switch.
+
+The `schedules:` block this row once named was never built, and is withdrawn: the
+trigger, the switch, `suspend`, `report` and the work events it needed all already
+exist on `jobs[]`, so the tier is one field there rather than a second block
+duplicating that envelope. See
+[the job body contract](../job-contract.md#a-job-that-is-a-turn). Both tiers are
 **kill-switch-first** (a scheduled run has nobody watching, so "off" must cost one
 check and nothing else) and honor the fleet's **silence-is-the-message** rule (a
 run that finds nothing posts nothing).

--- a/docs/design/2026-08-12-multi-surface-agent-toolkit-design.md
+++ b/docs/design/2026-08-12-multi-surface-agent-toolkit-design.md
@@ -826,16 +826,16 @@ The key idea: **a cron tick is just another inbound event.** It enters the
 gateway as a synthetic `InboundEvent` (author = the internal clock), so it flows
 through the exact same brain → guard → egress path — no new machinery. It
 **skips the author gate** (there is no channel author) but is still subject to the
-guard, the rate/turn caps, and the kill switch.
+guard, the rate/turn caps, and the kill switch. Both tiers are
+**kill-switch-first** (a scheduled run has nobody watching, so "off" must cost one
+check and nothing else) and honor the fleet's **silence-is-the-message** rule (a
+run that finds nothing posts nothing).
 
 The `schedules:` block this row once named was never built, and is withdrawn: the
 trigger, the switch, `suspend`, `report` and the work events it needed all already
 exist on `jobs[]`, so the tier is one field there rather than a second block
 duplicating that envelope. See
-[the job body contract](../job-contract.md#a-job-that-is-a-turn). Both tiers are
-**kill-switch-first** (a scheduled run has nobody watching, so "off" must cost one
-check and nothing else) and honor the fleet's **silence-is-the-message** rule (a
-run that finds nothing posts nothing).
+[the job body contract](../job-contract.md#a-job-that-is-a-turn).
 
 ---
 

--- a/docs/design/2026-08-19-jobs-rfc.md
+++ b/docs/design/2026-08-19-jobs-rfc.md
@@ -690,11 +690,13 @@ script, or a compiled binary — the contract is a process, an exit code, and a 
 **Two parts of §10 survive intact.** The "scheduled turn" tier — a clock tick entering
 as a synthetic inbound event through the ordinary brain → guard → egress path — is
 unchanged and remains the right answer for light work; it needs no separate process.
-It is declared here after all, as `jobs[].prompt`: the envelope around it is this one,
-and a `schedules:` block of its own would be the trigger, the switch, `suspend`, the
+And "on-request vs scheduled is unforgeable provenance stamped by the trigger, not an argv
+knob" is §9 above, verbatim.
+
+The tier is declared here after all, as `jobs[].prompt`: the envelope around it is this
+one, and a `schedules:` block of its own would be the trigger, the switch, `suspend`, the
 report and the work events written a second time for the sake of one field. See
-[the job body contract](../job-contract.md#a-job-that-is-a-turn). And "on-request vs scheduled is unforgeable provenance stamped by
-the trigger, not an argv knob" is §9 above, verbatim.
+[the job body contract](../job-contract.md#a-job-that-is-a-turn).
 
 ---
 

--- a/docs/design/2026-08-19-jobs-rfc.md
+++ b/docs/design/2026-08-19-jobs-rfc.md
@@ -689,8 +689,11 @@ script, or a compiled binary — the contract is a process, an exit code, and a 
 
 **Two parts of §10 survive intact.** The "scheduled turn" tier — a clock tick entering
 as a synthetic inbound event through the ordinary brain → guard → egress path — is
-unchanged and remains the right answer for light work; it needs no job declaration and
-no separate process. And "on-request vs scheduled is unforgeable provenance stamped by
+unchanged and remains the right answer for light work; it needs no separate process.
+It is declared here after all, as `jobs[].prompt`: the envelope around it is this one,
+and a `schedules:` block of its own would be the trigger, the switch, `suspend`, the
+report and the work events written a second time for the sake of one field. See
+[the job body contract](../job-contract.md#a-job-that-is-a-turn). And "on-request vs scheduled is unforgeable provenance stamped by
 the trigger, not an argv knob" is §9 above, verbatim.
 
 ---

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -106,6 +106,40 @@ and an operator running `sageox-agent job run` at the host all still can.
 `memory add` and `mcp add` write these for you. Reach for this table only when editing a
 policy by hand — and `doctor` will tell you if you get it wrong.
 
+## A job that is a scheduled turn
+
+A `jobs[]` entry declares exactly one body. `run: {command, args}` is a process the host
+spawns in a pod of its own, with a scrubbed environment and whatever credentials it
+declared. `prompt:` is the other one: words, run as an ordinary guarded brain turn inside
+`sageox-agent run`, on a clock the gateway holds itself.
+
+```yaml
+jobs:
+  - slug: daily-digest
+    archetype: watch
+    description: Summarize the last 24 hours of the status channel and post it on Slack.
+    trigger: { schedules: ["0 18 * * *"], timezone: America/Los_Angeles }
+    killSwitch: { failDirection: closed }
+    prompt: { file: ./jobs/daily-digest.md }   # or an inline string, for a one-liner
+    report: { surface: slack, channel: "C0123456789" }
+```
+
+Reach for it when the work needs the brain and no write credential — a daily digest of one
+surface's channel posted on another, a reminder into a channel, *check X with your tools
+and post what you find*. Reach for `run:` when the work is deterministic, needs a
+credential, or is long.
+
+The tick posts at top level in `report.channel`, through the same guard the brain's own
+`post_message` clears; an empty reply posts nothing. The kill switch, `suspend`, `doctor`,
+`job park` and the work events are the ones every other job has — which is the point of
+declaring it here rather than scheduling a bot message on the platform: a clock outside the
+agent is a clock none of those can see. `prompt` refuses `run`, `worker`, `parameters`,
+`model`, `output`, `report.probe`, `report.history`, `trigger.onRequest` and
+`trigger.webhook`; `budget` is optional and can only shorten the turn. The prompt file is
+read when the gateway starts, so editing it needs a restart — and `doctor` prints its path,
+its size, and the next fire time in the declared zone. The full contract is in
+[the job body contract](../job-contract.md#a-job-that-is-a-turn).
+
 ## What the log says about tool calls
 
 Every MCP tool call writes one line, whether it ran or not:

--- a/docs/guide/reference.md
+++ b/docs/guide/reference.md
@@ -120,7 +120,7 @@ jobs:
     description: Summarize the last 24 hours of the status channel and post it on Slack.
     trigger: { schedules: ["0 18 * * *"], timezone: America/Los_Angeles }
     killSwitch: { failDirection: closed }
-    prompt: { file: ./jobs/daily-digest.md }   # or an inline string, for a one-liner
+    prompt: { skill: daily-digest }           # or an inline string, for a one-liner
     report: { surface: slack, channel: "C0123456789" }
 ```
 
@@ -135,10 +135,14 @@ The tick posts at top level in `report.channel`, through the same guard the brai
 declaring it here rather than scheduling a bot message on the platform: a clock outside the
 agent is a clock none of those can see. `prompt` refuses `run`, `worker`, `parameters`,
 `model`, `output`, `report.probe`, `report.history`, `trigger.onRequest` and
-`trigger.webhook`; `budget` is optional and can only shorten the turn. The prompt file is
-read when the gateway starts, so editing it needs a restart — and `doctor` prints its path,
-its size, and the next fire time in the declared zone. The full contract is in
-[the job body contract](../job-contract.md#a-job-that-is-a-turn).
+`trigger.webhook`; `budget` is optional and can only shorten the turn.
+
+The words live at `skills/<name>/SKILL.md` in the bundle — the layout every agent runtime
+uses for a page of instructions an agent reads and follows — and the manifest names the
+skill rather than pointing at a path, so the same name is what a person will later say to
+invoke it. It is read when the gateway starts, so editing it needs a restart, and `doctor`
+prints the resolved file, its size, and the next fire time in the declared zone. The full
+contract is in [the job body contract](../job-contract.md#a-job-that-is-a-turn).
 
 ## What the log says about tool calls
 

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -401,6 +401,98 @@ here — count it, match it, tally it, and never splice it into a prompt or a co
 Deciding whether to post again by matching an identifier is a tally, in deterministic code,
 with no model in the path.
 
+## A job that is a turn
+
+Everything above describes a job whose body is a **process**: the host spawns an argv, hands
+it an envelope, and reads a file back. That body has no brain, no tool broker, and no second
+surface, and it is bounded to the one channel `report` names — which is the whole security
+argument for spawning it from a bundle at all.
+
+So it cannot do light work that only the brain can do. *Read the last day of one surface's
+channel, write a sentence about it, post that on another surface* is a few hundred tokens of
+brain work with no write credential anywhere in it, and a process body cannot express it.
+Neither can an ordinary turn, because a turn needs somebody to post a mention at 18:00.
+
+A job may declare `prompt` instead of `run`, and then its body is words:
+
+```yaml
+jobs:
+  - slug: daily-digest
+    archetype: watch
+    description: Summarize the last 24 hours of the status channel and post it on Slack.
+    trigger: { schedules: ["0 18 * * *"], timezone: America/Los_Angeles }
+    killSwitch: { key: mem/daily-digest/enabled, failDirection: closed }
+    prompt: { file: ./jobs/daily-digest.md }   # or an inline string, for a one-liner
+    report: { surface: slack, channel: "C0123456789" }
+```
+
+The prompt file is shaped like a skill — frontmatter, then the body the tick sends:
+
+```markdown
+---
+name: daily-digest
+description: One short post per day summarizing what the other agents did.
+---
+It is the scheduled daily digest. Read the last 24 hours of the status channel with
+read_channel. Write one line per agent that did something and keep the links those lines
+carry. Name agents with nothing as quiet. If `more` was true, say the window was busier
+than one read covers. Post nothing else.
+```
+
+The shape is fixed now because nothing in the runtime reads those two fields yet. When
+skills arrive, the same file can be offered to the chat face — so *run the digest now*,
+asked by a person, becomes this prompt invoked on request, with no second declaration and
+no edit to the file.
+
+**The tick runs in the gateway process, never in a pod.** The gateway holds an in-process
+clock: five cron fields plus `trigger.timezone`, with the next fire computed in that zone.
+A local time a spring-forward deletes does not run that day, and the hour a fall-back
+repeats fires once. Ticks that fall while the gateway is down are **not replayed** — a
+digest of yesterday posted at 06:00 because that is when the pod came back is worse than no
+digest — and the next tick's `run.started` event is the record that one was missed. The
+Helm chart renders no `CronJob` for a prompt job; [the chart README](../deploy/helm/README.md#jobs)
+has the mirror.
+
+Admission is this host's, in this order: the kill switch, then `suspend`, then the
+gateway's own turn caps. A refused tick is recorded exactly as a refused job tick is, and
+posts nothing. Then the tick enters the turn path as a **synthetic inbound event**: the
+surface and channel come from `report`, the author is `schedule:<slug>` — an id no surface
+issues, so nothing can be addressed to it and nothing can answer as it — and the text is
+the prompt body. The author gate is the one check skipped, because there is no channel
+author to weigh. The brain, the tool policy, the guard, the rate caps and `turnTimeoutMs`
+are the ones every other turn gets.
+
+The turn's reply is a **top-level post in `report.channel`**, through the same chokepoint
+the brain's own `post_message` clears: channel consent, the guard, and the leak scan all
+apply, and a channel the surface does not list is refused. Replies people leave under the
+post wake the agent as usual. An empty reply posts nothing — silence is the message here as
+everywhere else.
+
+`announce` keeps its meaning, with the turn standing in for the gate: `unproven` (the
+default) posts the host's own line only when the turn never spoke — a timeout, a brain
+failure, or a guard that refused everything it asked to send — and `always` posts after a
+clean tick too. `reported` is refused at load, because a turn writes no gate details for it
+to key on.
+
+**Provenance is unforgeable.** The prompt comes from the reviewed bundle and nowhere else.
+No channel text can start one of these turns, alter its prompt, or claim to be one, and the
+`trigger: "schedule"` on the work event is stamped by the ticker exactly as `JobHost` stamps
+a process job's.
+
+Each of these is refused at load on a prompt job, by name, because it belongs to a process
+body or opens a door this tier does not: `run`, `worker`, `parameters`, `model` (the turn
+runs on `brain.model`), `output`, `report.probe`, `report.history` (the brain has its own
+channel reads), `trigger.onRequest` and `trigger.webhook`. `budget` is optional and can only
+shorten the turn: `wallClockMs` below `limits.turnTimeoutMs` wins, and above it does
+nothing. A job declaring both bodies, or neither, is refused.
+
+`sageox-agent doctor` and `sageox-agent validate` list every prompt job with its resolved
+prompt file, that file's size, and its next fire time in the declared zone — a prompt that
+silently changed size is the kind of thing nobody notices until the 3am post reads wrong.
+`sageox-agent job run` refuses a prompt job: there is no process to spawn, and the gateway
+holds the clock. `sageox-agent job park <slug>` stops it without a deploy, as it stops any
+other job.
+
 ## Structured work events (schema 1)
 
 Set `AGENT_WORK_EVENTS=1` on `sageox-agent job run` or `sageox-agent run` to emit

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -475,11 +475,13 @@ chart fails the render for a `sharedVolumes` claim at or under `/agents/<name>`.
 
 **The tick runs in the gateway process, never in a pod.** The gateway holds an in-process
 clock: five cron fields — or one of the fixed descriptors, `@daily` and its siblings —
-resolved against `trigger.timezone`. `@every 5m` is refused at load, since an interval
-names no wall-clock time for a zone to resolve.
+resolved against `trigger.timezone` by [`croner`](https://www.npmjs.com/package/croner),
+the same shape of parser a deploy target runs. `@every 5m` is refused at load, since an
+interval names no wall-clock time for a zone to resolve.
 
-A local time a spring-forward deletes does not run that day, and the hour a fall-back
-repeats fires once. Ticks that fall while the gateway is down are **not replayed** — a
+A local time a spring-forward deletes runs at the next real instant instead — `02:30` on a
+day that has no `02:30` fires at `03:30`, which is what the CronJob a `run` job of the same
+expression renders does too — and the hour a fall-back repeats fires once. Ticks that fall while the gateway is down are **not replayed** — a
 digest of yesterday posted at 06:00 because that is when the pod came back is worse than no
 digest — and the gap in the work events is where a missed one is visible. The Helm chart
 renders no `CronJob` for a prompt job; [the chart README](../deploy/helm/README.md#jobs)

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -445,12 +445,15 @@ asked by a person, becomes this prompt invoked on request, with no second declar
 no edit to the file.
 
 **The tick runs in the gateway process, never in a pod.** The gateway holds an in-process
-clock: five cron fields plus `trigger.timezone`, with the next fire computed in that zone.
+clock: five cron fields — or one of the fixed descriptors, `@daily` and its siblings —
+resolved against `trigger.timezone`. `@every 5m` is refused at load, since an interval
+names no wall-clock time for a zone to resolve.
+
 A local time a spring-forward deletes does not run that day, and the hour a fall-back
 repeats fires once. Ticks that fall while the gateway is down are **not replayed** — a
 digest of yesterday posted at 06:00 because that is when the pod came back is worse than no
-digest — and the next tick's `run.started` event is the record that one was missed. The
-Helm chart renders no `CronJob` for a prompt job; [the chart README](../deploy/helm/README.md#jobs)
+digest — and the gap in the work events is where a missed one is visible. The Helm chart
+renders no `CronJob` for a prompt job; [the chart README](../deploy/helm/README.md#jobs)
 has the mirror.
 
 Admission is this host's, in this order: the kill switch, then `suspend`, then the
@@ -464,9 +467,10 @@ are the ones every other turn gets.
 
 The turn's reply is a **top-level post in `report.channel`**, through the same chokepoint
 the brain's own `post_message` clears: channel consent, the guard, and the leak scan all
-apply, and a channel the surface does not list is refused. Replies people leave under the
-post wake the agent as usual. An empty reply posts nothing — silence is the message here as
-everywhere else.
+apply, and a channel the surface does not list is refused. A reply left under the post
+reaches the agent exactly as any other message does, by mentioning it — the tick changes
+nothing about what wakes a turn. An empty reply posts nothing: silence is the message here
+as everywhere else.
 
 `announce` keeps its meaning, with the turn standing in for the gate: `unproven` (the
 default) posts the host's own line only when the turn never spoke — a timeout, a brain

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -422,11 +422,12 @@ jobs:
     description: Summarize the last 24 hours of the status channel and post it on Slack.
     trigger: { schedules: ["0 18 * * *"], timezone: America/Los_Angeles }
     killSwitch: { key: mem/daily-digest/enabled, failDirection: closed }
-    prompt: { file: ./jobs/daily-digest.md }   # or an inline string, for a one-liner
+    prompt: { skill: daily-digest }           # or an inline string, for a one-liner
     report: { surface: slack, channel: "C0123456789" }
 ```
 
-The prompt file is shaped like a skill — frontmatter, then the body the tick sends:
+The words are **a skill**, at the layout every agent runtime already uses for a page of
+instructions an agent reads and follows — `skills/<name>/SKILL.md` in the bundle:
 
 ```markdown
 ---
@@ -439,32 +440,31 @@ carry. Name agents with nothing as quiet. If `more` was true, say the window was
 than one read covers. Post nothing else.
 ```
 
-The shape is fixed now because nothing in the runtime reads those two fields yet. When
-skills arrive, the same file can be offered to the chat face — so *run the digest now*,
-asked by a person, becomes this prompt invoked on request, with no second declaration and
-no edit to the file.
+**Named, not pointed at.** A name is what a person says and what a tool argument carries,
+so the day a skill can be invoked from the chat face, *run the digest now* resolves the
+same name through the same lookup — no second declaration, no file moved. A path would not
+be an invocation handle. `name` in the frontmatter has to match the directory the skill was
+found under, because two spellings of one name is how a skill is found under one and
+announces itself as another.
 
-The path resolves against the agent directory, as `persona` does, and is **refused at load
-if it lands outside it** — along with a file that is missing, is not UTF-8, or is larger
-than a verdict artifact may be. The containment is what makes the rest of this section
-true: these words go to the brain as steering rather than as fenced data, and the reason
-they may is that they came out of the same reviewed bundle the persona did. A prompt read
-off a mounted path appears in no bundle diff.
+The root is `skills/` in the bundle rather than a harness's own discovery directory. A
+harness scans wherever it scans; this is the toolkit's contract and it outlives any one of
+them, which is [the naming rule](naming.md) applied to a layout instead of an identifier.
 
-Both the declared path and its real path are checked, because they fail differently. A
-symlink committed into the bundle is the one a path check cannot see, and it is the worse
-of the two: the diff shows a path and never the content, the content can change after the
-review that approved it, and what it resolves to reaches the brain as trusted words inside
-the process holding this agent's credentials. Writing the prompt file directly is not the
-same act — that puts the words themselves in front of a reviewer. A link that stays inside
-the bundle is fine, and so is a bundle reached through a symlinked home, which is how a
-mount usually arrives.
+A name is also the narrower thing to admit. A slug cannot be absolute, cannot climb out of
+the bundle, and cannot reach `workspace/` — where repository checkouts sit, refreshed from
+their remotes on every start, and whose contents are whoever can merge to them. None of
+those are doors this has to close one at a time; they are not expressible.
 
-`workspace/` is refused too, and it is inside the agent directory: the runtime owns that
-subtree, repository checkouts land there, and they are refreshed from their remotes on
-every start. A prompt read out of one is words whoever can merge to that repository chose.
-The gateway already refuses to make a checkout the brain's working directory for the same
-reason; this is that rule at the other door.
+What is still worth checking is what the filesystem says the file really is. A symlink at
+any step of `skills/<name>/SKILL.md` can point out of the bundle, and that is the case a
+reviewed diff shows as a path and never as the content it will resolve to — content that
+can change after the review that approved it, and that reaches the brain as trusted words
+inside the process holding this agent's credentials. So the real path has to land inside
+the bundle's `skills/` tree, and a skill that is missing, not UTF-8, not a regular file, or
+larger than a verdict artifact may be is refused at load. A link that stays inside the tree
+is fine, and so is a bundle reached through a symlinked home, which is how a mount usually
+arrives.
 
 What the runtime cannot see is a **mount** placed inside the bundle — a mount point is an
 ordinary directory to `realpath` — so the target that can create one owes the refusal. The
@@ -519,8 +519,8 @@ shorten the turn: `wallClockMs` below `limits.turnTimeoutMs` wins, and above it 
 nothing. A job declaring both bodies, or neither, is refused.
 
 `sageox-agent doctor` and `sageox-agent validate` list every prompt job with where its
-words came from, their size, and its next fire time in the declared zone — a resolved path
-for a file-backed prompt, `inline` for a one-liner. A prompt that silently changed size is
+words came from, their size, and its next fire time in the declared zone — the resolved
+`SKILL.md` for a named skill, `inline` for a one-liner. A prompt that silently changed size is
 the kind of thing nobody notices until the 3am post reads wrong.
 `sageox-agent job run` refuses a prompt job: there is no process to spawn, and the gateway
 holds the clock. `sageox-agent job park <slug>` stops it without a deploy, as it stops any

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -476,7 +476,9 @@ are the ones every other turn gets.
 
 The turn's reply is a **top-level post in `report.channel`**, through the same chokepoint
 the brain's own `post_message` clears: channel consent, the guard, and the leak scan all
-apply, and a channel the surface does not list is refused. A reply left under the post
+apply, and a channel the surface does not list is refused. So is a surface that carries no
+top-level post at all — the console surface is one — which is why `doctor` and `validate`
+check both before a deploy rather than leaving `run` to refuse at startup. A reply left under the post
 reaches the agent exactly as any other message does, by mentioning it — the tick changes
 nothing about what wakes a turn. An empty reply posts nothing: silence is the message here
 as everywhere else.

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -426,8 +426,11 @@ jobs:
     report: { surface: slack, channel: "C0123456789" }
 ```
 
-The words are **a skill**, at the layout every agent runtime already uses for a page of
-instructions an agent reads and follows — `skills/<name>/SKILL.md` in the bundle:
+Either form is taken at any length. Inline is for something short — nothing enforces that,
+since a bound on lines would refuse a readable three-line prompt to catch the page it is
+aimed at. Anything longer wants to be **a skill**, at the layout every agent runtime already
+uses for a page of instructions an agent reads and follows — `skills/<name>/SKILL.md` in the
+bundle:
 
 ```markdown
 ---

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -445,13 +445,20 @@ asked by a person, becomes this prompt invoked on request, with no second declar
 no edit to the file.
 
 The path resolves against the agent directory, as `persona` does, and is **refused at load
-if it resolves outside it** — along with a file that is missing, is not UTF-8, or is larger
+if it lands outside it** — along with a file that is missing, is not UTF-8, or is larger
 than a verdict artifact may be. The containment is what makes the rest of this section
 true: these words go to the brain as steering rather than as fenced data, and the reason
 they may is that they came out of the same reviewed bundle the persona did. A prompt read
-off a mounted path appears in no bundle diff. The check is lexical, so a symlink inside the
-bundle can still point out — that symlink is a reviewed line like `run.command`, and
-anyone who can write one can write the prompt file instead.
+off a mounted path appears in no bundle diff.
+
+Both the declared path and its real path are checked, because they fail differently. A
+symlink committed into the bundle is the one a path check cannot see, and it is the worse
+of the two: the diff shows a path and never the content, the content can change after the
+review that approved it, and what it resolves to reaches the brain as trusted words inside
+the process holding this agent's credentials. Writing the prompt file directly is not the
+same act — that puts the words themselves in front of a reviewer. A link that stays inside
+the bundle is fine, and so is a bundle reached through a symlinked home, which is how a
+mount usually arrives.
 
 **The tick runs in the gateway process, never in a pod.** The gateway holds an in-process
 clock: five cron fields — or one of the fixed descriptors, `@daily` and its siblings —

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -444,6 +444,15 @@ skills arrive, the same file can be offered to the chat face — so *run the dig
 asked by a person, becomes this prompt invoked on request, with no second declaration and
 no edit to the file.
 
+The path resolves against the agent directory, as `persona` does, and is **refused at load
+if it resolves outside it** — along with a file that is missing, is not UTF-8, or is larger
+than a verdict artifact may be. The containment is what makes the rest of this section
+true: these words go to the brain as steering rather than as fenced data, and the reason
+they may is that they came out of the same reviewed bundle the persona did. A prompt read
+off a mounted path appears in no bundle diff. The check is lexical, so a symlink inside the
+bundle can still point out — that symlink is a reviewed line like `run.command`, and
+anyone who can write one can write the prompt file instead.
+
 **The tick runs in the gateway process, never in a pod.** The gateway holds an in-process
 clock: five cron fields — or one of the fixed descriptors, `@daily` and its siblings —
 resolved against `trigger.timezone`. `@every 5m` is refused at load, since an interval

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -460,6 +460,16 @@ same act — that puts the words themselves in front of a reviewer. A link that 
 the bundle is fine, and so is a bundle reached through a symlinked home, which is how a
 mount usually arrives.
 
+`workspace/` is refused too, and it is inside the agent directory: the runtime owns that
+subtree, repository checkouts land there, and they are refreshed from their remotes on
+every start. A prompt read out of one is words whoever can merge to that repository chose.
+The gateway already refuses to make a checkout the brain's working directory for the same
+reason; this is that rule at the other door.
+
+What the runtime cannot see is a **mount** placed inside the bundle — a mount point is an
+ordinary directory to `realpath` — so the target that can create one owes the refusal. The
+chart fails the render for a `sharedVolumes` claim at or under `/agents/<name>`.
+
 **The tick runs in the gateway process, never in a pod.** The gateway holds an in-process
 clock: five cron fields — or one of the fixed descriptors, `@daily` and its siblings —
 resolved against `trigger.timezone`. `@every 5m` is refused at load, since an interval

--- a/docs/job-contract.md
+++ b/docs/job-contract.md
@@ -508,9 +508,10 @@ channel reads), `trigger.onRequest` and `trigger.webhook`. `budget` is optional 
 shorten the turn: `wallClockMs` below `limits.turnTimeoutMs` wins, and above it does
 nothing. A job declaring both bodies, or neither, is refused.
 
-`sageox-agent doctor` and `sageox-agent validate` list every prompt job with its resolved
-prompt file, that file's size, and its next fire time in the declared zone — a prompt that
-silently changed size is the kind of thing nobody notices until the 3am post reads wrong.
+`sageox-agent doctor` and `sageox-agent validate` list every prompt job with where its
+words came from, their size, and its next fire time in the declared zone — a resolved path
+for a file-backed prompt, `inline` for a one-liner. A prompt that silently changed size is
+the kind of thing nobody notices until the 3am post reads wrong.
 `sageox-agent job run` refuses a prompt job: there is no process to spawn, and the gateway
 holds the clock. `sageox-agent job park <slug>` stops it without a deploy, as it stops any
 other job.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -100,7 +100,7 @@ import {
   servePrivateBrain,
   toHexPubkey,
 } from "@sageox/agent-toolkit-adapter-buzz";
-import { buildAdapters, buzzSurface, buzzTarget, type BuzzTarget } from "./surfaces.ts";
+import { buildAdapters, buzzSurface, buzzTarget, carriesTopLevelPosts, type BuzzTarget } from "./surfaces.ts";
 import { normalizeActorId } from "./identity.ts";
 import {
   createCmd,
@@ -1576,18 +1576,20 @@ function scheduledTurns(
   if (!declared.length) return undefined;
 
   const turns: ScheduledTurn[] = declared.map((job) => {
-    // Resolved from the surfaces themselves rather than from the manifest, because a
-    // scheduled turn answers with a top-level post and not every surface can make one.
+    // The declared question first, in the same words `doctor` and `validate` use — a
+    // bundle that reaches here having passed either of those should fail for something
+    // they could not have seen, not for something they could.
+    const unreachable = unreachableReport(manifest, job);
+    if (unreachable) throw new Error(unreachable);
+
+    // Then the live one, which is a different fact: the surface is configured to post and
+    // lists this channel, and the adapter it was built into offers no such target.
     const targets = egress.targets().filter((target) => target.surface === job.report.surface);
     const channel = resolveTarget(targets, job.report.surface, job.report.channel);
     if (!channel) {
       throw new Error(
-        `job "${job.slug}" is a scheduled turn reporting to ${job.report.surface}:` +
-          `${job.report.channel}, ` +
-          (targets.length
-            ? "which that surface does not list as a channel it can post into"
-            : `but the ${job.report.surface} surface carries no top-level posts`) +
-          " — the turn answers there and nowhere else",
+        `job "${job.slug}" reports to ${job.report.surface}:${job.report.channel}, which the ` +
+          "surface this agent built offers no post target for",
       );
     }
     return { job, prompt: readJobPrompt(job, agentDir), channel };
@@ -1628,6 +1630,13 @@ function scheduledTurns(
  * surface that carries no top-level post is refused there and cannot be here.
  */
 function unreachableReport(manifest: AgentManifest, job: PromptJob): string | undefined {
+  const named = `job "${job.slug}" reports to ${job.report.surface}:${job.report.channel}`;
+  const nowhere = "its scheduled turn answers there and nowhere else, so `run` refuses to start";
+  // Asked first, because it is the one a channel list cannot answer: a console surface may
+  // list the channel and still have no way to publish a new top-level message in it.
+  if (!carriesTopLevelPosts(job.report.surface)) {
+    return `${named}, but the ${job.report.surface} surface carries no top-level posts — ${nowhere}`;
+  }
   const surface = manifest.surfaces.find((declared) => declared.kind === job.report.surface);
   const targets = (surface?.channels ?? []).map((channel) => ({
     surface: job.report.surface,
@@ -1636,11 +1645,7 @@ function unreachableReport(manifest: AgentManifest, job: PromptJob): string | un
     name: channel.name,
   }));
   if (resolveTarget(targets, job.report.surface, job.report.channel)) return undefined;
-  return (
-    `job "${job.slug}" reports to ${job.report.surface}:${job.report.channel}, which that ` +
-    "surface does not list as a channel — its scheduled turn would have nowhere to post, " +
-    "and `run` refuses to start"
-  );
+  return `${named}, which that surface does not list as a channel — ${nowhere}`;
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1514,7 +1514,8 @@ async function runCmd(argv: string[]): Promise<void> {
     shuttingDown = true;
     clearInterval(ticker);
     // Before the turns are drained: a tick admitted after this would be a turn `drain`
-    // already waited for.
+    // already waited for. One still in flight keeps its turn and its run record; what can
+    // be lost is the host's status line, to a surface closed underneath it below.
     scheduled?.stop();
     process.stdout.write("\nshutting down…\n");
     // A turn may be waiting for a ledger refresh. Cancel Git before waiting for turns.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -68,6 +68,7 @@ import {
   requestableJobs,
   isPromptJob,
   readJobPrompt,
+  type PromptJob,
   resolveTarget,
   ScheduledTurns,
   nextFire,
@@ -1513,13 +1514,19 @@ async function runCmd(argv: string[]): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     clearInterval(ticker);
-    // Before the turns are drained: a tick admitted after this would be a turn `drain`
-    // already waited for. One still in flight keeps its turn and its run record; what can
-    // be lost is the host's status line, to a surface closed underneath it below.
+    // Closes the door before anything waits: a tick admitted after this would be a turn
+    // `drain` has already gone past.
     scheduled?.stop();
     process.stdout.write("\nshutting down…\n");
     // A turn may be waiting for a ledger refresh. Cancel Git before waiting for turns.
-    await Promise.all([team?.stopSync().catch(() => {}), gw.drain().catch(() => {})]);
+    // `drained` is in the same pass rather than before it, for that reason: a tick's turn
+    // can be the one blocked on the ledger, and waiting for it first would hold the whole
+    // shutdown behind a refresh nothing had cancelled yet.
+    await Promise.all([
+      team?.stopSync().catch(() => {}),
+      gw.drain().catch(() => {}),
+      scheduled?.drained().catch(() => {}),
+    ]);
     // After the turns and before the surfaces close, which is the only window where both
     // are true: a job started inside a turn was just waited for by `drain`, while a
     // detached one never was and is owed a last word through a channel that is still up.
@@ -1612,9 +1619,39 @@ function scheduledTurns(
   return clock;
 }
 
-/** A next fire time, in the zone the job declared it in. `never` is a legal cron answer. */
+/**
+ * Why a prompt job's `report` destination is not a channel it can post into, or nothing.
+ *
+ * Read off the manifest rather than off the live surfaces, so `validate` can ask it with no
+ * agent home, no credential and no relay — which is the whole point of that command. `run`
+ * asks the surfaces themselves, where the answer is narrower still: a listed channel on a
+ * surface that carries no top-level post is refused there and cannot be here.
+ */
+function unreachableReport(manifest: AgentManifest, job: PromptJob): string | undefined {
+  const surface = manifest.surfaces.find((declared) => declared.kind === job.report.surface);
+  const targets = (surface?.channels ?? []).map((channel) => ({
+    surface: job.report.surface,
+    id: channel.id,
+    isPublic: channel.reply === "public",
+    name: channel.name,
+  }));
+  if (resolveTarget(targets, job.report.surface, job.report.channel)) return undefined;
+  return (
+    `job "${job.slug}" reports to ${job.report.surface}:${job.report.channel}, which that ` +
+    "surface does not list as a channel — its scheduled turn would have nowhere to post, " +
+    "and `run` refuses to start"
+  );
+}
+
+/**
+ * A next fire time, in the zone the job declared it in.
+ *
+ * `never` is a legal answer and a final one — `0 0 31 2 *` parses and names no day — so it
+ * is said plainly rather than hedged: the search horizon is long enough to reach the
+ * sparsest real schedule, and the ticker arms nothing for a job that comes back empty.
+ */
 function describeFire(at: Date | undefined, timezone: string): string {
-  if (!at) return `never within a year (timezone ${timezone})`;
+  if (!at) return `never — no expression matches any day (timezone ${timezone})`;
   return `${at.toLocaleString("sv-SE", { timeZone: timezone })} ${timezone}`;
 }
 
@@ -2311,6 +2348,13 @@ function validateCmd(argv: string[]): boolean {
       const scheduled = manifest.jobs
         .filter(isPromptJob)
         .map((job) => ({ job, prompt: readJobPrompt(job, dirname(resolve(path))) }));
+      // The other thing `run` refuses to start on. Asked here for the same reason the
+      // prompt file is read: a CI step that passed would be green about a bundle that
+      // cannot boot.
+      const unreachable = scheduled
+        .map(({ job }) => unreachableReport(manifest, job))
+        .filter((why): why is string => why !== undefined);
+      if (unreachable.length) throw new Error(unreachable.join("\n"));
       process.stdout.write(
         `  ok    ${path} — ${manifest.name}, ${manifest.surfaces.length} surface(s), ` +
           `${manifest.jobs.length} job(s)\n`,
@@ -2669,29 +2713,20 @@ async function doctorCmd(argv: string[]): Promise<boolean> {
         // parser may still refuse, and that refusal is a finding rather than a crash.
         const at = nextFire(job.trigger.schedules, job.trigger.timezone, new Date());
         const prompt = readJobPrompt(job, agent.dir);
-        ok.push(
+        const line =
           `job "${job.slug}" is a scheduled turn — prompt ${prompt.source} ` +
-            `(${prompt.bytes} bytes), next ${describeFire(at, job.trigger.timezone)}`,
-        );
+          `(${prompt.bytes} bytes), next ${describeFire(at, job.trigger.timezone)}`;
+        // A schedule that matches no day loads, deploys, and is never heard from. Reported
+        // rather than refused: it is a legal expression, and the operator chose it.
+        if (at) ok.push(line);
+        else warnings.push(line);
       } catch (error) {
         problems.push(errorText(error));
       }
       // `loadManifest` checks that `report.surface` is declared; the channel is checked
       // here, against the same list and the same resolution a post is admitted through.
-      const surface = manifest.surfaces.find((s) => s.kind === job.report.surface);
-      const targets = (surface?.channels ?? []).map((channel) => ({
-        surface: job.report.surface,
-        id: channel.id,
-        isPublic: channel.reply === "public",
-        name: channel.name,
-      }));
-      if (!resolveTarget(targets, job.report.surface, job.report.channel)) {
-        problems.push(
-          `job "${job.slug}" reports to ${job.report.surface}:${job.report.channel}, which that ` +
-            "surface does not list as a channel — its turn would have nowhere to post, and " +
-            "`run` refuses to start",
-        );
-      }
+      const unreachable = unreachableReport(manifest, job);
+      if (unreachable) problems.push(unreachable);
     }
 
     if (manifest.tools) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -66,6 +66,12 @@ import {
   describeJobRun,
   serveJobs,
   requestableJobs,
+  isPromptJob,
+  readJobPrompt,
+  resolveTarget,
+  ScheduledTurns,
+  nextFire,
+  type ScheduledTurn,
   JOB_SERVER,
   JOB_RUN_TOOL,
   JOB_RUN_TOOL_NAME,
@@ -277,6 +283,7 @@ async function buildBrain(
   egress?: SurfaceEgress,
   codeWorkspace?: RepoWorkspace,
   policy?: ToolPolicy,
+  switchSource?: SwitchSource,
 ): Promise<{
   brain: Brain;
   closeHosted: () => Promise<void>;
@@ -415,7 +422,7 @@ async function buildBrain(
     jobs = new JobHost({
       external: externalJobs(),
       ...jobWorkEvents(manifest.name),
-      switchSource: await jobSwitchSource(manifest, secretsDir),
+      switchSource,
       secretOpts: { dir: secretsDir },
       // A job started from chat announces itself exactly as a scheduled one does. The
       // gateway already holds the adapters and the guarded path through them, so this
@@ -1429,6 +1436,9 @@ async function runCmd(argv: string[]): Promise<void> {
   const state = loadState(statePath);
   const adapters = await buildAdapters(manifest, { secretsDir, since: state.since });
   const egress = new SurfaceEgress({ manifest, adapters });
+  // One reader for both things that admit a job here — the chat door and the ticker below
+  // — so a parked switch means the same thing to each.
+  const switchSource = await jobSwitchSource(manifest, secretsDir);
   const { brain, closeHosted, postMessage, react, jobs, team } = await buildBrain(
     manifest,
     agent.dir,
@@ -1436,6 +1446,7 @@ async function runCmd(argv: string[]): Promise<void> {
     egress,
     codeWorkspace,
     policy,
+    switchSource,
   );
 
   // One lookup, so a credential that was already dead at deploy time is not first noticed
@@ -1481,6 +1492,11 @@ async function runCmd(argv: string[]): Promise<void> {
     capabilities: () => [...(codeWorkspace?.readings() ?? []), ...(team?.readings() ?? [])],
   });
 
+  // Read before anything starts listening: a schedule whose prompt file is missing,
+  // oversized, or not UTF-8 refuses the launch here rather than discovering it at 18:00,
+  // with nothing to say and no turn to say it in.
+  const scheduled = scheduledTurns(manifest, agent.dir, egress, gw, switchSource);
+
   // Persist the resume cursor periodically and on exit, so a restart does not reopen a
   // deaf window over the messages that arrived while the process was down.
   const persist = () => {
@@ -1497,6 +1513,9 @@ async function runCmd(argv: string[]): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     clearInterval(ticker);
+    // Before the turns are drained: a tick admitted after this would be a turn `drain`
+    // already waited for.
+    scheduled?.stop();
     process.stdout.write("\nshutting down…\n");
     // A turn may be waiting for a ledger refresh. Cancel Git before waiting for turns.
     await Promise.all([team?.stopSync().catch(() => {}), gw.drain().catch(() => {})]);
@@ -1520,11 +1539,82 @@ async function runCmd(argv: string[]): Promise<void> {
 
   await gw.start();
   await starting; // report a brain that never came up, now that we are listening
+  // After the surfaces are up: a tick whose turn landed before them would post through an
+  // adapter that has not connected.
+  scheduled?.start();
   const surfaces = manifest.surfaces.map((s) => s.kind).join(", ");
   const model = manifest.brain.model ? ` model=${manifest.brain.model}` : "";
   process.stdout.write(
     `sageox-agent "${manifest.name}" is live — brain=${manifest.brain.provider}${model} surfaces=[${surfaces}] respondTo=${manifest.respondTo}\n`,
   );
+}
+
+/**
+ * The gateway's own clock, or nothing when no job declares a prompt body.
+ *
+ * Everything it needs is resolved here, at startup, where a failure is a launch that
+ * refuses: the words each tick sends, and the configured channel each one is addressed
+ * to. A prompt job that reports to a channel no surface carries has nowhere to run at all
+ * — its turn answers there and nowhere else — so that is a refusal rather than a note.
+ */
+function scheduledTurns(
+  manifest: AgentManifest,
+  agentDir: string,
+  egress: SurfaceEgress,
+  gateway: Gateway,
+  switchSource?: SwitchSource,
+): ScheduledTurns | undefined {
+  const declared = manifest.jobs.filter(isPromptJob);
+  if (!declared.length) return undefined;
+
+  const turns: ScheduledTurn[] = declared.map((job) => {
+    // Resolved from the surfaces themselves rather than from the manifest, because a
+    // scheduled turn answers with a top-level post and not every surface can make one.
+    const targets = egress.targets().filter((target) => target.surface === job.report.surface);
+    const channel = resolveTarget(targets, job.report.surface, job.report.channel);
+    if (!channel) {
+      throw new Error(
+        `job "${job.slug}" is a scheduled turn reporting to ${job.report.surface}:` +
+          `${job.report.channel}, ` +
+          (targets.length
+            ? "which that surface does not list as a channel it can post into"
+            : `but the ${job.report.surface} surface carries no top-level posts`) +
+          " — the turn answers there and nowhere else",
+      );
+    }
+    return { job, prompt: readJobPrompt(job, agentDir), channel };
+  });
+
+  // The same work-event records a process job writes, under the same schema. A prompt job
+  // that went quiet has to be diagnosable from the same place every other job is.
+  const { onStart, onRun } = jobWorkEvents(manifest.name);
+  const clock = new ScheduledTurns({
+    turns,
+    gateway,
+    turnTimeoutMs: manifest.limits.turnTimeoutMs,
+    switchSource,
+    post: jobPoster(egress),
+    onStart,
+    onRun,
+  });
+
+  // Printing the roster is also what parses every expression, and that is why it happens
+  // here rather than beside `start()`: `looksLikeCron` checks the shape in the manifest and
+  // leaves the parse to whatever runs the job, so this is the definitive one — and a throw
+  // at the first fire would take down a gateway that was already live and answering.
+  for (const turn of clock.turns) {
+    process.stdout.write(
+      `  scheduled turn "${turn.job.slug}" next fires ` +
+        `${describeFire(clock.next(turn), turn.job.trigger.timezone)}\n`,
+    );
+  }
+  return clock;
+}
+
+/** A next fire time, in the zone the job declared it in. `never` is a legal cron answer. */
+function describeFire(at: Date | undefined, timezone: string): string {
+  if (!at) return `never within a year (timezone ${timezone})`;
+  return `${at.toLocaleString("sv-SE", { timeZone: timezone })} ${timezone}`;
 }
 
 /**
@@ -1847,6 +1937,17 @@ async function jobCmd(argv: string[]): Promise<void> {
     return;
   }
   if (sub === "arm" || sub === "park") return jobSwitchCmd(manifest, job, sub, secretsDir);
+
+  // `arm` and `park` are above, because a prompt job's kill switch is an ordinary one and
+  // parking it is exactly what an operator reaches for. Running one is what this cannot do:
+  // its body is words, and the only thing that can send them is a gateway with a brain.
+  if (isPromptJob(job)) {
+    throw new Error(
+      `job "${job.slug}" is a scheduled turn — its body is a prompt, run by the gateway in ` +
+        "its own process on its own clock, so there is no process here to spawn. " +
+        `\`sageox-agent run\` holds that clock; \`sageox-agent job park ${job.slug}\` stops it`,
+    );
+  }
 
   // Before anything is opened: a mistyped flag is a refusal at the terminal, not a relay
   // connection and a chdir that a throw would leave behind.
@@ -2203,10 +2304,23 @@ function validateCmd(argv: string[]): boolean {
       // strings, so validating one rung below the runtime would pass a file the runtime
       // refuses at startup — this command's own failure mode.
       const manifest = readManifest(path);
+      // Read here and not only reported: `run` refuses to start on a prompt file it cannot
+      // read, so a CI step that passed on one would be green about a bundle that will not
+      // boot. Resolved against the manifest's own directory, exactly as `run` resolves it.
+      const scheduled = manifest.jobs
+        .filter(isPromptJob)
+        .map((job) => ({ job, prompt: readJobPrompt(job, dirname(resolve(path))) }));
       process.stdout.write(
         `  ok    ${path} — ${manifest.name}, ${manifest.surfaces.length} surface(s), ` +
           `${manifest.jobs.length} job(s)\n`,
       );
+      for (const { job, prompt } of scheduled) {
+        const at = nextFire(job.trigger.schedules, job.trigger.timezone, new Date());
+        process.stdout.write(
+          `        ${job.slug}: scheduled turn, prompt ${prompt.source} (${prompt.bytes} bytes), ` +
+            `next ${describeFire(at, job.trigger.timezone)}\n`,
+        );
+      }
     } catch (error) {
       invalid++;
       // Zod's own rendering, because its default `message` is the whole issue list as JSON:
@@ -2543,6 +2657,40 @@ async function doctorCmd(argv: string[]): Promise<boolean> {
           "rather than waiting — but they declare no `report`, so the verdict would reach " +
           "no channel; give each one a report destination",
       );
+    }
+
+    // A prompt job runs in this process on a clock, so `run` reads its words at startup and
+    // refuses the launch if it cannot. Reported here for the same reason every secretRef is:
+    // a clean doctor must not precede a launch that dies on a file.
+    for (const job of manifest.jobs.filter(isPromptJob)) {
+      try {
+        // Inside the `try` with the file read: `looksLikeCron` admits an expression this
+        // parser may still refuse, and that refusal is a finding rather than a crash.
+        const at = nextFire(job.trigger.schedules, job.trigger.timezone, new Date());
+        const prompt = readJobPrompt(job, agent.dir);
+        ok.push(
+          `job "${job.slug}" is a scheduled turn — prompt ${prompt.source} ` +
+            `(${prompt.bytes} bytes), next ${describeFire(at, job.trigger.timezone)}`,
+        );
+      } catch (error) {
+        problems.push(errorText(error));
+      }
+      // `loadManifest` checks that `report.surface` is declared; the channel is checked
+      // here, against the same list and the same resolution a post is admitted through.
+      const surface = manifest.surfaces.find((s) => s.kind === job.report.surface);
+      const targets = (surface?.channels ?? []).map((channel) => ({
+        surface: job.report.surface,
+        id: channel.id,
+        isPublic: channel.reply === "public",
+        name: channel.name,
+      }));
+      if (!resolveTarget(targets, job.report.surface, job.report.channel)) {
+        problems.push(
+          `job "${job.slug}" reports to ${job.report.surface}:${job.report.channel}, which that ` +
+            "surface does not list as a channel — its turn would have nowhere to post, and " +
+            "`run` refuses to start",
+        );
+      }
     }
 
     if (manifest.tools) {

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -352,7 +352,8 @@ export function declaredSecrets(manifest: AgentManifest, repos: RepoSpec[]): Dec
   // this error otherwise offers — mount the file here, add it to `.env` — are both the
   // arrangement the split was for.
   manifest.jobs.forEach((job, index) => {
-    if (job.worker) return;
+    // A prompt body declares no credential at all — its turn runs on the gateway's own.
+    if (job.worker || !job.run) return;
     for (const [envVar, ref] of Object.entries(job.run.secrets)) {
       declared.push({
         ...spawnedSecretSpec(ref, envVar, "the job body"),

--- a/packages/cli/src/surfaces.ts
+++ b/packages/cli/src/surfaces.ts
@@ -63,6 +63,36 @@ export function buzzSurface(manifest: AgentManifest): BuzzTarget | undefined {
   return buzzTarget(manifest.surfaces.find((surface) => surface.kind === "buzz"));
 }
 
+/**
+ * The adapter class behind each surface kind, for the questions that have an answer before
+ * anything is built. Keep it beside {@link buildAdapters}: a kind added to that switch
+ * belongs here too, and `surfaces.test.ts` holds the two together.
+ */
+const ADAPTERS: Record<string, { prototype: Partial<SurfaceAdapter> }> = {
+  console: ConsoleAdapter,
+  buzz: BuzzAdapter,
+  slack: SlackAdapter,
+};
+
+/**
+ * Whether a surface of this kind can create a **new top-level post** — which is how a
+ * scheduled turn answers, and the console surface cannot.
+ *
+ * Read off the adapter's own prototype rather than restated as a list here, so it cannot
+ * disagree with the adapter it names: `post` and `postTargets` are optional on
+ * {@link SurfaceAdapter}, and every adapter this CLI builds either defines them as class
+ * methods or has neither. That is what lets `validate` ask with no agent home, no
+ * credential and no relay, and `doctor` ask before a deploy — neither builds an adapter,
+ * and both have to refuse what `run` would refuse.
+ *
+ * An unknown kind answers `false`. `buildAdapters` refuses it anyway, and the caller that
+ * asks this is reporting on a channel, so naming the channel is the wrong finding.
+ */
+export function carriesTopLevelPosts(kind: string): boolean {
+  const adapter = ADAPTERS[kind]?.prototype;
+  return typeof adapter?.post === "function" && typeof adapter?.postTargets === "function";
+}
+
 /** Turns the manifest's declared surfaces into live adapters. */
 export async function buildAdapters(
   manifest: AgentManifest,
@@ -108,7 +138,8 @@ export async function buildAdapters(
 
       default:
         throw new Error(
-          `surface "${surface.kind}" is not implemented yet (have: console, buzz, slack)`,
+          `surface "${surface.kind}" is not implemented yet ` +
+            `(have: ${Object.keys(ADAPTERS).join(", ")})`,
         );
     }
   }

--- a/packages/cli/test/doctor-jobs.test.ts
+++ b/packages/cli/test/doctor-jobs.test.ts
@@ -161,7 +161,12 @@ describe("doctor and the job tool", () => {
   it("fails on a prompt file that is not there, rather than at 18:00", async () => {
     declarePrompt("{file: ./jobs/digest.md}");
 
-    expect(await doctor(home)).toContain("jobs/digest.md");
+    const report = await doctor(home);
+
+    // `doctorReport` hands back stdout either way, so the path alone would pass on a run
+    // that merely mentioned the file. The verdict is what says `run` would refuse.
+    expect(report).toContain("FAIL");
+    expect(report).toContain("jobs/digest.md");
   });
 
   it("fails when the turn would have nowhere to post", async () => {

--- a/packages/cli/test/doctor-jobs.test.ts
+++ b/packages/cli/test/doctor-jobs.test.ts
@@ -122,4 +122,54 @@ describe("doctor and the job tool", () => {
     expect(report).not.toContain("job tool");
     expect(report).not.toContain("mcp__jobs__job_run");
   });
+  /**
+   * A job whose body is a prompt: the gateway holds its clock, so `run` reads the prompt at
+   * startup and refuses to launch on a file it cannot read. `doctor` has to find that first
+   * — the same rule that puts every declared `secretRef` in this report.
+   */
+  const declarePrompt = (body: string, report = "{surface: console, channel: local}") =>
+    writeFileSync(
+      join(agentDir, "agent.yaml"),
+      AGENT_YAML("demo").replace(
+        "surfaces:\n  - kind: console\n",
+        "surfaces:\n  - kind: console\n    channels: [{id: local, reply: private}]\n",
+      ) +
+        "\nbrains:\n  - preset: local\nkillSwitchParkBy: []\n" +
+        "jobs:\n  - slug: daily-digest\n    archetype: watch\n" +
+        "    description: One short post per day.\n" +
+        "    trigger: {schedules: ['0 18 * * *'], timezone: America/Los_Angeles}\n" +
+        "    killSwitch: {failDirection: closed}\n" +
+        `    prompt: ${body}\n` +
+        `    report: ${report}\n`,
+    );
+
+  it("names a scheduled turn's prompt, its size, and when it next fires", async () => {
+    mkdirSync(join(agentDir, "jobs"));
+    writeFileSync(
+      join(agentDir, "jobs", "digest.md"),
+      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
+    );
+    declarePrompt("{file: ./jobs/digest.md}");
+
+    const report = await doctor(home);
+
+    expect(report).toContain('job "daily-digest" is a scheduled turn');
+    expect(report).toContain(join(agentDir, "jobs", "digest.md"));
+    expect(report).toMatch(/\(\d+ bytes\), next \d{4}-\d{2}-\d{2} 18:00:00 America\/Los_Angeles/);
+  });
+
+  it("fails on a prompt file that is not there, rather than at 18:00", async () => {
+    declarePrompt("{file: ./jobs/digest.md}");
+
+    expect(await doctor(home)).toContain("jobs/digest.md");
+  });
+
+  it("fails when the turn would have nowhere to post", async () => {
+    declarePrompt("'Summarize the day.'", "{surface: console, channel: nowhere}");
+
+    const report = await doctor(home);
+
+    expect(report).toContain("FAIL");
+    expect(report).toContain("does not list as a channel");
+  });
 });

--- a/packages/cli/test/doctor-jobs.test.ts
+++ b/packages/cli/test/doctor-jobs.test.ts
@@ -147,27 +147,33 @@ describe("doctor and the job tool", () => {
         `    report: ${report}\n`,
     );
 
-  it("names a scheduled turn's prompt, its size, and when it next fires", async () => {
-    mkdirSync(join(agentDir, "jobs"));
+  /** `skills/<name>/SKILL.md` — the one layout a named skill resolves to. */
+  const writeSkill = (name: string) => {
+    mkdirSync(join(agentDir, "skills", name), { recursive: true });
     writeFileSync(
-      join(agentDir, "jobs", "digest.md"),
-      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
+      join(agentDir, "skills", name, "SKILL.md"),
+      `---\nname: ${name}\ndescription: One short post per day.\n---\nSummarize the day.\n`,
     );
-    declarePrompt("{file: ./jobs/digest.md}");
+    return join(agentDir, "skills", name, "SKILL.md");
+  };
+
+  it("names a scheduled turn's skill, its size, and when it next fires", async () => {
+    const path = writeSkill("daily-digest");
+    declarePrompt("{skill: daily-digest}");
 
     const report = await doctor(home, TOKENS);
 
     expect(report).toContain('job "daily-digest" is a scheduled turn');
-    expect(report).toContain(join(agentDir, "jobs", "digest.md"));
+    expect(report).toContain(path);
     expect(report).toMatch(/\(\d+ bytes\), next \d{4}-\d{2}-\d{2} 18:00:00 America\/Los_Angeles/);
   });
 
-  it("fails on a prompt file that is not there, rather than at 18:00", async () => {
-    declarePrompt("{file: ./jobs/digest.md}");
+  it("fails on a skill that is not there, rather than at 18:00", async () => {
+    declarePrompt("{skill: daily-digest}");
 
     // `doctorReport` hands back stdout either way, so the path alone would pass on a run
     // that merely mentioned the file. The verdict beside it is what says `run` would refuse.
-    expect(await doctor(home, TOKENS)).toMatch(/FAIL\s+job "daily-digest" prompt .*jobs\/digest\.md/);
+    expect(await doctor(home, TOKENS)).toMatch(/FAIL\s+job "daily-digest" skill daily-digest/);
   });
 
   it("fails when the turn would have nowhere to post", async () => {

--- a/packages/cli/test/doctor-jobs.test.ts
+++ b/packages/cli/test/doctor-jobs.test.ts
@@ -127,13 +127,17 @@ describe("doctor and the job tool", () => {
    * startup and refuses to launch on a file it cannot read. `doctor` has to find that first
    * — the same rule that puts every declared `secretRef` in this report.
    */
-  const declarePrompt = (body: string, report = "{surface: console, channel: local}") =>
+  /** Slack rather than console: a scheduled turn answers with a top-level post. */
+  const SLACK_SURFACE =
+    "surfaces:\n  - kind: slack\n    identity: TEST_SLACK_BOT_TOKEN\n" +
+    "    appToken: TEST_SLACK_APP_TOKEN\n    channels: [{id: C01, name: hive, reply: private}]\n";
+
+  const TOKENS = { TEST_SLACK_BOT_TOKEN: "xoxb-test", TEST_SLACK_APP_TOKEN: "xapp-test" };
+
+  const declarePrompt = (body: string, report = "{surface: slack, channel: C01}", surface = SLACK_SURFACE) =>
     writeFileSync(
       join(agentDir, "agent.yaml"),
-      AGENT_YAML("demo").replace(
-        "surfaces:\n  - kind: console\n",
-        "surfaces:\n  - kind: console\n    channels: [{id: local, reply: private}]\n",
-      ) +
+      AGENT_YAML("demo").replace("surfaces:\n  - kind: console\n", surface) +
         "\nbrains:\n  - preset: local\nkillSwitchParkBy: []\n" +
         "jobs:\n  - slug: daily-digest\n    archetype: watch\n" +
         "    description: One short post per day.\n" +
@@ -151,7 +155,7 @@ describe("doctor and the job tool", () => {
     );
     declarePrompt("{file: ./jobs/digest.md}");
 
-    const report = await doctor(home);
+    const report = await doctor(home, TOKENS);
 
     expect(report).toContain('job "daily-digest" is a scheduled turn');
     expect(report).toContain(join(agentDir, "jobs", "digest.md"));
@@ -161,20 +165,32 @@ describe("doctor and the job tool", () => {
   it("fails on a prompt file that is not there, rather than at 18:00", async () => {
     declarePrompt("{file: ./jobs/digest.md}");
 
-    const report = await doctor(home);
-
     // `doctorReport` hands back stdout either way, so the path alone would pass on a run
-    // that merely mentioned the file. The verdict is what says `run` would refuse.
-    expect(report).toContain("FAIL");
-    expect(report).toContain("jobs/digest.md");
+    // that merely mentioned the file. The verdict beside it is what says `run` would refuse.
+    expect(await doctor(home, TOKENS)).toMatch(/FAIL\s+job "daily-digest" prompt .*jobs\/digest\.md/);
   });
 
   it("fails when the turn would have nowhere to post", async () => {
-    declarePrompt("'Summarize the day.'", "{surface: console, channel: nowhere}");
+    declarePrompt("'Summarize the day.'", "{surface: slack, channel: nowhere}");
+
+    const report = await doctor(home, TOKENS);
+
+    expect(report).toContain("FAIL");
+    expect(report).toContain("does not list as a channel");
+  });
+
+  // The one a channel list cannot answer: console lists the channel and has no way to
+  // publish a new top-level message in it, so `run` refuses a turn that would answer there.
+  it("fails when the report surface carries no top-level posts at all", async () => {
+    declarePrompt(
+      "'Summarize the day.'",
+      "{surface: console, channel: local}",
+      "surfaces:\n  - kind: console\n    channels: [{id: local, reply: private}]\n",
+    );
 
     const report = await doctor(home);
 
     expect(report).toContain("FAIL");
-    expect(report).toContain("does not list as a channel");
+    expect(report).toContain("carries no top-level posts");
   });
 });

--- a/packages/cli/test/surfaces.test.ts
+++ b/packages/cli/test/surfaces.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { loadManifest } from "@sageox/agent-toolkit-core";
 import { SlackAdapter } from "@sageox/agent-toolkit-adapter-slack";
-import { buildAdapters } from "../src/surfaces.ts";
+import { buildAdapters, carriesTopLevelPosts } from "../src/surfaces.ts";
 
 const slackConfig = (channels: string) => `
 name: slack-test
@@ -54,5 +54,38 @@ describe("buildAdapters Slack wiring", () => {
 
     expect(adapters[0]).toBeInstanceOf(SlackAdapter);
     expect((adapters[0] as SlackAdapter).postTargets()).toEqual([]);
+  });
+});
+/**
+ * The capability `validate` and `doctor` answer without building anything, held against the
+ * adapters that answer it at runtime.
+ *
+ * A scheduled turn answers with a top-level post, so a surface that cannot make one is a
+ * bundle `run` refuses to start — and both pre-flight commands have to refuse it first,
+ * with no credential, no relay, and no agent home to build an adapter from.
+ */
+describe("carriesTopLevelPosts", () => {
+  afterEach(() => {
+    delete process.env.TEST_SLACK_BOT_TOKEN;
+    delete process.env.TEST_SLACK_APP_TOKEN;
+  });
+
+  it("agrees with the adapter each kind is actually built into", async () => {
+    process.env.TEST_SLACK_BOT_TOKEN = "xoxb-test";
+    process.env.TEST_SLACK_APP_TOKEN = "xapp-test";
+    for (const [kind, yaml] of [
+      ["console", "name: t\nbrain: {provider: mock}\nrespondTo: anyone\nsurfaces: [{kind: console}]"],
+      ["slack", slackConfig("{ id: GENG, reply: private }")],
+    ] as const) {
+      const [adapter] = await buildAdapters(loadManifest(yaml));
+      const built = typeof adapter!.post === "function" && typeof adapter!.postTargets === "function";
+      expect(carriesTopLevelPosts(kind), kind).toBe(built);
+    }
+  });
+
+  it("says no for a kind nothing builds, rather than guessing", () => {
+    // `buildAdapters` refuses such a surface anyway; what matters is that the answer here
+    // is never an optimistic yes for something that will not exist.
+    expect(carriesTopLevelPosts("discord")).toBe(false);
   });
 });

--- a/packages/cli/test/surfaces.test.ts
+++ b/packages/cli/test/surfaces.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { loadManifest } from "@sageox/agent-toolkit-core";
 import { SlackAdapter } from "@sageox/agent-toolkit-adapter-slack";
+import { generateKeypair } from "@sageox/agent-toolkit-adapter-buzz";
 import { buildAdapters, carriesTopLevelPosts } from "../src/surfaces.ts";
 
 const slackConfig = (channels: string) => `
@@ -68,14 +69,24 @@ describe("carriesTopLevelPosts", () => {
   afterEach(() => {
     delete process.env.TEST_SLACK_BOT_TOKEN;
     delete process.env.TEST_SLACK_APP_TOKEN;
+    delete process.env.TEST_BUZZ_NSEC;
   });
 
   it("agrees with the adapter each kind is actually built into", async () => {
     process.env.TEST_SLACK_BOT_TOKEN = "xoxb-test";
     process.env.TEST_SLACK_APP_TOKEN = "xapp-test";
+    // Every kind `ADAPTERS` registers, so the table cannot claim a capability for one the
+    // CLI never checks. Buzz builds offline — the adapter opens its relay in `start()`.
+    process.env.TEST_BUZZ_NSEC = generateKeypair().nsec;
     for (const [kind, yaml] of [
       ["console", "name: t\nbrain: {provider: mock}\nrespondTo: anyone\nsurfaces: [{kind: console}]"],
       ["slack", slackConfig("{ id: GENG, reply: private }")],
+      [
+        "buzz",
+        "name: t\nbrain: {provider: mock}\nrespondTo: anyone\nsurfaces:\n  - kind: buzz\n" +
+          "    relayUrl: wss://relay.example\n    identity: TEST_BUZZ_NSEC\n" +
+          "    channels: [{id: hive, reply: private}]",
+      ],
     ] as const) {
       const [adapter] = await buildAdapters(loadManifest(yaml));
       const built = typeof adapter!.post === "function" && typeof adapter!.postTargets === "function";

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -169,8 +169,19 @@ describe("sageox-agent validate", () => {
     "    description: One short post per day.\n" +
     "    trigger: {schedules: ['0 18 * * *'], timezone: America/Los_Angeles}\n" +
     "    killSwitch: {failDirection: closed}\n" +
-    "    prompt: {file: ./jobs/digest.md}\n" +
+    "    prompt: {skill: daily-digest}\n" +
     "    report: {surface: slack, channel: C01}\n";
+
+  /** `skills/<name>/SKILL.md` beside the manifest — the one layout a name resolves to. */
+  const writeSkill = (name = "daily-digest") => {
+    mkdirSync(join(dir, "skills", name), { recursive: true });
+    const path = join(dir, "skills", name, "SKILL.md");
+    writeFileSync(
+      path,
+      `---\nname: ${name}\ndescription: One short post per day.\n---\nSummarize the day.\n`,
+    );
+    return path;
+  };
 
   /**
    * Slack rather than the scaffold's console surface, and the channel the job answers in:
@@ -183,27 +194,19 @@ describe("sageox-agent validate", () => {
         "    appToken: TEST_SLACK_APP_TOKEN\n    channels: [{id: C01, reply: private}]\n",
     );
 
-  it("lists a prompt job with its file, its size, and its next fire time", async () => {
-    mkdirSync(join(dir, "jobs"));
-    writeFileSync(
-      join(dir, "jobs", "digest.md"),
-      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
-    );
+  it("lists a prompt job with its skill, its size, and its next fire time", async () => {
+    const skill = writeSkill();
     const path = write("agent.yaml", withChannel(AGENT_YAML("demo")) + PROMPT_JOB);
 
     const { code, stdout } = await validate([path]);
 
     expect(code).toBe(0);
-    expect(stdout).toContain(`daily-digest: scheduled turn, prompt ${join(dir, "jobs", "digest.md")}`);
+    expect(stdout).toContain(`daily-digest: scheduled turn, prompt ${skill}`);
     expect(stdout).toMatch(/\(\d+ bytes\), next \d{4}-\d{2}-\d{2} 18:00:00 America\/Los_Angeles/);
   });
 
   it("fails on a report channel the gateway would refuse to start on", async () => {
-    mkdirSync(join(dir, "jobs"));
-    writeFileSync(
-      join(dir, "jobs", "digest.md"),
-      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
-    );
+    writeSkill();
     const path = write(
       "agent.yaml",
       withChannel(AGENT_YAML("demo")) + PROMPT_JOB.replace("channel: C01", "channel: nowhere"),
@@ -218,11 +221,7 @@ describe("sageox-agent validate", () => {
   it("fails on a report surface that carries no top-level post at all", async () => {
     // The half a channel list cannot answer: console lists the channel and still has no way
     // to publish a new top-level message in it, which is how a scheduled turn answers.
-    mkdirSync(join(dir, "jobs"));
-    writeFileSync(
-      join(dir, "jobs", "digest.md"),
-      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
-    );
+    writeSkill();
     const path = write(
       "agent.yaml",
       AGENT_YAML("demo").replace(
@@ -237,13 +236,13 @@ describe("sageox-agent validate", () => {
     expect(stdout).toContain("carries no top-level posts");
   });
 
-  it("fails on a prompt file the gateway would refuse to start on", async () => {
+  it("fails on a skill the gateway would refuse to start on", async () => {
     const path = write("agent.yaml", withChannel(AGENT_YAML("demo")) + PROMPT_JOB);
 
     const { code, stdout } = await validate([path]);
 
     expect(code).not.toBe(0);
-    expect(stdout).toContain("jobs/digest.md");
+    expect(stdout).toContain("skill daily-digest");
     expect(stdout).toContain("FAIL");
   });
 });

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -195,6 +195,23 @@ describe("sageox-agent validate", () => {
     expect(stdout).toMatch(/\(\d+ bytes\), next \d{4}-\d{2}-\d{2} 18:00:00 America\/Los_Angeles/);
   });
 
+  it("fails on a report channel the gateway would refuse to start on", async () => {
+    mkdirSync(join(dir, "jobs"));
+    writeFileSync(
+      join(dir, "jobs", "digest.md"),
+      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
+    );
+    const path = write(
+      "agent.yaml",
+      withChannel(AGENT_YAML("demo")) + PROMPT_JOB.replace("channel: local", "channel: nowhere"),
+    );
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain("does not list as a channel");
+  });
+
   it("fails on a prompt file the gateway would refuse to start on", async () => {
     const path = write("agent.yaml", withChannel(AGENT_YAML("demo")) + PROMPT_JOB);
 

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -155,4 +155,53 @@ describe("sageox-agent validate", () => {
     expect(existsSync(home)).toBe(false);
     expect(readdirSync(dir)).toEqual(before);
   });
+  /**
+   * A prompt job, whose words live in a file beside the manifest. `run` reads that file at
+   * startup and refuses to launch on one it cannot, so a CI step that passed on a broken
+   * one would be green about a bundle that will not boot.
+   */
+  const PROMPT_JOB =
+    "brains:\n  - preset: local\n" +
+    "# A channel on the surface the job reports to, which is where the turn answers.\n" +
+    "killSwitchParkBy: []\n" +
+    "jobs:\n" +
+    "  - slug: daily-digest\n" +
+    "    archetype: watch\n" +
+    "    description: One short post per day.\n" +
+    "    trigger: {schedules: ['0 18 * * *'], timezone: America/Los_Angeles}\n" +
+    "    killSwitch: {failDirection: closed}\n" +
+    "    prompt: {file: ./jobs/digest.md}\n" +
+    "    report: {surface: console, channel: local}\n";
+
+  /** The console surface gains the channel the job above answers in. */
+  const withChannel = (yaml: string) =>
+    yaml.replace(
+      "surfaces:\n  - kind: console\n",
+      "surfaces:\n  - kind: console\n    channels: [{id: local, reply: private}]\n",
+    );
+
+  it("lists a prompt job with its file, its size, and its next fire time", async () => {
+    mkdirSync(join(dir, "jobs"));
+    writeFileSync(
+      join(dir, "jobs", "digest.md"),
+      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
+    );
+    const path = write("agent.yaml", withChannel(AGENT_YAML("demo")) + PROMPT_JOB);
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain(`daily-digest: scheduled turn, prompt ${join(dir, "jobs", "digest.md")}`);
+    expect(stdout).toMatch(/\(\d+ bytes\), next \d{4}-\d{2}-\d{2} 18:00:00 America\/Los_Angeles/);
+  });
+
+  it("fails on a prompt file the gateway would refuse to start on", async () => {
+    const path = write("agent.yaml", withChannel(AGENT_YAML("demo")) + PROMPT_JOB);
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain("jobs/digest.md");
+    expect(stdout).toContain("FAIL");
+  });
 });

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -162,7 +162,6 @@ describe("sageox-agent validate", () => {
    */
   const PROMPT_JOB =
     "brains:\n  - preset: local\n" +
-    "# A channel on the surface the job reports to, which is where the turn answers.\n" +
     "killSwitchParkBy: []\n" +
     "jobs:\n" +
     "  - slug: daily-digest\n" +
@@ -171,13 +170,17 @@ describe("sageox-agent validate", () => {
     "    trigger: {schedules: ['0 18 * * *'], timezone: America/Los_Angeles}\n" +
     "    killSwitch: {failDirection: closed}\n" +
     "    prompt: {file: ./jobs/digest.md}\n" +
-    "    report: {surface: console, channel: local}\n";
+    "    report: {surface: slack, channel: C01}\n";
 
-  /** The console surface gains the channel the job above answers in. */
+  /**
+   * Slack rather than the scaffold's console surface, and the channel the job answers in:
+   * a scheduled turn posts at top level, which console cannot do at all.
+   */
   const withChannel = (yaml: string) =>
     yaml.replace(
       "surfaces:\n  - kind: console\n",
-      "surfaces:\n  - kind: console\n    channels: [{id: local, reply: private}]\n",
+      "surfaces:\n  - kind: slack\n    identity: TEST_SLACK_BOT_TOKEN\n" +
+        "    appToken: TEST_SLACK_APP_TOKEN\n    channels: [{id: C01, reply: private}]\n",
     );
 
   it("lists a prompt job with its file, its size, and its next fire time", async () => {
@@ -203,7 +206,7 @@ describe("sageox-agent validate", () => {
     );
     const path = write(
       "agent.yaml",
-      withChannel(AGENT_YAML("demo")) + PROMPT_JOB.replace("channel: local", "channel: nowhere"),
+      withChannel(AGENT_YAML("demo")) + PROMPT_JOB.replace("channel: C01", "channel: nowhere"),
     );
 
     const { code, stdout } = await validate([path]);

--- a/packages/cli/test/validate.test.ts
+++ b/packages/cli/test/validate.test.ts
@@ -215,6 +215,28 @@ describe("sageox-agent validate", () => {
     expect(stdout).toContain("does not list as a channel");
   });
 
+  it("fails on a report surface that carries no top-level post at all", async () => {
+    // The half a channel list cannot answer: console lists the channel and still has no way
+    // to publish a new top-level message in it, which is how a scheduled turn answers.
+    mkdirSync(join(dir, "jobs"));
+    writeFileSync(
+      join(dir, "jobs", "digest.md"),
+      "---\nname: daily-digest\ndescription: One short post per day.\n---\nSummarize the day.\n",
+    );
+    const path = write(
+      "agent.yaml",
+      AGENT_YAML("demo").replace(
+        "surfaces:\n  - kind: console\n",
+        "surfaces:\n  - kind: console\n    channels: [{id: local, reply: private}]\n",
+      ) + PROMPT_JOB.replace("{surface: slack, channel: C01}", "{surface: console, channel: local}"),
+    );
+
+    const { code, stdout } = await validate([path]);
+
+    expect(code).not.toBe(0);
+    expect(stdout).toContain("carries no top-level posts");
+  });
+
   it("fails on a prompt file the gateway would refuse to start on", async () => {
     const path = write("agent.yaml", withChannel(AGENT_YAML("demo")) + PROMPT_JOB);
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.ts",
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.3.0",
+    "croner": "^10.0.1",
     "yaml": "^2.5.0",
     "zod": "^4.4.3"
   }

--- a/packages/core/src/brain.ts
+++ b/packages/core/src/brain.ts
@@ -12,6 +12,15 @@ export interface BrainContext {
   /** A gateway-hosted, explicitly allowlisted reaction tool is available. */
   react?: boolean;
   /**
+   * This turn is a clock tick, so `event.text` is the bundle's own prompt rather than
+   * something somebody sent — see {@link assembleTurnPrompt}, which renders it as steering
+   * instead of fencing it as untrusted data.
+   *
+   * Set by `Gateway.tick` and by nothing else. No adapter produces an event that reaches
+   * that door, so no channel message can claim to be one.
+   */
+  scheduled?: boolean;
+  /**
    * How every capability the agent has is doing, right now. Trusted runtime data, not chat
    * content: each reading is built from a closed vocabulary by whoever probed it.
    *

--- a/packages/core/src/gateway.ts
+++ b/packages/core/src/gateway.ts
@@ -1,9 +1,9 @@
 import type { AgentManifest } from "./manifest.ts";
 import type { SurfaceAdapter } from "./adapter.ts";
 import type { Brain, BrainContext, GuardFeedback } from "./brain.ts";
-import type { InboundEvent } from "./events.ts";
+import type { GuardedMessage, InboundEvent } from "./events.ts";
 import type { ProbeResult } from "./health.ts";
-import { evaluateEgress } from "./guard.ts";
+import { evaluateEgress, type GuardVerdict } from "./guard.ts";
 import { SurfaceEgress, type LiveTurnHandle } from "./surface-egress.ts";
 import { TurnPolicy } from "./policy.ts";
 import { ChannelQueue } from "./queue.ts";
@@ -38,6 +38,37 @@ export interface GatewayOpts {
    * has not.
    */
   capabilities?: () => readonly ProbeResult[];
+}
+
+/**
+ * How one step of a turn reaches its channel. A message the brain woke on is answered
+ * where it was asked ({@link SurfaceEgress.reply}); a clock tick has no message to answer,
+ * so it posts at top level ({@link SurfaceEgress.postReply}). Both clear the same guard,
+ * and both hand a refusal back rather than throwing, because the turn loop replays one to
+ * the brain as the result of its own yield.
+ */
+type Send = (msg: GuardedMessage) => Promise<GuardVerdict>;
+
+/**
+ * What a turn did with its channel, counted as it goes into an object the caller holds.
+ *
+ * Held rather than only returned, because a turn that timed out still posted whatever it
+ * posted before it hung, and a promise that rejected cannot say so. A caller that has to
+ * report on the turn needs both halves.
+ */
+export interface TurnTally {
+  /** Replies the brain asked to send. */
+  asked: number;
+  /** Replies that cleared the guard and reached the surface. */
+  sent: number;
+}
+
+/** {@link Gateway.tick}'s answer: whether the turn ran at all, and what it did. */
+export interface TickOutcome extends TurnTally {
+  /** Why no turn ran, in {@link Gateway}'s own skip vocabulary. Absent when one did. */
+  skipped?: string;
+  /** The turn threw, or outlived its timeout. The tally still says what had landed. */
+  error?: unknown;
 }
 
 /**
@@ -159,7 +190,7 @@ export class Gateway {
       const turn = this.egress.answers(e);
       const stopSignalling = this.signalWorking(e, adapter, turn);
       try {
-        const sent = await this.runTurn(e, adapter);
+        const { sent } = await this.runTurn(e, (msg) => this.egress.reply(adapter, e, msg));
         console.info(
           `turn_done surface=${e.surface} channel=${e.channel.id} event=${e.id.nativeId} ` +
             `sent=${sent} ms=${Date.now() - started}`,
@@ -175,6 +206,68 @@ export class Gateway {
         stopSignalling();
         turn.close();
       }
+    });
+  }
+
+  /**
+   * A clock tick, run as an ordinary turn and answered with what it did.
+   *
+   * The event is synthetic: nothing in a channel produced it, and its text came from the
+   * reviewed bundle. That is the whole of what makes this safe to admit without a mention
+   * — see `scheduled-turn.ts`, which is the only caller.
+   *
+   * **One check is skipped and only one**: the author gate, because the author is this
+   * process's own clock and `respondTo` has nothing to weigh about it. The kill switch and
+   * the policy caps are applied here in the order `skipReason` applies them, and the turn
+   * is queued on the destination channel, so a tick waits behind a live turn there rather
+   * than interleaving posts with it.
+   *
+   * The answer is a top-level post into `to`, which the guard admits exactly as it admits
+   * the brain's own `post_message`: a channel the agent has no consent to speak in is one
+   * this cannot reach either.
+   */
+  async tick(
+    event: InboundEvent,
+    to: { surface: string; channel: string },
+    timeoutMs = this.opts.manifest.limits.turnTimeoutMs,
+  ): Promise<TickOutcome> {
+    const tally: TurnTally = { asked: 0, sent: 0 };
+    if (!this.serving) return { ...tally, skipped: "kill_switch" };
+    const admission = this.policy.admit(event);
+    if (!admission.ok) return { ...tally, skipped: `limit:${admission.rule}` };
+
+    return new Promise<TickOutcome>((resolve) => {
+      this.queue.submit(`${event.surface}:${event.channel.id}`, async () => {
+        const started = Date.now();
+        console.info(
+          `tick_start surface=${event.surface} channel=${event.channel.id} author=${event.author.id}`,
+        );
+        try {
+          const scheduled = true; // the prompt is the bundle's, so the turn is not fenced
+          await this.runTurn(
+            event,
+            (msg) => this.egress.postReply(to.surface, to.channel, msg),
+            tally,
+            timeoutMs,
+            scheduled,
+          );
+          console.info(
+            `tick_done surface=${event.surface} channel=${event.channel.id} ` +
+              `author=${event.author.id} sent=${tally.sent} ms=${Date.now() - started}`,
+          );
+          resolve(tally);
+        } catch (error) {
+          // Never rethrown into the queue: a failed tick is this caller's to report, and
+          // `ChannelQueue.onError` would put it in the log as a chat turn that failed.
+          console.warn(
+            `tick_failed surface=${event.surface} channel=${event.channel.id} ` +
+              `author=${event.author.id} ms=${Date.now() - started}`,
+          );
+          resolve({ ...tally, error });
+        }
+      // Shed rather than run: the queue is full of live chat in this channel, which is the
+      // `channelQueueLimit` cap doing its job. The tick is owed a record either way.
+      }, () => resolve({ ...tally, skipped: "limit:channelQueueLimit" }));
     });
   }
 
@@ -278,20 +371,27 @@ export class Gateway {
     );
   }
 
-  private async runTurn(e: InboundEvent, adapter: SurfaceAdapter): Promise<number> {
+  private async runTurn(
+    e: InboundEvent,
+    send: Send,
+    tally: TurnTally = { asked: 0, sent: 0 },
+    timeoutMs = this.opts.manifest.limits.turnTimeoutMs,
+    scheduled = false,
+  ): Promise<TurnTally> {
     const turn = this.opts.brain.runTurn(e, {
       agentName: this.opts.manifest.name,
       persona: this.opts.persona,
       memory: this.opts.memory,
       postMessage: this.opts.postMessage,
       react: this.opts.react,
+      scheduled,
       capabilities: this.opts.capabilities?.(),
     });
     try {
       return await withTimeout(
-        this.drive(turn, e, adapter),
-        this.opts.manifest.limits.turnTimeoutMs,
-        `turn timed out after ${this.opts.manifest.limits.turnTimeoutMs}ms`,
+        this.drive(turn, e, send, tally),
+        timeoutMs,
+        `turn timed out after ${timeoutMs}ms`,
       );
     } finally {
       // An abandoned generator never runs its own `finally`, so the brain would never
@@ -314,9 +414,9 @@ export class Gateway {
   private async drive(
     turn: ReturnType<Brain["runTurn"]>,
     e: InboundEvent,
-    adapter: SurfaceAdapter,
-  ): Promise<number> {
-    let sent = 0;
+    send: Send,
+    tally: TurnTally,
+  ): Promise<TurnTally> {
     // The guard is a feedback loop: a refused step is handed back to the brain as the
     // result of its own yield, so it can adapt without the turn ending. The loop is
     // bounded by the brain — the gateway never retries on its behalf.
@@ -328,8 +428,9 @@ export class Gateway {
 
       const step = next.value;
       if (step.type !== "reply") continue;
+      tally.asked++;
 
-      const verdict = await this.egress.reply(adapter, e, step.msg);
+      const verdict = await send(step.msg);
       if (!verdict.ok) {
         // The reason too, not just the rule: `leakPatterns` refuses over a list of pattern
         // names an operator has to see to act on, and a bare `rule=leakPatterns` says a
@@ -343,9 +444,9 @@ export class Gateway {
         feedback = { blocked: true, rule: verdict.rule, reason: verdict.reason };
         continue;
       }
-      sent++;
+      tally.sent++;
     }
-    return sent;
+    return tally;
   }
 }
 

--- a/packages/core/src/gateway.ts
+++ b/packages/core/src/gateway.ts
@@ -237,6 +237,18 @@ export class Gateway {
     if (!admission.ok) return { ...tally, skipped: `limit:${admission.rule}` };
 
     return new Promise<TickOutcome>((resolve) => {
+      // The timeout releases the queue slot; it cannot cancel a brain suspended inside an
+      // `await`. So an abandoned turn can come back and yield a reply minutes later, and
+      // for a tick that reply would land at top level under the failure line the host has
+      // already posted about it — two answers to one tick, in the wrong order. A chat
+      // turn's late reply threads under the message it answers and contradicts nothing, so
+      // this is the scheduled path's to close and not the shared loop's.
+      let live = true;
+      const send: Send = async (msg) =>
+        live
+          ? this.egress.postReply(to.surface, to.channel, msg)
+          : { ok: false, rule: "turnEnded", reason: "this tick was recorded before the step arrived" };
+
       this.queue.submit(`${event.surface}:${event.channel.id}`, async () => {
         const started = Date.now();
         // Everything is inside the `try`, logging included: this promise is the only thing
@@ -247,13 +259,7 @@ export class Gateway {
             `tick_start surface=${event.surface} channel=${event.channel.id} author=${event.author.id}`,
           );
           const scheduled = true; // the prompt is the bundle's, so the turn is not fenced
-          await this.runTurn(
-            event,
-            (msg) => this.egress.postReply(to.surface, to.channel, msg),
-            tally,
-            timeoutMs,
-            scheduled,
-          );
+          await this.runTurn(event, send, tally, timeoutMs, scheduled);
           console.info(
             `tick_done surface=${event.surface} channel=${event.channel.id} ` +
               `author=${event.author.id} sent=${tally.sent} ms=${Date.now() - started}`,
@@ -267,6 +273,10 @@ export class Gateway {
               `author=${event.author.id} ms=${Date.now() - started}`,
           );
           resolve({ ...tally, error });
+        } finally {
+          // Closed on both paths and after the tally is read, so nothing this tick is about
+          // to be recorded for can still reach the channel.
+          live = false;
         }
       // Shed rather than run: the queue is full of live chat in this channel, which is the
       // `channelQueueLimit` cap doing its job. The tick is owed a record either way.

--- a/packages/core/src/gateway.ts
+++ b/packages/core/src/gateway.ts
@@ -239,10 +239,13 @@ export class Gateway {
     return new Promise<TickOutcome>((resolve) => {
       this.queue.submit(`${event.surface}:${event.channel.id}`, async () => {
         const started = Date.now();
-        console.info(
-          `tick_start surface=${event.surface} channel=${event.channel.id} author=${event.author.id}`,
-        );
+        // Everything is inside the `try`, logging included: this promise is the only thing
+        // the ticker is waiting on, and a throw that escaped would leave it pending for the
+        // life of the process rather than reporting a failed tick.
         try {
+          console.info(
+            `tick_start surface=${event.surface} channel=${event.channel.id} author=${event.author.id}`,
+          );
           const scheduled = true; // the prompt is the bundle's, so the turn is not fenced
           await this.runTurn(
             event,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export * from "./kill-switch.ts";
 export * from "./job-channel.ts";
 export * from "./job-host.ts";
 export * from "./job-server.ts";
+export * from "./scheduled-turn.ts";
 
 export { ExternalJobs, ExternalRequestSchema, workerResult, publishJobOutput } from "./external-jobs.ts";
 export { type FinalJobOutput } from "./job-output.ts";

--- a/packages/core/src/job-dispatcher.ts
+++ b/packages/core/src/job-dispatcher.ts
@@ -5,7 +5,7 @@ import { request as httpsRequest } from "node:https";
 import { z } from "zod";
 import { jobDeadlineMs, jobParams } from "./job-host.ts";
 import { admitJob } from "./kill-switch.ts";
-import { type JobConfig } from "./manifest.ts";
+import { isProcessJob, type JobConfig, type ProcessJob } from "./manifest.ts";
 import { tokenMatches, type ServeOptions } from "./mcp-http.ts";
 import { WorkerDiagnosticsSchema, type WorkerDiagnostics } from "./job-diagnostics.ts";
 import { FinalJobOutputSchema, JobOutputEnvelopeSchema, JOB_STATUS_LIMIT_BYTES } from "./job-output.ts";
@@ -94,7 +94,7 @@ interface StoredRun {
   tokenHash?: string;
   claimed?: boolean;
   cleaned?: boolean;
-  job?: JobConfig;
+  job?: ProcessJob;
   profile?: WorkerProfiles[string];
 }
 
@@ -111,7 +111,8 @@ export class JobDispatcher {
     ObjectName.parse(opts.name);
     this.label = { "agent-toolkit/dispatcher": opts.name };
     opts.profiles = WorkerProfilesSchema.parse(opts.profiles);
-    for (const job of opts.jobs.filter((job) => job.worker)) {
+    for (const job of opts.jobs) {
+      if (!isProcessJob(job) || !job.worker) continue;
       const profile = opts.profiles[job.slug];
       if (!profile) throw new Error(`job ${job.slug} has no worker deployment profile`);
       for (const ref of Object.values({ ...job.run.secrets, ...job.run.jobSecrets })) {
@@ -141,7 +142,11 @@ export class JobDispatcher {
 
   async dispatch(raw: unknown): Promise<ExternalStatus> {
     const request = ExternalRequestSchema.parse(raw);
-    const job = this.opts.jobs.find((job) => job.slug === request.jobSlug);
+    // Narrowed at the lookup: a worker is always a `run` body, and a dispatcher that
+    // found a prompt job under this slug has nothing to deploy.
+    const job = this.opts.jobs.find(
+      (candidate): candidate is ProcessJob => candidate.slug === request.jobSlug && isProcessJob(candidate),
+    );
     if (!job?.worker || request.definition !== jobDefinition(job)) throw new KubeError(400);
     jobParams(job, request.parameters);
     const arms = request.trigger === "on-request" ? job.trigger.onRequest

--- a/packages/core/src/job-host.ts
+++ b/packages/core/src/job-host.ts
@@ -23,7 +23,7 @@ import type { ActorRef, ChannelHistory, EventRef, ThreadReply } from "./events.t
 import { serveJobChannel } from "./job-channel.ts";
 import type { HostedMcp } from "./mcp-http.ts";
 import { withTimeout } from "./gateway.ts";
-import type { JobAnnounce, JobConfig } from "./manifest.ts";
+import { isProcessJob, type JobAnnounce, type JobConfig, type ProcessJob } from "./manifest.ts";
 import { resolveSecret } from "./secrets.ts";
 import {
   combineVerdicts,
@@ -427,7 +427,7 @@ export function jobParams(job: JobConfig, given: Readonly<Record<string, unknown
  */
 const SAY_GRACE_MS = 5_000;
 
-export function jobDeadlineMs(job: JobConfig): number {
+export function jobDeadlineMs(job: ProcessJob): number {
   return job.budget.wallClockMs + job.budget.deadlineHeadroomMs;
 }
 
@@ -499,7 +499,11 @@ export class JobHost {
 
   /** Only the standalone worker entrypoint calls this with a dispatcher-owned record. */
   async executeWorker(job: JobConfig, request: ExternalRequest): Promise<JobRun> {
-    if (!job.worker || jobDefinition(job) !== request.definition) throw new Error("worker definition mismatch");
+    // `isProcessJob` narrows for everything below: a worker is always a `run` body, so a
+    // prompt job reaching here is the same mismatch as a job with no worker at all.
+    if (!isProcessJob(job) || !job.worker || jobDefinition(job) !== request.definition) {
+      throw new Error("worker definition mismatch");
+    }
     jobParams(job, request.parameters);
     const remaining = request.startedAt + job.budget.wallClockMs - Date.now();
     if (remaining <= 0) {
@@ -742,7 +746,7 @@ export class JobHost {
 
   /** One abandoned run: the record, then the last thing its channel will hear about it. */
   private async giveUp(
-    job: JobConfig,
+    job: ProcessJob,
     base: RunBase,
     admission: JobAdmission,
     answer?: JobAnswer,
@@ -884,7 +888,9 @@ export class JobHost {
           bypassedSwitch: false,
           gates: [didNotRun],
           checks: [{ gate: jobGate(job), executed: false, exitCode: null }],
-          reason: `${job.slug} does not arm the ${trigger} trigger, so nothing may start it that way`,
+          reason: job.prompt
+            ? `${job.slug} has a prompt body, which only the gateway's own ticker runs`
+            : `${job.slug} does not arm the ${trigger} trigger, so nothing may start it that way`,
         }),
       );
     }
@@ -997,7 +1003,7 @@ export class JobHost {
 
   /** The body, the record it produced, and the post that says so — in that order. */
   private async finish(
-    job: JobConfig,
+    job: ProcessJob,
     base: RunBase,
     admission: JobAdmission,
     detached: boolean,
@@ -1021,7 +1027,7 @@ export class JobHost {
 
   /** Spawn the body, hold it to its wall clock, and read back what it says it ran. */
   private async execute(
-    job: JobConfig,
+    job: ProcessJob,
     base: RunBase,
   ): Promise<Pick<JobRun, "outcome" | "gates" | "reason" | "execution" | "work" | "checks" | "reportStatus">> {
     let verdictPath: string;
@@ -1131,7 +1137,7 @@ export class JobHost {
    * whose verdict would be minted from a channel it never spoke into. Unstarted gate,
    * UNKNOWN verdict, and a run record naming what was missing.
    */
-  private async openChannel(job: JobConfig): Promise<HostedMcp | undefined> {
+  private async openChannel(job: ProcessJob): Promise<HostedMcp | undefined> {
     if (!job.report?.probe) return undefined;
     if (!this.opts.post) {
       throw new Error(
@@ -1148,7 +1154,7 @@ export class JobHost {
     });
   }
 
-  private spawnBody(job: JobConfig, env: NodeJS.ProcessEnv, base: RunBase): Promise<Execution> {
+  private spawnBody(job: ProcessJob, env: NodeJS.ProcessEnv, base: RunBase): Promise<Execution> {
     return new Promise<Execution>((resolve) => {
       const knownSecrets = [...(this.opts.diagnosticSecrets ?? []), ...Object.keys({ ...job.run.secrets, ...job.run.jobSecrets })
         .map((name) => env[name]).filter((value): value is string => Boolean(value))];
@@ -1291,7 +1297,7 @@ export class JobHost {
    *    and so is `JOB_CHANNEL_*` when this run has a channel to talk through.
    */
   private envelope(
-    job: JobConfig,
+    job: ProcessJob,
     base: RunBase,
     verdictPath: string,
     channel?: HostedMcp,
@@ -1528,19 +1534,32 @@ export function describeJobRun(run: JobRun, proven?: ProvenVoice): string {
  * The two denied outcomes stay silent in every mode. They are a posture somebody chose, and
  * the run whose verdict these modes weigh never happened.
  */
-function announces(run: JobRun, detached: boolean, announce: JobAnnounce): boolean {
+export function announces(run: JobRun, detached: boolean, announce: JobAnnounce): boolean {
   if (run.outcome === "denied-switch" || run.outcome === "denied-suspend") return false;
   if (detached || announce === "always" || !isProven(run.verdict)) return true;
   return announce === "reported" && run.gates.some((gate) => gate.detail);
 }
 
-/** The host's own gate: did the process run, and what did it say on the way out. */
-function jobGate(job: JobConfig): string {
+/**
+ * The host's own gate: did the process run, and what did it say on the way out.
+ *
+ * Exported for the one other thing that mints a run record under a job's slug — the
+ * gateway's ticker, whose gate is the turn rather than a process. One spelling, so a
+ * channel reading both kinds of record reads one vocabulary.
+ */
+export function jobGate(job: JobConfig): string {
   return `job:${job.slug}`;
 }
 
-/** Whether this job declared that this door may open it. */
-function arms(job: JobConfig, trigger: JobTriggerKind): boolean {
+/**
+ * Whether this job declared that this door may open it.
+ *
+ * A prompt body arms none of them. Its schedules are the gateway ticker's, and every other
+ * trigger is refused at load — so this host, which only ever spawns a process, narrows the
+ * job here rather than re-testing for a `run` at each place that reads one.
+ */
+function arms(job: JobConfig, trigger: JobTriggerKind): job is ProcessJob {
+  if (!isProcessJob(job)) return false;
   if (trigger === "schedule") return job.trigger.schedules.length > 0;
   if (trigger === "on-request") return job.trigger.onRequest;
   return job.trigger.webhook;

--- a/packages/core/src/job-server.ts
+++ b/packages/core/src/job-server.ts
@@ -14,7 +14,7 @@ import {
   type JobRun,
   type JobStart,
 } from "./job-host.ts";
-import type { JobConfig } from "./manifest.ts";
+import { isProcessJob, type JobConfig, type ProcessJob } from "./manifest.ts";
 import {
   mcpToolServer,
   serveMcp,
@@ -66,8 +66,10 @@ function outputReader(agentName: string, home: InboundEvent): string {
  * job that only takes a clock is not offered here — and the refusal is the host's, not this
  * list's, so naming one anyway is denied and recorded rather than quietly ignored.
  */
-export function requestableJobs(jobs: readonly JobConfig[]): readonly JobConfig[] {
-  return jobs.filter((job) => job.trigger.onRequest);
+export function requestableJobs(jobs: readonly JobConfig[]): readonly ProcessJob[] {
+  // Every one of these has a `run` body — `JobSchema` refuses `trigger.onRequest` on a
+  // prompt job — so the narrowing costs a predicate and saves every caller a second test.
+  return jobs.filter((job): job is ProcessJob => job.trigger.onRequest && isProcessJob(job));
 }
 
 export interface JobToolOptions {
@@ -374,7 +376,9 @@ export function jobHandler(opts: JobToolOptions): McpHandler {
       // picks between them — not a field in this call, and not a field in the manifest that
       // could disagree with either number. A job that fits inside a turn is waited for and
       // quoted; one that cannot is started, and answers where it declared it would.
-      if (job.worker || jobDeadlineMs(job) > turnTimeoutMs) {
+      // Both shapes below are a process job's: `requestableJobs` offers no other kind, and
+      // a slug naming a prompt body falls through to the host, which records the refusal.
+      if (isProcessJob(job) && (job.worker || jobDeadlineMs(job) > turnTimeoutMs)) {
         // Read now, not when the run lands: by then the turn is over and the gateway has
         // forgotten which message it was answering. Chat gets a bounded human summary;
         // diagnostic prose stays in tool results and the declared operator reports.
@@ -465,7 +469,7 @@ function describeRun(run: JobRun, job: JobConfig): string {
  * for the person in the channel to discover by waiting. `doctor` flags the same job before
  * a deploy; this is the honest thing to say when one is running anyway.
  */
-function describeStart(job: JobConfig, start: JobStart, answered: boolean): string {
+function describeStart(job: ProcessJob, start: JobStart, answered: boolean): string {
   if (job.worker) return `job ${job.slug} accepted — run id ${start.runId}; no verdict yet. ` +
     "Use job_status with this job and runId to retrieve the result, including after a restart. " +
     "job_cancel stops the worker but does not roll back external side effects.";

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1433,9 +1433,17 @@ export type PromptJob = JobConfig & {
   report: NonNullable<JobConfig["report"]>;
 };
 
-/** Narrowing, not a test: `JobSchema` already refused a job with neither body or both. */
+/**
+ * Narrowing, not a test: `JobSchema` already refused a job with neither body or both, and
+ * a `run` body without a `budget`.
+ *
+ * Both fields are tested anyway, because the type claims both and not every job reaching
+ * these doors came through `loadManifest` — a hand-built one missing its budget would
+ * otherwise narrow here and throw in `jobDeadlineMs`, past the guard that was meant to
+ * catch it.
+ */
 export function isProcessJob(job: JobConfig): job is ProcessJob {
-  return job.run !== undefined;
+  return job.run !== undefined && job.budget !== undefined;
 }
 
 export function isPromptJob(job: JobConfig): job is PromptJob {

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -863,9 +863,10 @@ export const JobSchema = z
      * A one-liner may be written inline. Anything longer is a file, root-relative to the
      * agent directory exactly as `persona` is, because a page of prompt inside a YAML block
      * scalar is a page nobody reviews. The file is read at load and refused there if it is
-     * missing, is not UTF-8, or is larger than a verdict artifact may be — a schedule that
-     * discovers its own prompt is unreadable at 18:00 has nothing to say and nowhere to say
-     * it.
+     * missing, is not UTF-8, is larger than a verdict artifact may be, or resolves outside
+     * the agent directory — a schedule that discovers its own prompt is unreadable at 18:00
+     * has nothing to say and nowhere to say it, and one reading a file from outside the
+     * bundle is not the reviewed steering the tier below claims it is.
      *
      * It is shaped like a skill — `name` and `description` in frontmatter, then the body
      * the tick sends — and that shape is the whole of what this fixes now. The runtime has

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -728,8 +728,17 @@ const JobParameterSchema = z.discriminatedUnion("type", [
  * identity with.
  *
  * The toolkit owns the *envelope* — the trigger, the switch, the bound, the run record,
- * the shape of the status post. It never owns the job body, which is an ordinary process
- * named by `run`. See [the RFC](../../../docs/design/2026-08-19-jobs-rfc.md).
+ * the shape of the status post. It never owns the job body.
+ * See [the RFC](../../../docs/design/2026-08-19-jobs-rfc.md).
+ *
+ * A job declares exactly one body, and which one decides where it runs and what it can
+ * reach. `run` is a process in a pod of its own, with a scrubbed environment and whatever
+ * credentials it declared; `prompt` is a brain turn in the gateway, with the agent's own
+ * tools and no credential at all. The envelope above them is the same one, which is why
+ * this is one list rather than two: the trigger, the switch, `suspend`, `report` and the
+ * work events already exist here, and a second block would be all of them again for the
+ * sake of one field. The line that matters holds in both directions — a `run` body cannot
+ * reach the brain, and a `prompt` body cannot reach a scrubbed process or a job secret.
  *
  * Here rather than in chart values because `docs/deployment-contract.md` requires a
  * deployment target to "preserve this contract instead of translating `agent.yaml` into a
@@ -778,7 +787,12 @@ export const JobSchema = z
      * want on the roster but not running is `suspend: true`.
      */
     suspend: z.boolean().default(false),
-    budget: BudgetSchema,
+    /**
+     * Required of a `run` body and optional on a `prompt` one, which has no process to
+     * bound: a brain turn is already held to `limits.turnTimeoutMs`, and a `wallClockMs`
+     * below that number is the only thing a prompt job's budget can shorten.
+     */
+    budget: BudgetSchema.optional(),
     /**
      * The tier this job's work runs on. Independent of `brain.model` — a job is its own
      * process, not a turn on the agent's brain.
@@ -792,8 +806,9 @@ export const JobSchema = z
       directory: z.string().regex(/^\//, "worker directory must be absolute"),
     }).strict().optional(),
     /**
-     * The job body: a process, an exit code, and a verdict artifact. TypeScript, a shell
-     * script, or a compiled binary — the toolkit spawns it and reads what it wrote.
+     * One of the two job bodies: a process, an exit code, and a verdict artifact.
+     * TypeScript, a shell script, or a compiled binary — the toolkit spawns it and reads
+     * what it wrote. See {@link JobSchema}'s `prompt` for the other.
      *
      * This names a process the host spawns, so it sits on the same trust boundary as
      * `mcpServers[].command` and `brains[].command`: a bundle is code-equivalent. Two
@@ -837,7 +852,34 @@ export const JobSchema = z
          */
         passthrough: z.array(EnvVarName).default([]),
       })
-      .strict(),
+      .strict()
+      .optional(),
+    /**
+     * The other job body: words, run as an ordinary guarded brain turn in the gateway
+     * process. No pod, no argv, no scrubbed environment, and no credential of its own —
+     * a tick enters the turn path as a synthetic inbound event and comes out as a post in
+     * the channel `report` names.
+     *
+     * A one-liner may be written inline. Anything longer is a file, root-relative to the
+     * agent directory exactly as `persona` is, because a page of prompt inside a YAML block
+     * scalar is a page nobody reviews. The file is read at load and refused there if it is
+     * missing, is not UTF-8, or is larger than a verdict artifact may be — a schedule that
+     * discovers its own prompt is unreadable at 18:00 has nothing to say and nowhere to say
+     * it.
+     *
+     * It is shaped like a skill — `name` and `description` in frontmatter, then the body
+     * the tick sends — and that shape is the whole of what this fixes now. The runtime has
+     * no skills notion, and v1 depends on none arriving; when one does, the same file can
+     * be offered to the chat face so "run the digest now" is this prompt invoked on
+     * request, without a second declaration.
+     *
+     * Provenance is the property that must survive: the words come from the reviewed
+     * bundle and nowhere else. No channel message can start one of these turns, edit its
+     * prompt, or claim to be one.
+     */
+    prompt: z
+      .union([z.string().trim().min(1), z.object({ file: z.string().min(1) }).strict()])
+      .optional(),
     /**
      * Values a caller may hand one run of this job, by name. See {@link JobParameterSchema}.
      *
@@ -945,6 +987,111 @@ export const JobSchema = z
       .optional(),
   })
   .strict()
+  // One body per job, and every field that belongs to the body it is not.
+  //
+  // The refusals below are not tidiness. Each one is a field that would load, read as a
+  // grant, and do nothing — a `model` nothing pins, a `parameters` nothing can fill, a
+  // `report.probe` opening a channel no body is there to talk through. A declaration that
+  // claims a capability it does not have is worse than one that never made the claim,
+  // because the next person to read it plans against it.
+  .superRefine((job, ctx) => {
+    // Nothing below is true yet while the object's own fields are failing: a `prompt`
+    // refused for its own reason is simply absent from `job` here, and "declares neither
+    // body" would then be said about a manifest that plainly declares one.
+    if (ctx.issues.length) return;
+
+    const refuse = (message: string, path: string[] = []) =>
+      ctx.addIssue({ code: "custom", message, path });
+
+    if (!job.run === !job.prompt) {
+      refuse(
+        `job "${job.slug}" declares ` +
+          (job.run ? "both `run` and `prompt`" : "neither `run` nor `prompt`") +
+          " — a job has exactly one body: `run` for a process in its own pod, `prompt` for " +
+          "a brain turn in the gateway",
+      );
+      return;
+    }
+
+    if (job.run) {
+      // Required here and optional on the other body, because a turn already has a clock
+      // it cannot outlive and a spawned process has none.
+      if (!job.budget) {
+        refuse(
+          `job "${job.slug}" declares a \`run\` body but no \`budget\` — a spawned process ` +
+            "has no bound of its own, and an unstated bound is no bound",
+          ["budget"],
+        );
+      }
+      return;
+    }
+
+    for (const [field, declared, why] of [
+      ["worker", job.worker, "a turn runs in the gateway process; there is no image to pin"],
+      [
+        "parameters",
+        Object.keys(job.parameters).length > 0,
+        "a tick carries no values, and the prompt is the bundle's rather than a caller's",
+      ],
+      ["model", job.model, "a turn runs on the agent's own brain — pin it with `brain.model`"],
+      ["output", job.output, "a turn writes no verdict artifact to retrieve application data from"],
+      [
+        "trigger.onRequest",
+        job.trigger.onRequest,
+        "nothing serves this door yet; a person who wants the turn now can ask for it in the channel",
+      ],
+      [
+        "trigger.webhook",
+        job.trigger.webhook,
+        "nothing serves this door yet; the clock is the only trigger a prompt body takes",
+      ],
+      [
+        "report.probe",
+        job.report?.probe,
+        "it opens the per-run job channel, and no body is spawned here to talk through one",
+      ],
+      [
+        "report.history",
+        job.report?.history,
+        "the brain reads the channel with its own read tools",
+      ],
+    ] as const) {
+      if (declared) {
+        refuse(`job "${job.slug}" declares a \`prompt\` body, so it declares no \`${field}\` — ${why}`,
+          field.split("."));
+      }
+    }
+
+    // The tick has to enter the turn path somewhere, and `report` is the only field that
+    // says where. Without it there is no surface, no channel, and nothing to post into.
+    if (!job.report) {
+      refuse(
+        `job "${job.slug}" declares a \`prompt\` body but no \`report\` — that is where the ` +
+          "tick is addressed and where the turn answers",
+        ["report"],
+      );
+    }
+    // `reported` announces a run whose body wrote a `detail` on some gate. A turn writes no
+    // gates, so the mode would silence every tick rather than select among them.
+    if (job.report?.announce === "reported") {
+      refuse(
+        `job "${job.slug}" declares a \`prompt\` body, so \`report.announce: reported\` has ` +
+          "nothing to key on — a turn writes no gate details. Use `unproven` or `always`",
+        ["report", "announce"],
+      );
+    }
+    // The gateway's ticker computes a next wall-clock fire time in `trigger.timezone`.
+    // `@every 5m` names an interval instead, so there is nothing for the zone to resolve.
+    const intervals = job.trigger.schedules.filter((expression) => expression.startsWith("@every"));
+    if (intervals.length) {
+      refuse(
+        `job "${job.slug}" declares a \`prompt\` body and the schedule ` +
+          `${intervals.join(", ")} — the gateway fires a prompt job at a wall-clock time in ` +
+          "`trigger.timezone`, and an interval descriptor names none. Write it as five fields",
+        ["trigger", "schedules"],
+      );
+    }
+  })
   // Resolve the switch key here so no consumer re-derives it. Two derivations of one key
   // is how a reader and a writer end up on different keys.
   .transform((job) => ({
@@ -1159,7 +1306,7 @@ const ManifestSchema = z
   // only which process the deployment started it in.
   .superRefine((m, ctx) => {
     for (const job of m.jobs) {
-      const moved = Object.values(job.run.jobSecrets);
+      const moved = Object.values(job.run?.jobSecrets ?? {});
       if (!moved.length || !job.trigger.onRequest || job.worker) continue;
       ctx.addIssue({
         code: "custom",
@@ -1188,7 +1335,9 @@ const ManifestSchema = z
   // last — and which map a ref is in is what the rule above reads.
   .superRefine((m, ctx) => {
     for (const job of m.jobs) {
-      const both = Object.keys(job.run.jobSecrets).filter((name) => name in job.run.secrets);
+      const run = job.run;
+      if (!run) continue;
+      const both = Object.keys(run.jobSecrets).filter((name) => name in run.secrets);
       if (!both.length) continue;
       ctx.addIssue({
         code: "custom",
@@ -1261,6 +1410,38 @@ export type LimitsConfig = z.infer<typeof LimitsSchema>;
 export type AckConfig = z.infer<typeof AckSchema>;
 export type BrainConfig = z.infer<typeof BrainSchema>;
 export type JobConfig = z.infer<typeof JobSchema>;
+
+/**
+ * A job whose body is a process. `run` and `budget` are what every path that spawns one,
+ * holds it to a clock, or renders it into a deploy target reads, and a prompt job has
+ * neither — so those paths take this rather than re-deciding per field whether the job
+ * they were handed has a body they can run.
+ */
+export type ProcessJob = JobConfig & {
+  run: NonNullable<JobConfig["run"]>;
+  budget: NonNullable<JobConfig["budget"]>;
+};
+
+/**
+ * A job whose body is a prompt — the gateway's ticker is the only thing that runs one.
+ *
+ * `report` is part of the type because it is where the tick is addressed and where the
+ * turn answers; `JobSchema` refuses a prompt job without one.
+ */
+export type PromptJob = JobConfig & {
+  prompt: NonNullable<JobConfig["prompt"]>;
+  report: NonNullable<JobConfig["report"]>;
+};
+
+/** Narrowing, not a test: `JobSchema` already refused a job with neither body or both. */
+export function isProcessJob(job: JobConfig): job is ProcessJob {
+  return job.run !== undefined;
+}
+
+export function isPromptJob(job: JobConfig): job is PromptJob {
+  return job.prompt !== undefined && job.report !== undefined;
+}
+
 export type JobArchetype = JobConfig["archetype"];
 /** Whether a job's status post is gated on the verdict. See the `report.announce` field. */
 export type JobAnnounce = NonNullable<JobConfig["report"]>["announce"];

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -860,10 +860,14 @@ export const JobSchema = z
      * a tick enters the turn path as a synthetic inbound event and comes out as a post in
      * the channel `report` names.
      *
-     * A one-liner may be written inline. Anything longer **is a skill**, named here and
-     * found at `skills/<name>/SKILL.md` in the bundle — a page of prompt inside a YAML
-     * block scalar is a page nobody reviews, and a skill is what the rest of the world
-     * already calls a page of instructions an agent reads and follows.
+     * Two forms, and the schema takes either at any length: a string written inline, or the
+     * name of a skill found at `skills/<name>/SKILL.md` in the bundle.
+     *
+     * Inline is for something short. Nothing here enforces that — a bound on lines or
+     * characters would refuse a perfectly readable three-line prompt to catch the case it
+     * is aimed at — but a page of prompt inside a YAML block scalar is a page nobody
+     * reviews, and a skill is what the rest of the world already calls a page of
+     * instructions an agent reads and follows.
      *
      * Named rather than pointed at, and that is the whole of the difference. A name is what
      * a person says and what a tool argument carries, so the day a skill can be invoked
@@ -966,7 +970,15 @@ export const JobSchema = z
          * is still minted from what the body ran, and the headline stays host-phrased —
          * a combined verdict carries none of the body's words.
          */
-        proven: z.enum(["labelled", "verbatim"]).default("labelled"),
+        /**
+         * Left undefined rather than defaulted, because the default already lives where it
+         * is used: `jobStatus` and `describeJobRun` both take `proven?: ProvenVoice` and
+         * render `labelled` for an absent one. Defaulting here as well would be the same
+         * decision written twice — and it would erase the difference between a job that
+         * omitted the field and one that asked for `labelled`, which is the difference a
+         * prompt job's refusal below is made of.
+         */
+        proven: z.enum(["labelled", "verbatim"]).optional(),
         /**
          * Whether this job's body may talk through this channel while it runs, rather than
          * only being reported into it when it is over.
@@ -1081,6 +1093,12 @@ export const JobSchema = z
         "report.history",
         job.report?.history,
         "the brain reads the channel with its own read tools",
+      ],
+      [
+        "report.proven",
+        job.report?.proven !== undefined,
+        "it renders the threaded gate lines, and a tick mints one gate — so there is no " +
+          "thread and nothing for this to phrase",
       ],
     ] as const) {
       if (declared) {

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -860,26 +860,52 @@ export const JobSchema = z
      * a tick enters the turn path as a synthetic inbound event and comes out as a post in
      * the channel `report` names.
      *
-     * A one-liner may be written inline. Anything longer is a file, root-relative to the
-     * agent directory exactly as `persona` is, because a page of prompt inside a YAML block
-     * scalar is a page nobody reviews. The file is read at load and refused there if it is
-     * missing, is not UTF-8, is larger than a verdict artifact may be, or resolves outside
-     * the agent directory — a schedule that discovers its own prompt is unreadable at 18:00
-     * has nothing to say and nowhere to say it, and one reading a file from outside the
-     * bundle is not the reviewed steering the tier below claims it is.
+     * A one-liner may be written inline. Anything longer **is a skill**, named here and
+     * found at `skills/<name>/SKILL.md` in the bundle — a page of prompt inside a YAML
+     * block scalar is a page nobody reviews, and a skill is what the rest of the world
+     * already calls a page of instructions an agent reads and follows.
      *
-     * It is shaped like a skill — `name` and `description` in frontmatter, then the body
-     * the tick sends — and that shape is the whole of what this fixes now. The runtime has
-     * no skills notion, and v1 depends on none arriving; when one does, the same file can
-     * be offered to the chat face so "run the digest now" is this prompt invoked on
-     * request, without a second declaration.
+     * Named rather than pointed at, and that is the whole of the difference. A name is what
+     * a person says and what a tool argument carries, so the day a skill can be invoked
+     * from the chat face, "run the digest now" resolves the same name through the same
+     * lookup with no second declaration and no file moved. A path is not an invocation
+     * handle. It is also the narrower thing to admit: a slug cannot be absolute, cannot
+     * traverse, and cannot reach the runtime's own `workspace/` — where repository
+     * checkouts live, refreshed from their remotes — so those are not doors this has to
+     * close one at a time.
+     *
+     * The file is read at load, and refused there if it is missing, is not UTF-8, is larger
+     * than a verdict artifact may be, or really lives outside the bundle's `skills/` tree.
+     * A schedule that discovers its own prompt is unreadable at 18:00 has nothing to say
+     * and nowhere to say it.
      *
      * Provenance is the property that must survive: the words come from the reviewed
      * bundle and nowhere else. No channel message can start one of these turns, edit its
      * prompt, or claim to be one.
      */
     prompt: z
-      .union([z.string().trim().min(1), z.object({ file: z.string().min(1) }).strict()])
+      .union([
+        z.string().trim().min(1),
+        z
+          .object({
+            /**
+             * The directory under `skills/` holding this skill's `SKILL.md`, and the name
+             * its frontmatter has to agree with — two spellings of one thing are how a
+             * skill ends up found under one name and announcing itself as another.
+             *
+             * A job slug's grammar, because it names the same kind of thing and a second
+             * spelling of "what may name a thing here" is one more rule to remember.
+             */
+            skill: z
+              .string()
+              .regex(
+                /^[a-z][a-z0-9-]*$/,
+                "a skill name is lower-case letters, digits, and hyphens, starting with a " +
+                  "letter — it names the directory under `skills/`",
+              ),
+          })
+          .strict(),
+      ])
       .optional(),
     /**
      * Values a caller may hand one run of this job, by name. See {@link JobParameterSchema}.

--- a/packages/core/src/queue.ts
+++ b/packages/core/src/queue.ts
@@ -10,8 +10,14 @@ export interface QueueOptions {
   onError?: (error: unknown, channel: string) => void;
 }
 
+/** One queued turn, and how to tell it that it will never run. */
+interface Queued {
+  turn: Turn;
+  shed?: () => void;
+}
+
 interface ChannelState {
-  pending: Turn[];
+  pending: Queued[];
   running: boolean;
 }
 
@@ -29,15 +35,24 @@ export class ChannelQueue {
 
   constructor(private opts: QueueOptions) {}
 
-  submit(channel: string, turn: Turn): void {
+  /**
+   * `shed` is called when overflow drops this turn instead of running it.
+   *
+   * A chat turn needs none: the message is still in the channel, and the shedding is
+   * already in the log. A caller that is owed an answer whatever happens — a clock tick,
+   * which has a run record to write either way — passes one, because a dropped turn is
+   * otherwise a promise that never settles.
+   */
+  submit(channel: string, turn: Turn, shed?: () => void): void {
     const state = this.channels.get(channel) ?? { pending: [], running: false };
     this.channels.set(channel, state);
 
-    state.pending.push(turn);
+    state.pending.push({ turn, shed });
     if (state.pending.length > this.opts.channelQueueLimit) {
-      const dropped = state.pending.length - this.opts.channelQueueLimit;
-      state.pending.splice(0, dropped); // shed oldest — the newest message is the live one
-      this.opts.onShed?.(channel, dropped);
+      const count = state.pending.length - this.opts.channelQueueLimit;
+      // shed oldest — the newest message is the live one
+      for (const dropped of state.pending.splice(0, count)) dropped.shed?.();
+      this.opts.onShed?.(channel, count);
     }
     this.pump();
   }
@@ -64,8 +79,8 @@ export class ChannelQueue {
     state.running = true;
     this.activeChannels++;
     try {
-      const turn = state.pending.shift();
-      if (turn) await turn();
+      const queued = state.pending.shift();
+      if (queued) await queued.turn();
     } catch (error) {
       // One bad turn must not wedge its channel forever.
       this.opts.onError?.(error, channel);

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -9,7 +9,7 @@ import {
   statSync,
   type Stats,
 } from "node:fs";
-import { resolve, sep } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { errorLine, errorText } from "./errors.ts";
@@ -68,6 +68,12 @@ const Frontmatter = z.object({
 });
 
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * The subtree of an agent directory the runtime owns rather than the bundle: repository
+ * checkouts and the indexes over them. See `createRepoWorkspace`, which roots them here.
+ */
+const RUNTIME_STATE = "workspace";
 
 /** Whether `path` is `root` itself or sits beneath it. Both must already be resolved. */
 function within(path: string, root: string): boolean {
@@ -169,8 +175,25 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
     // Missing, or unreadable on the way down. Same sentence the read below would give.
     throw new Error(`${named}: ${errorText(error)}`);
   }
-  if (!within(real, realpathSync(resolve(agentDir)))) {
+  // One resolved root for every test below it: on a host where the agent directory is
+  // reached through a link — `/var` on macOS, a mounted bundle anywhere — comparing a real
+  // path against an unresolved root silently matches nothing.
+  const root = realpathSync(resolve(agentDir));
+  if (!within(real, root)) {
     throw new Error(`${named} is a link to ${real}, which is outside the agent directory — ${steering}`);
+  }
+
+  // `workspace/` is the runtime's, not the bundle's: repository checkouts land there and are
+  // refreshed from their remotes on every start, so a prompt read out of one is words
+  // whoever can merge to that repository chose — arriving as steering, in the process that
+  // holds this agent's credentials. The gateway already refuses to make a checkout the
+  // brain's working directory for this exact reason; this is the same rule at the other
+  // door. Unlike a mount, the runtime can see this one, because the directory is its own.
+  if (within(real, join(root, RUNTIME_STATE))) {
+    throw new Error(
+      `${named} is under ${RUNTIME_STATE}/, which the runtime writes and refreshes from ` +
+        `remotes — ${steering}`,
+    );
   }
 
   let raw: Buffer;

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -60,6 +60,11 @@ const Frontmatter = z.object({
 
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
+/** Whether `path` is `root` itself or sits beneath it. Both must already be resolved. */
+function within(path: string, root: string): boolean {
+  return path === root || path.startsWith(root + sep);
+}
+
 /**
  * Reads a prompt job's words, at load and once.
  *
@@ -78,24 +83,40 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
 
   const source = resolve(agentDir, job.prompt.file);
   const named = `job "${job.slug}" prompt ${source}`;
+  const steering =
+    "a prompt is read as steering, so it comes from the bundle and nowhere a review would " +
+    "not see it";
+
   // The words go to the brain as steering rather than inside the untrusted fence, and the
   // whole argument for that is that they came out of the same reviewed bundle the persona
-  // did. A path that leaves the agent directory breaks it: `/mnt/shared/digest.md` is
-  // mutable by whoever mounted it and appears in no bundle diff. Refused at load so the
-  // provenance claim is one the code keeps rather than one the manifest asserts.
+  // did. Both halves of that are checked here, because they fail differently.
   //
-  // Lexical, and only lexical. A symlink inside the bundle can still point out, and that is
-  // a line in the reviewed diff like any other — the same standing `run.command` has. What
-  // this closes is the case nobody reviews: a path in `agent.yaml` that plainly points away.
-  if (!source.startsWith(resolve(agentDir) + sep)) {
-    throw new Error(
-      `${named} is outside the agent directory — a prompt is read as steering, so it comes ` +
-        "from the bundle and nowhere a review would not see it",
-    );
+  // The path as written: `/mnt/shared/digest.md` is mutable by whoever mounted it and
+  // appears in no bundle diff.
+  if (!within(source, resolve(agentDir))) {
+    throw new Error(`${named} is outside the agent directory — ${steering}`);
   }
+
+  // And what the filesystem says it really is. A symlink committed into the bundle is the
+  // case the first check cannot see, and it is the worse one: the diff shows a path and
+  // never the content, the content can change after the review that approved it, and what
+  // it resolves to reaches the brain as trusted words in the process that holds this
+  // agent's credentials. Writing the prompt file directly is not the same act — that puts
+  // the words themselves in front of a reviewer.
+  let real: string;
+  try {
+    real = realpathSync(source);
+  } catch (error) {
+    // Missing, or unreadable on the way down. Same sentence the read below would give.
+    throw new Error(`${named}: ${errorText(error)}`);
+  }
+  if (!within(real, realpathSync(resolve(agentDir)))) {
+    throw new Error(`${named} is a link to ${real}, which is outside the agent directory — ${steering}`);
+  }
+
   let raw: Buffer;
   try {
-    raw = readFileSync(source);
+    raw = readFileSync(real);
   } catch (error) {
     throw new Error(`${named}: ${errorText(error)}`);
   }

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -70,10 +70,16 @@ const Frontmatter = z.object({
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 
 /**
- * The subtree of an agent directory the runtime owns rather than the bundle: repository
- * checkouts and the indexes over them. See `createRepoWorkspace`, which roots them here.
+ * Where a bundle keeps its skills, and what one is called.
+ *
+ * `skills/<name>/SKILL.md` is the shape the rest of the world already uses for a page of
+ * instructions an agent reads and follows, which is exactly what a prompt job's body is.
+ * Harness-neutral on purpose: a harness discovers skills under a root of its own choosing,
+ * and `docs/naming.md` is why the manifest does not spell one of those roots — this
+ * contract outlives any single one.
  */
-const RUNTIME_STATE = "workspace";
+const SKILLS_DIR = "skills";
+const SKILL_FILE = "SKILL.md";
 
 /** Whether `path` is `root` itself or sits beneath it. Both must already be resolved. */
 function within(path: string, root: string): boolean {
@@ -142,32 +148,31 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
     return { source: "inline", bytes: Buffer.byteLength(job.prompt), body: job.prompt };
   }
 
-  const source = resolve(agentDir, job.prompt.file);
-  const named = `job "${job.slug}" prompt ${source}`;
-  const steering =
-    "a prompt is read as steering, so it comes from the bundle and nowhere a review would " +
-    "not see it";
+  const name = job.prompt.skill;
+  // The one place the layout is written down. A name is all the manifest supplies, so there
+  // is no path here for an operator to point somewhere else and none for this to contain.
+  const source = join(resolve(agentDir), SKILLS_DIR, name, SKILL_FILE);
+  // Canonical only for the containment test below. The path an operator is shown stays the
+  // one they wrote the bundle at — `/private/var/...` on a macOS temp dir is a true answer
+  // to a question nobody asked.
+  const tree = join(realpathSync(resolve(agentDir)), SKILLS_DIR);
+  const named = `job "${job.slug}" skill ${name} (${source})`;
 
-  // The words go to the brain as steering rather than inside the untrusted fence, and the
-  // whole argument for that is that they came out of the same reviewed bundle the persona
-  // did. Both halves of that are checked here, because they fail differently.
+  // What the filesystem says it really is. A slug cannot traverse, but a symlink at any
+  // step of `skills/<name>/SKILL.md` can still point out of the bundle — at a mounted
+  // credential, or at `workspace/`, where repository checkouts sit refreshed from their
+  // remotes. The words go to the brain as steering rather than as fenced data, and the
+  // whole argument for that is that they came out of the reviewed bundle; a link is the
+  // one way the diff shows a path and never the content it will resolve to.
   //
-  // The path as written: `/mnt/shared/digest.md` is mutable by whoever mounted it and
-  // appears in no bundle diff.
-  if (!within(source, resolve(agentDir))) {
-    throw new Error(`${named} is outside the agent directory — ${steering}`);
-  }
-
-  // Neither check can see a *mount* inside the bundle — a mount point is an ordinary
-  // directory to `realpath` — so a target that can place one owes that refusal itself. The
-  // chart refuses a `sharedVolumes` claim under `/agents/<name>` for this reason.
+  // Contained to `skills/` rather than to the agent directory, which is stricter and says
+  // what is meant: the bundle's skills tree is where a skill lives, and every other
+  // subtree — the runtime's included — is out by construction rather than by a carve-out
+  // per subtree.
   //
-  // And what the filesystem says it really is. A symlink committed into the bundle is the
-  // case the first check cannot see, and it is the worse one: the diff shows a path and
-  // never the content, the content can change after the review that approved it, and what
-  // it resolves to reaches the brain as trusted words in the process that holds this
-  // agent's credentials. Writing the prompt file directly is not the same act — that puts
-  // the words themselves in front of a reviewer.
+  // What this cannot see is a *mount* placed inside the tree; a mount point is an ordinary
+  // directory to `realpath`. The chart refuses a `sharedVolumes` claim under
+  // `/agents/<name>` for that reason.
   let real: string;
   try {
     real = realpathSync(source);
@@ -175,31 +180,17 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
     // Missing, or unreadable on the way down. Same sentence the read below would give.
     throw new Error(`${named}: ${errorText(error)}`);
   }
-  // One resolved root for every test below it: on a host where the agent directory is
-  // reached through a link — `/var` on macOS, a mounted bundle anywhere — comparing a real
-  // path against an unresolved root silently matches nothing.
-  const root = realpathSync(resolve(agentDir));
-  if (!within(real, root)) {
-    throw new Error(`${named} is a link to ${real}, which is outside the agent directory — ${steering}`);
-  }
-
-  // `workspace/` is the runtime's, not the bundle's: repository checkouts land there and are
-  // refreshed from their remotes on every start, so a prompt read out of one is words
-  // whoever can merge to that repository chose — arriving as steering, in the process that
-  // holds this agent's credentials. The gateway already refuses to make a checkout the
-  // brain's working directory for this exact reason; this is the same rule at the other
-  // door. Unlike a mount, the runtime can see this one, because the directory is its own.
-  if (within(real, join(root, RUNTIME_STATE))) {
+  if (!within(real, tree)) {
     throw new Error(
-      `${named} is under ${RUNTIME_STATE}/, which the runtime writes and refreshes from ` +
-        `remotes — ${steering}`,
+      `${named} is a link to ${real}, outside the bundle's ${SKILLS_DIR}/ tree — a prompt is ` +
+        "read as steering, so it comes from the bundle and nowhere a review would not see it",
     );
   }
 
   let raw: Buffer;
   try {
-    // The identity of what containment admitted, pinned here and compared against the
-    // descriptor that gets read — see {@link readBounded}.
+    // The identity of what the containment check admitted, pinned here and compared against
+    // the descriptor that gets read — see {@link readBounded}.
     raw = readBounded(real, statSync(real));
   } catch (error) {
     throw new Error(`${named}: ${errorText(error)}`);
@@ -222,13 +213,22 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
   const matter = FRONTMATTER.exec(text);
   if (!matter) {
     throw new Error(
-      `${named} has no frontmatter — a prompt file opens with \`---\`, a \`name\` and a ` +
+      `${named} has no frontmatter — a ${SKILL_FILE} opens with \`---\`, a \`name\` and a ` +
         "`description`, and a closing `---`, then the words the tick sends",
     );
   }
   const parsed = Frontmatter.safeParse(parseYaml(matter[1]!)); // data only — never evaluated
   if (!parsed.success) {
     throw new Error(`${named}: frontmatter needs a \`name\` and a \`description\``);
+  }
+  // The frontmatter stopped being decorative the moment the manifest addressed this by
+  // name: two spellings of one name is how a skill is found under one and announces itself
+  // as another, and whichever the chat face later reads would be a coin toss.
+  if (parsed.data.name !== name) {
+    throw new Error(
+      `${named}: its frontmatter says \`name: ${parsed.data.name}\`, and a skill is found ` +
+        "under the name it calls itself",
+    );
   }
   const body = text.slice(matter[0].length).trim();
   if (!body) throw new Error(`${named} is frontmatter and nothing else — there is no prompt`);

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -748,7 +748,11 @@ function named(
   // `Number("")` is 0, so a blank end would read as a legal value and `1-` would refuse
   // for counting backwards rather than for being half a range.
   if (!written) return undefined;
-  const byName = names?.indexOf(written.slice(0, 3).toLowerCase());
+  // Exactly three, never a prefix of what was written. `MONSOON` truncates to a valid
+  // `MON` and would schedule Mondays for an expression nobody meant — and Kubernetes'
+  // own parser takes the three-letter abbreviations and nothing longer, so a `run` job
+  // and a `prompt` job carrying one expression have to refuse it the same way.
+  const byName = written.length === 3 ? names?.indexOf(written.toLowerCase()) : -1;
   if (byName !== undefined && byName >= 0) return byName + min;
   const value = Number(written);
   return Number.isInteger(value) && value >= min && value <= max ? value : undefined;

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -1,0 +1,593 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { z } from "zod";
+import { errorLine, errorText } from "./errors.ts";
+import type { ChannelRef, InboundEvent } from "./events.ts";
+import type { Gateway, TickOutcome } from "./gateway.ts";
+import { admitJob, type SwitchSource } from "./kill-switch.ts";
+import {
+  announces,
+  jobGate,
+  jobStatus,
+  type JobPoster,
+  type JobRun,
+} from "./job-host.ts";
+import { JOB_ARTIFACT_LIMIT_BYTES } from "./job-output.ts";
+import type { PromptJob } from "./manifest.ts";
+import { combineVerdicts, verdictFromGate } from "./verdict.ts";
+import type { WorkStart } from "./work-events.ts";
+
+/**
+ * The light tier of scheduled work: a clock tick that runs an ordinary guarded brain turn
+ * in this process, rather than spawning a body in a pod of its own.
+ *
+ * Everything around it is the envelope `jobs[]` already has — the trigger, the switch,
+ * `suspend`, `report`, the run record — and only the body differs. What that buys is the
+ * work a job cannot do and a turn cannot be woken for: read one surface's channel,
+ * summarize it with the agent's own tools, and post the summary on another, at 18:00,
+ * without anybody posting a mention at 18:00.
+ *
+ * The credential line is unmoved in both directions. This tier holds none — it is a turn,
+ * so it reaches exactly what the brain already reaches through the guard — and a `run`
+ * body still cannot reach the brain. See `docs/job-contract.md`, "A job that is a turn".
+ */
+
+/** The words one prompt job's tick sends, and where they came from. */
+export interface JobPrompt {
+  /** An absolute path, or `inline` for a one-liner written in the manifest. */
+  source: string;
+  /** What the source was, in bytes — `doctor` prints it so a silent edit is visible. */
+  bytes: number;
+  /** What the tick sends: the body, with the frontmatter removed. */
+  body: string;
+}
+
+/**
+ * The frontmatter a prompt file carries.
+ *
+ * Nothing reads either field yet, and requiring them anyway is the point: the file is
+ * shaped like a skill now so that the day one can be offered to the chat face — "run the
+ * digest now", asked by a person — the file does not have to change and the job does not
+ * need a second declaration. Unknown keys are dropped rather than refused, so a file that
+ * grows a field this version has never heard of still loads.
+ */
+const Frontmatter = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+});
+
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * Reads a prompt job's words, at load and once.
+ *
+ * Everything here throws rather than degrades. A schedule that discovers at 18:00 that its
+ * prompt is missing has nothing to say and no turn to say it in, so the refusal belongs
+ * where a person is watching: `run` will not start, and `doctor` and `validate` report it.
+ *
+ * `agentDir` is the agent's own directory and the path is resolved against it, exactly as
+ * `persona` is — the file rides in the bundle image, so editing it restarts the gateway
+ * like any other bundle change.
+ */
+export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
+  if (typeof job.prompt === "string") {
+    return { source: "inline", bytes: Buffer.byteLength(job.prompt), body: job.prompt };
+  }
+
+  const source = resolve(agentDir, job.prompt.file);
+  const named = `job "${job.slug}" prompt ${source}`;
+  let raw: Buffer;
+  try {
+    raw = readFileSync(source);
+  } catch (error) {
+    throw new Error(`${named}: ${errorText(error)}`);
+  }
+  // The same ceiling a verdict artifact has. A prompt is a page; anything approaching this
+  // is a document that was pointed at the wrong field.
+  if (raw.byteLength > JOB_ARTIFACT_LIMIT_BYTES) {
+    throw new Error(
+      `${named} is ${raw.byteLength} bytes, over the ${JOB_ARTIFACT_LIMIT_BYTES}-byte limit`,
+    );
+  }
+  let text: string;
+  try {
+    // `readFileSync(path, "utf8")` would substitute U+FFFD for every bad byte and hand
+    // back a prompt nobody wrote. Decoding strictly is what turns that into a refusal.
+    text = new TextDecoder("utf-8", { fatal: true }).decode(raw);
+  } catch {
+    throw new Error(`${named} is not valid UTF-8`);
+  }
+
+  const matter = FRONTMATTER.exec(text);
+  if (!matter) {
+    throw new Error(
+      `${named} has no frontmatter — a prompt file opens with \`---\`, a \`name\` and a ` +
+        "`description`, and a closing `---`, then the words the tick sends",
+    );
+  }
+  const parsed = Frontmatter.safeParse(parseYaml(matter[1]!)); // data only — never evaluated
+  if (!parsed.success) {
+    throw new Error(`${named}: frontmatter needs a \`name\` and a \`description\``);
+  }
+  const body = text.slice(matter[0].length).trim();
+  if (!body) throw new Error(`${named} is frontmatter and nothing else — there is no prompt`);
+
+  return { source, bytes: raw.byteLength, body };
+}
+
+/** One prompt job, with its words and its destination already resolved. */
+export interface ScheduledTurn {
+  job: PromptJob;
+  prompt: JobPrompt;
+  /**
+   * The configured channel the tick is addressed to, resolved from `report` once at load.
+   *
+   * Resolved rather than carried as the declared string because `report.channel` may name
+   * a channel rather than identify it, and the turn is queued on the channel's **id** —
+   * a tick keyed by a name would run alongside a live turn in the same channel instead of
+   * behind it.
+   */
+  channel: ChannelRef;
+}
+
+export interface ScheduledTurnsOptions {
+  turns: readonly ScheduledTurn[];
+  /** Where a tick's turn actually runs. The gateway, in this process. */
+  gateway: Pick<Gateway, "tick">;
+  /** The ceiling on a turn, which a job's own `budget.wallClockMs` may lower. */
+  turnTimeoutMs: number;
+  /**
+   * How each job's kill switch is read. Unset is not "no switch" but an unreadable one,
+   * which a fail-closed job refuses to tick on — {@link admitJob} holds that line.
+   */
+  switchSource?: SwitchSource | null;
+  /**
+   * Where the host's own line goes when a tick has something to say that the turn did not.
+   * Unset means nowhere; the run record is still written.
+   */
+  post?: JobPoster;
+  /** Admitted ticks, before the turn. No call for a refused one. */
+  onStart?: (run: WorkStart) => void;
+  /** Every tick's record, refusals included. */
+  onRun?: (run: JobRun) => void;
+}
+
+/**
+ * The gateway's in-process clock.
+ *
+ * Ticks that fall while this is not running are **not replayed**. A digest of the last
+ * day, posted at 06:00 because that is when the pod came back, is worse than no digest:
+ * the next tick's start event is the record that one was missed, and the next post is on
+ * time.
+ */
+export class ScheduledTurns {
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private stopped = false;
+
+  constructor(private opts: ScheduledTurnsOptions) {}
+
+  /** The jobs this clock holds, for a caller printing the roster. */
+  get turns(): readonly ScheduledTurn[] {
+    return this.opts.turns;
+  }
+
+  /** Arms every declared schedule from now. */
+  start(): void {
+    for (const turn of this.opts.turns) this.arm(turn, new Date());
+  }
+
+  /** Disarms every schedule. A tick already in flight finishes on its own. */
+  stop(): void {
+    this.stopped = true;
+    for (const timer of this.timers.values()) clearTimeout(timer);
+    this.timers.clear();
+  }
+
+  /**
+   * When one job fires next, in its declared zone. What `doctor` prints.
+   *
+   * Throws on an expression this cannot parse. `looksLikeCron` in the manifest checks the
+   * shape and leaves the definitive parse to whatever runs the job — for a prompt job that
+   * is this — so a caller should ask once before the gateway is live rather than let the
+   * first fire discover it.
+   */
+  next(turn: ScheduledTurn, after = new Date()): Date | undefined {
+    try {
+      return nextFire(turn.job.trigger.schedules, turn.job.trigger.timezone, after);
+    } catch (error) {
+      throw new Error(`job "${turn.job.slug}": ${errorText(error)}`);
+    }
+  }
+
+  private arm(turn: ScheduledTurn, after: Date): void {
+    if (this.stopped) return;
+    const at = this.next(turn, after);
+    if (!at) return;
+
+    const delay = at.getTime() - Date.now();
+    // `setTimeout` silently fires at once past its 32-bit range, so a fire more than
+    // three weeks out is waited for in hops. The hop re-computes from the same `after`,
+    // so nothing drifts.
+    const hop = delay > MAX_TIMEOUT_MS;
+    const timer = setTimeout(
+      () => {
+        this.timers.delete(turn.job.slug);
+        if (hop) return this.arm(turn, after);
+        // Armed from the scheduled instant rather than from now, so a turn that took ten
+        // minutes does not move the next fire — and a tick can never re-arm itself onto
+        // the one it just ran.
+        this.arm(turn, at);
+        void this.fire(turn, at);
+      },
+      hop ? MAX_TIMEOUT_MS : Math.max(0, delay),
+    );
+    this.timers.set(turn.job.slug, timer);
+  }
+
+  /** One tick: admission, the turn, the record, and then the host's line if it is owed. */
+  private async fire(turn: ScheduledTurn, at: Date): Promise<void> {
+    const { job, prompt, channel } = turn;
+    const runId = randomUUID();
+    const base = {
+      jobSlug: job.slug,
+      runId,
+      trigger: "schedule" as const,
+      requestedBy: null,
+      startedAt: Date.now(),
+      parameters: {},
+    };
+    const didNotRun = { gate: jobGate(job), executed: false, exitCode: null };
+
+    try {
+      // The job host's order, because it is the same contract: the switch, then `suspend`,
+      // then — inside `Gateway.tick` — the caps that decide whether a turn may start here.
+      const admission = await admitJob(job, { trigger: "schedule", requestedBy: null }, this.opts.switchSource);
+      if (!admission.admitted) {
+        // Recorded and never announced. Refusing to start a parked job is a posture
+        // somebody chose, and a channel told about it every evening learns to skim past
+        // the evening the announcement is real.
+        this.record({
+          ...base,
+          outcome: admission.outcome ?? "denied-switch",
+          switch: admission.switch,
+          bypassedSwitch: false,
+          gates: [verdictFromGate(didNotRun)],
+          checks: [didNotRun],
+          reason: admission.reason,
+        });
+        return;
+      }
+
+      // A turn is already held to `turnTimeoutMs`; a declared budget can only shorten it.
+      const deadlineMs = Math.min(this.opts.turnTimeoutMs, job.budget?.wallClockMs ?? Infinity);
+      this.opts.onStart?.({ ...base, admittedAt: Date.now(), deadlineMs });
+
+      const outcome = await this.opts.gateway.tick(
+        tickEvent(job, prompt, channel, runId, at),
+        job.report,
+        deadlineMs,
+      );
+
+      // A tick the gateway would not start is the caps doing their job, and it is told the
+      // same way a dropped job tick is: recorded, and silent.
+      if (outcome.skipped) {
+        this.record({
+          ...base,
+          outcome: "skipped-overlap",
+          switch: admission.switch,
+          bypassedSwitch: false,
+          gates: [verdictFromGate(didNotRun)],
+          checks: [didNotRun],
+          reason: `the gateway did not start this tick (${outcome.skipped})`,
+          deadlineMs,
+        });
+        return;
+      }
+
+      const check = { gate: jobGate(job), executed: true, exitCode: exitCodeFor(outcome) };
+      const run = this.record({
+        ...base,
+        // A timed-out turn and a brain that threw are one fact here: nobody will learn what
+        // this tick found. `budget-bowout` is a process body's word — it names a clock this
+        // host stopped a spawned body on — and the reason line below says which happened.
+        outcome: outcome.error ? "crashed" : "completed",
+        switch: admission.switch,
+        bypassedSwitch: false,
+        gates: [verdictFromGate(check)],
+        checks: [check],
+        reason: describeTick(outcome),
+        deadlineMs,
+      });
+      await this.announce(turn, run);
+    } catch (error) {
+      // Nothing above is allowed to take the process down: this runs on a timer, so a
+      // throw here would be an unhandled rejection and the whole of what anyone saw.
+      console.warn(`tick_lost job=${job.slug} runId=${runId} reason=${errorLine(error)}`);
+    }
+  }
+
+  /** Says the tick out loud, when the host has something the turn did not say itself. */
+  private async announce(turn: ScheduledTurn, run: JobRun): Promise<void> {
+    const report = turn.job.report;
+    if (!this.opts.post || !announces(run, false, report.announce)) return;
+    try {
+      await this.opts.post(report, jobStatus(run, report.proven).headline);
+    } catch (error) {
+      console.warn(`tick_status job=${run.jobSlug} result=lost reason=${errorLine(error)}`);
+    }
+  }
+
+  private record(run: Omit<JobRun, "endedAt" | "verdict">): JobRun {
+    // Combined even though there is only ever one gate here, because `JobRun.verdict` is
+    // documented as exactly `combineVerdicts(gates)` — a record whose sum a reader cannot
+    // check is a record they have to take on trust.
+    const complete: JobRun = { ...run, endedAt: Date.now(), verdict: combineVerdicts(run.gates) };
+    try {
+      Promise.resolve(this.opts.onRun?.(complete)).catch(() => {});
+    } catch {
+      /* Observers cannot change what a tick did. */
+    }
+    return complete;
+  }
+}
+
+/**
+ * What the turn proved, in the one vocabulary a job record has.
+ *
+ * `0` — the turn ran to the end. That covers a turn that posted and a turn that chose not
+ * to: silence is the message, and a digest with nothing to report is a success.
+ * `1` — the brain asked to post and nothing reached the channel. Every ask was refused by
+ * the guard, which is a run that tried to speak and failed to.
+ * `null` — the turn timed out or threw, so it never got to say what it found.
+ */
+function exitCodeFor(outcome: TickOutcome): number | null {
+  if (outcome.error) return null;
+  return outcome.asked > 0 && outcome.sent === 0 ? 1 : 0;
+}
+
+function describeTick(outcome: TickOutcome): string {
+  if (outcome.error) return `the turn did not finish: ${errorLine(outcome.error)}`;
+  if (outcome.asked > 0 && outcome.sent === 0) {
+    return `the turn asked to post ${outcome.asked} time(s) and the guard refused every one`;
+  }
+  return outcome.sent > 0
+    ? `the turn posted ${outcome.sent} message(s)`
+    : "the turn finished with nothing to say";
+}
+
+/**
+ * The tick as the gateway sees it: a synthetic inbound event, exactly as the design doc's
+ * §10.1 describes one.
+ *
+ * The author is this process's clock and is deliberately unresolvable to a channel member:
+ * `schedule:<slug>` is not an id any surface issues, so nothing can be addressed to it,
+ * nothing answers as it, and the author gate has nobody to weigh. `mentionsMe` is true
+ * because the clock is the wake, and there is no `threadRoot` because a tick starts a
+ * conversation rather than continuing one.
+ */
+function tickEvent(
+  job: PromptJob,
+  prompt: JobPrompt,
+  channel: ChannelRef,
+  runId: string,
+  at: Date,
+): InboundEvent {
+  return {
+    id: { surface: channel.surface, nativeId: `schedule:${job.slug}:${runId}` },
+    surface: channel.surface,
+    channel,
+    author: { surface: channel.surface, id: `schedule:${job.slug}`, isSelf: false, isAgent: false },
+    text: prompt.body,
+    mentionsMe: true,
+    ts: at.toISOString(),
+    // No adapter produced this, so there is no surface payload to escape into.
+    raw: null,
+  };
+}
+
+/** `setTimeout`'s 32-bit range — about 24.8 days. Longer waits are taken in hops. */
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
+/** How far ahead {@link nextFire} will look before answering "never". */
+const SEARCH_DAYS = 366;
+
+/** The fixed descriptors, as the five fields they stand for. `@every` names no clock time. */
+const DESCRIPTORS: Record<string, string> = {
+  "@yearly": "0 0 1 1 *",
+  "@annually": "0 0 1 1 *",
+  "@monthly": "0 0 1 * *",
+  "@weekly": "0 0 * * 0",
+  "@daily": "0 0 * * *",
+  "@midnight": "0 0 * * *",
+  "@hourly": "0 * * * *",
+};
+
+const MONTH_NAMES = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+const DAY_NAMES = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+
+/** One compiled expression: which values each field admits, and whether it was restricted. */
+interface Schedule {
+  minute: Set<number>;
+  hour: Set<number>;
+  day: Set<number>;
+  month: Set<number>;
+  weekday: Set<number>;
+  /** Vixie's rule below needs to know which of the two day fields were written as `*`. */
+  anyDay: boolean;
+  anyWeekday: boolean;
+}
+
+/** A wall-clock instant as one zone renders it. */
+interface WallClock {
+  minute: number;
+  hour: number;
+  day: number;
+  month: number;
+  weekday: number;
+  /** `YYYY-MM-DDTHH:MM` in the zone — what tells one side of a fall-back from the other. */
+  key: string;
+}
+
+/**
+ * The next instant strictly after `after` that one of these expressions names in `timeZone`.
+ *
+ * **A repeated local minute fires once.** The hour an autumn fall-back replays is two real
+ * instants with one wall-clock reading, and a daily digest does not want to be posted
+ * twice on one evening — so a candidate whose local minute is the one `after` was already
+ * at is passed over. Spring forward needs no rule: a local time that does not exist is
+ * never produced by formatting a real instant, so a job scheduled inside the gap simply
+ * does not run that day, which is what every cron in a zone does.
+ *
+ * `undefined` means nothing matches inside {@link SEARCH_DAYS} — a `30 2 31 2 *`, which is
+ * legal, parses, and names no day.
+ */
+export function nextFire(
+  schedules: readonly string[],
+  timeZone: string,
+  after: Date,
+): Date | undefined {
+  const compiled = schedules.map(compileSchedule);
+  if (!compiled.length) return undefined;
+  const format = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    weekday: "short",
+  });
+
+  const alreadyAt = wallClock(after, format).key;
+  let at = Math.floor(after.getTime() / 60_000) * 60_000 + 60_000;
+  const limit = at + SEARCH_DAYS * 24 * 60 * 60_000;
+  while (at <= limit) {
+    const wall = wallClock(new Date(at), format);
+    const onDate = compiled.filter((schedule) => matchesDate(schedule, wall));
+    if (wall.key !== alreadyAt && onDate.some((schedule) => matchesTime(schedule, wall))) {
+      return new Date(at);
+    }
+    // Nothing in the rest of this local day can match a date that does not, so step to the
+    // next local hour instead of the next minute — local midnight is an hour boundary, so
+    // this can never step over the start of a day that does match. It takes the worst case
+    // (a yearly expression) from half a million wall-clock formats to about ten thousand.
+    at += (onDate.length ? 1 : 60 - wall.minute) * 60_000;
+  }
+  return undefined;
+}
+
+function wallClock(at: Date, format: Intl.DateTimeFormat): WallClock {
+  const parts: Record<string, string> = {};
+  for (const part of format.formatToParts(at)) parts[part.type] = part.value;
+  return {
+    minute: Number(parts.minute),
+    hour: Number(parts.hour),
+    day: Number(parts.day),
+    month: Number(parts.month),
+    weekday: DAY_NAMES.indexOf(parts.weekday!.slice(0, 3).toLowerCase()),
+    key: `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`,
+  };
+}
+
+/**
+ * Vixie cron's day rule, which Kubernetes' own parser also implements: when **both** day
+ * fields are restricted the expression matches if **either** does, and otherwise the one
+ * that was written governs. `0 0 1 * 1` is the first of the month *and* every Monday.
+ */
+function matchesDate(schedule: Schedule, wall: WallClock): boolean {
+  if (!schedule.month.has(wall.month)) return false;
+  const day = schedule.day.has(wall.day);
+  const weekday = schedule.weekday.has(wall.weekday);
+  if (schedule.anyDay) return weekday;
+  if (schedule.anyWeekday) return day;
+  return day || weekday;
+}
+
+function matchesTime(schedule: Schedule, wall: WallClock): boolean {
+  return schedule.hour.has(wall.hour) && schedule.minute.has(wall.minute);
+}
+
+/**
+ * Five fields into five sets.
+ *
+ * Throws on anything it cannot read. `looksLikeCron` in the manifest admits a wider
+ * grammar than this deliberately — it checks the shape and leaves the definitive parse to
+ * whatever runs the job — so a prompt job's expression is parsed here at load, where the
+ * failure is a launch that refuses rather than a schedule that silently never fires.
+ */
+function compileSchedule(expression: string): Schedule {
+  const source = DESCRIPTORS[expression.trim().toLowerCase()] ?? expression.trim();
+  const fields = source.split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error(`\`${expression}\` is not five cron fields`);
+  }
+  const [minute, hour, day, month, weekday] = fields as [string, string, string, string, string];
+  return {
+    minute: fieldValues(expression, minute, 0, 59),
+    hour: fieldValues(expression, hour, 0, 23),
+    day: fieldValues(expression, day, 1, 31),
+    month: fieldValues(expression, month, 1, 12, MONTH_NAMES),
+    // 7 and 0 are both Sunday, so the set is folded to 0..6 after the numbers are read.
+    weekday: new Set([...fieldValues(expression, weekday, 0, 7, DAY_NAMES)].map((d) => d % 7)),
+    anyDay: unrestricted(day),
+    anyWeekday: unrestricted(weekday),
+  };
+}
+
+/** `*` and `?` both mean "this field does not narrow anything". A step does narrow. */
+function unrestricted(field: string): boolean {
+  return field === "*" || field === "?";
+}
+
+function fieldValues(
+  expression: string,
+  field: string,
+  min: number,
+  max: number,
+  names?: readonly string[],
+): Set<number> {
+  const values = new Set<number>();
+  for (const term of field.split(",")) {
+    const [range, stride = "1"] = term.split("/");
+    const step = Number(stride);
+    if (!Number.isInteger(step) || step < 1) {
+      throw new Error(`\`${expression}\`: \`${term}\` has no usable step`);
+    }
+    let from: number;
+    let to: number;
+    if (unrestricted(range ?? "")) {
+      [from, to] = [min, max];
+    } else {
+      const ends = (range ?? "").split("-").map((end) => named(end, names, min, max));
+      if (ends.length > 2 || ends.some((end) => end === undefined)) {
+        throw new Error(`\`${expression}\`: \`${term}\` is not a value or a range`);
+      }
+      from = ends[0]!;
+      // `5/2` is "from 5, every 2" — a range with no end, which is the field's own end.
+      to = ends.length === 2 ? ends[1]! : term.includes("/") ? max : from;
+    }
+    if (from > to) throw new Error(`\`${expression}\`: \`${term}\` counts backwards`);
+    for (let value = from; value <= to; value += step) values.add(value);
+  }
+  return values;
+}
+
+/** One end of a range: a number in the field's own bounds, or a three-letter name. */
+function named(
+  end: string,
+  names: readonly string[] | undefined,
+  min: number,
+  max: number,
+): number | undefined {
+  const written = end.trim();
+  // `Number("")` is 0, so a blank end would read as a legal value and `1-` would refuse
+  // for counting backwards rather than for being half a range.
+  if (!written) return undefined;
+  const byName = names?.indexOf(written.slice(0, 3).toLowerCase());
+  if (byName !== undefined && byName >= 0) return byName + min;
+  const value = Number(written);
+  return Number.isInteger(value) && value >= min && value <= max ? value : undefined;
+}

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -10,6 +10,7 @@ import {
   type Stats,
 } from "node:fs";
 import { join, resolve, sep } from "node:path";
+import { Cron } from "croner";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { errorLine, errorText } from "./errors.ts";
@@ -573,218 +574,29 @@ function tickEvent(
 const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 /**
- * How far ahead {@link nextFire} will look before answering "never".
- *
- * Eight years, because that is the longest gap any five-field expression can have: `0 0 29
- * 2 *` matches only on a leap day, and a century that is not a leap year puts eight years
- * between two of them (2096 to 2104). A shorter horizon would report that schedule as one
- * that never fires, and the ticker would arm nothing for it — silently, and permanently.
- */
-const SEARCH_DAYS = 8 * 366;
-
-/** The fixed descriptors, as the five fields they stand for. `@every` names no clock time. */
-const DESCRIPTORS: Record<string, string> = {
-  "@yearly": "0 0 1 1 *",
-  "@annually": "0 0 1 1 *",
-  "@monthly": "0 0 1 * *",
-  "@weekly": "0 0 * * 0",
-  "@daily": "0 0 * * *",
-  "@midnight": "0 0 * * *",
-  "@hourly": "0 * * * *",
-};
-
-const MONTH_NAMES = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
-const DAY_NAMES = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-
-/** One compiled expression: which values each field admits, and whether it was restricted. */
-interface Schedule {
-  minute: Set<number>;
-  hour: Set<number>;
-  day: Set<number>;
-  month: Set<number>;
-  weekday: Set<number>;
-  /** Vixie's rule below needs to know which of the two day fields narrowed anything. */
-  anyDay: boolean;
-  anyWeekday: boolean;
-}
-
-/** A wall-clock instant as one zone renders it. */
-interface WallClock {
-  minute: number;
-  hour: number;
-  day: number;
-  month: number;
-  weekday: number;
-  /** `YYYY-MM-DDTHH:MM` in the zone — what tells one side of a fall-back from the other. */
-  key: string;
-}
-
-/**
  * The next instant strictly after `after` that one of these expressions names in `timeZone`.
  *
- * **A repeated local minute fires once.** The hour an autumn fall-back replays is two real
- * instants with one wall-clock reading, and a daily digest does not want to be posted
- * twice on one evening — so a candidate whose local minute is the one `after` was already
- * at is passed over. Spring forward needs no rule: a local time that does not exist is
- * never produced by formatting a real instant, so a job scheduled inside the gap simply
- * does not run that day, which is what every cron in a zone does.
+ * Delegated, and the delegation is the point: a cron field grammar plus wall-clock
+ * arithmetic across DST is a solved problem with sharp edges, and the hand-rolled version
+ * this replaced earned three review findings in one pull request — a leap day read as "never
+ * fires", `MONSOON` parsed as Monday, and `0x10` parsed as 16. `croner` refuses all three,
+ * has no dependencies of its own, and is the same shape of parser a deploy target runs.
  *
- * `undefined` means nothing matches inside {@link SEARCH_DAYS} — a `30 2 31 2 *`, which is
- * legal, parses, and names no day.
+ * The array is the only thing left to do here: a job may declare several schedules, and the
+ * next fire is the earliest any of them names. `undefined` means none of them names a day —
+ * `30 2 31 2 *` parses and matches nothing — and the ticker arms nothing for it.
+ *
+ * Throws on an expression it cannot parse, which is `looksLikeCron`'s under-check arriving
+ * at its definitive parser: the manifest checks the shape and leaves the grammar to whatever
+ * runs the job.
  */
 export function nextFire(
   schedules: readonly string[],
   timeZone: string,
   after: Date,
 ): Date | undefined {
-  const compiled = schedules.map(compileSchedule);
-  if (!compiled.length) return undefined;
-  const format = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hourCycle: "h23",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    weekday: "short",
-  });
-
-  const alreadyAt = wallClock(after, format).key;
-  let at = Math.floor(after.getTime() / 60_000) * 60_000 + 60_000;
-  const limit = at + SEARCH_DAYS * 24 * 60 * 60_000;
-  while (at <= limit) {
-    const wall = wallClock(new Date(at), format);
-    const onDate = compiled.filter((schedule) => matchesDate(schedule, wall));
-    if (wall.key !== alreadyAt && onDate.some((schedule) => matchesTime(schedule, wall))) {
-      return new Date(at);
-    }
-    // Nothing in the rest of this local day can match a date that does not, so step to the
-    // next local hour instead of the next minute — local midnight is an hour boundary, so
-    // this can never step over the start of a day that does match. It takes the worst case
-    // (a yearly expression) from half a million wall-clock formats to about ten thousand.
-    at += (onDate.length ? 1 : 60 - wall.minute) * 60_000;
-  }
-  return undefined;
-}
-
-function wallClock(at: Date, format: Intl.DateTimeFormat): WallClock {
-  const parts: Record<string, string> = {};
-  for (const part of format.formatToParts(at)) parts[part.type] = part.value;
-  return {
-    minute: Number(parts.minute),
-    hour: Number(parts.hour),
-    day: Number(parts.day),
-    month: Number(parts.month),
-    weekday: DAY_NAMES.indexOf(parts.weekday!.slice(0, 3).toLowerCase()),
-    key: `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}`,
-  };
-}
-
-/**
- * Vixie cron's day rule, which Kubernetes' own parser also implements: when **both** day
- * fields are restricted the expression matches if **either** does, and otherwise the one
- * that was written governs. `0 0 1 * 1` is the first of the month *and* every Monday.
- */
-function matchesDate(schedule: Schedule, wall: WallClock): boolean {
-  if (!schedule.month.has(wall.month)) return false;
-  const day = schedule.day.has(wall.day);
-  const weekday = schedule.weekday.has(wall.weekday);
-  if (schedule.anyDay) return weekday;
-  if (schedule.anyWeekday) return day;
-  return day || weekday;
-}
-
-function matchesTime(schedule: Schedule, wall: WallClock): boolean {
-  return schedule.hour.has(wall.hour) && schedule.minute.has(wall.minute);
-}
-
-/**
- * Five fields into five sets.
- *
- * Throws on anything it cannot read. `looksLikeCron` in the manifest admits a wider
- * grammar than this deliberately — it checks the shape and leaves the definitive parse to
- * whatever runs the job — so a prompt job's expression is parsed here at load, where the
- * failure is a launch that refuses rather than a schedule that silently never fires.
- */
-function compileSchedule(expression: string): Schedule {
-  const source = DESCRIPTORS[expression.trim().toLowerCase()] ?? expression.trim();
-  const fields = source.split(/\s+/);
-  if (fields.length !== 5) {
-    throw new Error(`\`${expression}\` is not five cron fields`);
-  }
-  const [minute, hour, day, month, weekday] = fields as [string, string, string, string, string];
-  return {
-    minute: fieldValues(expression, minute, 0, 59),
-    hour: fieldValues(expression, hour, 0, 23),
-    day: fieldValues(expression, day, 1, 31),
-    month: fieldValues(expression, month, 1, 12, MONTH_NAMES),
-    // 7 and 0 are both Sunday, so the set is folded to 0..6 after the numbers are read.
-    weekday: new Set([...fieldValues(expression, weekday, 0, 7, DAY_NAMES)].map((d) => d % 7)),
-    anyDay: unrestricted(day),
-    anyWeekday: unrestricted(weekday),
-  };
-}
-
-/** `*` and `?` both mean "this field does not narrow anything". A step does narrow. */
-function unrestricted(field: string): boolean {
-  return field === "*" || field === "?";
-}
-
-function fieldValues(
-  expression: string,
-  field: string,
-  min: number,
-  max: number,
-  names?: readonly string[],
-): Set<number> {
-  const values = new Set<number>();
-  for (const term of field.split(",")) {
-    const [range, stride = "1"] = term.split("/");
-    const step = Number(stride);
-    if (!Number.isInteger(step) || step < 1) {
-      throw new Error(`\`${expression}\`: \`${term}\` has no usable step`);
-    }
-    let from: number;
-    let to: number;
-    if (unrestricted(range ?? "")) {
-      [from, to] = [min, max];
-    } else {
-      const ends = (range ?? "").split("-").map((end) => named(end, names, min, max));
-      if (ends.length > 2 || ends.some((end) => end === undefined)) {
-        throw new Error(`\`${expression}\`: \`${term}\` is not a value or a range`);
-      }
-      from = ends[0]!;
-      // `5/2` is "from 5, every 2" — a range with no end, which is the field's own end.
-      to = ends.length === 2 ? ends[1]! : term.includes("/") ? max : from;
-    }
-    if (from > to) throw new Error(`\`${expression}\`: \`${term}\` counts backwards`);
-    for (let value = from; value <= to; value += step) values.add(value);
-  }
-  return values;
-}
-
-/** One end of a range: a number in the field's own bounds, or a three-letter name. */
-function named(
-  end: string,
-  names: readonly string[] | undefined,
-  min: number,
-  max: number,
-): number | undefined {
-  const written = end.trim();
-  // `Number("")` is 0, so a blank end would read as a legal value and `1-` would refuse
-  // for counting backwards rather than for being half a range.
-  if (!written) return undefined;
-  // Exactly three, never a prefix of what was written. `MONSOON` truncates to a valid
-  // `MON` and would schedule Mondays for an expression nobody meant — and Kubernetes'
-  // own parser takes the three-letter abbreviations and nothing longer, so a `run` job
-  // and a `prompt` job carrying one expression have to refuse it the same way.
-  const byName = written.length === 3 ? names?.indexOf(written.toLowerCase()) : -1;
-  if (byName !== undefined && byName >= 0) return byName + min;
-  // Digits only. `Number` also reads `0x10` as 16, `+5` as 5 and `1e1` as 10, and every one
-  // of those is a field the Kubernetes parser refuses for a `run` job — the same invariant
-  // the three-letter rule above keeps: one expression means one thing to both bodies.
-  if (!/^\d+$/.test(written)) return undefined;
-  const value = Number(written);
-  return value >= min && value <= max ? value : undefined;
+  const fires = schedules
+    .map((expression) => new Cron(expression, { timezone: timeZone }).nextRun(after))
+    .filter((at): at is Date => at !== null);
+  return fires.length ? new Date(Math.min(...fires.map((at) => at.getTime()))) : undefined;
 }

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync, realpathSync } from "node:fs";
+import { closeSync, constants, fstatSync, openSync, readSync, realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -66,6 +66,38 @@ function within(path: string, root: string): boolean {
 }
 
 /**
+ * One regular file, read no further than one byte past the bound its caller enforces.
+ *
+ * `readFileSync` weighs nothing before it allocates: pointed at a large file it takes the
+ * whole of it into memory to be told afterwards that it was too big, and pointed at a FIFO
+ * it never returns at all. Both would turn a `run`, `doctor` or `validate` load into an
+ * OOM or a silent hang, where every other bad prompt in this function is a named refusal.
+ *
+ * `O_NONBLOCK` is what keeps the *open* from being the thing that blocks — opening a FIFO
+ * for reading waits for a writer otherwise — and the kind is then checked on the descriptor
+ * rather than on the path, so nothing swapped in between is what gets read.
+ */
+function readBounded(path: string): Buffer {
+  const fd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK);
+  try {
+    if (!fstatSync(fd).isFile()) {
+      throw new Error("not a regular file — a prompt is a file in the bundle");
+    }
+    // One past the limit: enough for the caller to refuse, and never the whole of something
+    // that should have been refused.
+    const buffer = Buffer.alloc(JOB_ARTIFACT_LIMIT_BYTES + 1);
+    let read = 0;
+    // A short read is legal even for a regular file, so this fills rather than assumes.
+    for (let chunk = -1; chunk !== 0 && read < buffer.byteLength; read += chunk) {
+      chunk = readSync(fd, buffer, read, buffer.byteLength - read, read);
+    }
+    return buffer.subarray(0, read);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
  * Reads a prompt job's words, at load and once.
  *
  * Everything here throws rather than degrades. A schedule that discovers at 18:00 that its
@@ -116,16 +148,15 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
 
   let raw: Buffer;
   try {
-    raw = readFileSync(real);
+    raw = readBounded(real);
   } catch (error) {
     throw new Error(`${named}: ${errorText(error)}`);
   }
   // The same ceiling a verdict artifact has. A prompt is a page; anything approaching this
-  // is a document that was pointed at the wrong field.
+  // is a document that was pointed at the wrong field. The read above stops one byte past
+  // the limit, so this says the bound rather than a size it did not measure.
   if (raw.byteLength > JOB_ARTIFACT_LIMIT_BYTES) {
-    throw new Error(
-      `${named} is ${raw.byteLength} bytes, over the ${JOB_ARTIFACT_LIMIT_BYTES}-byte limit`,
-    );
+    throw new Error(`${named} is over the ${JOB_ARTIFACT_LIMIT_BYTES}-byte limit`);
   }
   let text: string;
   try {

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { errorLine, errorText } from "./errors.ts";
@@ -78,6 +78,21 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
 
   const source = resolve(agentDir, job.prompt.file);
   const named = `job "${job.slug}" prompt ${source}`;
+  // The words go to the brain as steering rather than inside the untrusted fence, and the
+  // whole argument for that is that they came out of the same reviewed bundle the persona
+  // did. A path that leaves the agent directory breaks it: `/mnt/shared/digest.md` is
+  // mutable by whoever mounted it and appears in no bundle diff. Refused at load so the
+  // provenance claim is one the code keeps rather than one the manifest asserts.
+  //
+  // Lexical, and only lexical. A symlink inside the bundle can still point out, and that is
+  // a line in the reviewed diff like any other — the same standing `run.command` has. What
+  // this closes is the case nobody reviews: a path in `agent.yaml` that plainly points away.
+  if (!source.startsWith(resolve(agentDir) + sep)) {
+    throw new Error(
+      `${named} is outside the agent directory — a prompt is read as steering, so it comes ` +
+        "from the bundle and nowhere a review would not see it",
+    );
+  }
   let raw: Buffer;
   try {
     raw = readFileSync(source);
@@ -166,6 +181,17 @@ export class ScheduledTurns {
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
   private stopped = false;
 
+  /**
+   * Ticks past their timer and not yet settled, which {@link drained} waits out.
+   *
+   * A tick spends its first moments reading a kill switch, and a shutdown lands inside that
+   * await as readily as before it. Without this, `stop()` would clear the timers, the
+   * gateway's own `drain()` would see an idle queue, and the tick would then submit a turn
+   * into surfaces that were closing — with `process.exit` some milliseconds behind it and
+   * no record of the run anywhere.
+   */
+  private firing = new Set<Promise<void>>();
+
   constructor(private opts: ScheduledTurnsOptions) {}
 
   /** The jobs this clock holds, for a caller printing the roster. */
@@ -178,11 +204,31 @@ export class ScheduledTurns {
     for (const turn of this.opts.turns) this.arm(turn, new Date());
   }
 
-  /** Disarms every schedule. A tick already in flight finishes on its own. */
+  /**
+   * Disarms every schedule, and refuses any tick that has not yet reached the gateway.
+   *
+   * A **state**, not an event, for the reason {@link JobHost.abandon} is one: a pass that
+   * only cleared the timers would miss every tick whose switch was still being read when it
+   * ran. {@link drained} is the other half.
+   */
   stop(): void {
     this.stopped = true;
     for (const timer of this.timers.values()) clearTimeout(timer);
     this.timers.clear();
+  }
+
+  /**
+   * Resolves once every tick that was in flight at {@link stop} has settled.
+   *
+   * Bounded by what a shutdown already waits for: a tick past the gateway is a turn
+   * `Gateway.drain` is waiting on anyway, and one that has not reached it refuses in
+   * microseconds. So awaiting this alongside the drain costs the grace period nothing, and
+   * buys the record — and the status post, through surfaces that are still up.
+   */
+  async drained(): Promise<void> {
+    // In a loop rather than once: a tick settling during the pass can still be adding its
+    // status post. It terminates because `stop` has already closed the door.
+    while (this.firing.size > 0) await Promise.all([...this.firing]);
   }
 
   /**
@@ -219,7 +265,8 @@ export class ScheduledTurns {
         // minutes does not move the next fire — and a tick can never re-arm itself onto
         // the one it just ran.
         this.arm(turn, at);
-        void this.fire(turn, at);
+        const firing = this.fire(turn, at).finally(() => this.firing.delete(firing));
+        this.firing.add(firing);
       },
       hop ? MAX_TIMEOUT_MS : Math.max(0, delay),
     );
@@ -260,9 +307,29 @@ export class ScheduledTurns {
         return;
       }
 
+      // Checked here rather than at the top, because reading the switch is the slowest thing
+      // this does and a shutdown lands inside that await as readily as before it. A turn
+      // started now would reach surfaces that are closing, and the record of it would be
+      // lost at the exit some milliseconds behind. The same call `JobHost.begin` makes at
+      // the same moment, in the same words.
+      if (this.stopped) {
+        this.record({
+          ...base,
+          outcome: "abandoned",
+          switch: admission.switch,
+          bypassedSwitch: admission.bypassedSwitch,
+          gates: [verdictFromGate(didNotRun)],
+          checks: [didNotRun],
+          reason:
+            `this gateway was asked to stop while ${job.slug} was still being admitted, ` +
+            "so the tick was never started",
+        });
+        return;
+      }
+
       // A turn is already held to `turnTimeoutMs`; a declared budget can only shorten it.
       const deadlineMs = Math.min(this.opts.turnTimeoutMs, job.budget?.wallClockMs ?? Infinity);
-      this.opts.onStart?.({ ...base, admittedAt: Date.now(), deadlineMs });
+      this.observe(() => this.opts.onStart?.({ ...base, admittedAt: Date.now(), deadlineMs }));
 
       const outcome = await this.opts.gateway.tick(
         tickEvent(job, prompt, channel, runId, at),
@@ -324,12 +391,23 @@ export class ScheduledTurns {
     // documented as exactly `combineVerdicts(gates)` — a record whose sum a reader cannot
     // check is a record they have to take on trust.
     const complete: JobRun = { ...run, endedAt: Date.now(), verdict: combineVerdicts(run.gates) };
-    try {
-      Promise.resolve(this.opts.onRun?.(complete)).catch(() => {});
-    } catch {
-      /* Observers cannot change what a tick did. */
-    }
+    this.observe(() => this.opts.onRun?.(complete));
     return complete;
+  }
+
+  /**
+   * Both observers, held to the same rule: they cannot change what a tick did.
+   *
+   * An `onStart` that threw would take the turn *and* the record with it — a work-event
+   * stream that failed to write during a shutdown is the realistic way that happens — and
+   * "every tick's record, refusals included" would stop being true where it matters most.
+   */
+  private observe(publish: () => unknown): void {
+    try {
+      Promise.resolve(publish()).catch(() => {});
+    } catch {
+      /* An observer cannot change what a tick did. */
+    }
   }
 }
 
@@ -390,8 +468,15 @@ function tickEvent(
 /** `setTimeout`'s 32-bit range — about 24.8 days. Longer waits are taken in hops. */
 const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
-/** How far ahead {@link nextFire} will look before answering "never". */
-const SEARCH_DAYS = 366;
+/**
+ * How far ahead {@link nextFire} will look before answering "never".
+ *
+ * Eight years, because that is the longest gap any five-field expression can have: `0 0 29
+ * 2 *` matches only on a leap day, and a century that is not a leap year puts eight years
+ * between two of them (2096 to 2104). A shorter horizon would report that schedule as one
+ * that never fires, and the ticker would arm nothing for it — silently, and permanently.
+ */
+const SEARCH_DAYS = 8 * 366;
 
 /** The fixed descriptors, as the five fields they stand for. `@every` names no clock time. */
 const DESCRIPTORS: Record<string, string> = {

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -414,7 +414,7 @@ interface Schedule {
   day: Set<number>;
   month: Set<number>;
   weekday: Set<number>;
-  /** Vixie's rule below needs to know which of the two day fields were written as `*`. */
+  /** Vixie's rule below needs to know which of the two day fields narrowed anything. */
   anyDay: boolean;
   anyWeekday: boolean;
 }

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -1,5 +1,14 @@
 import { randomUUID } from "node:crypto";
-import { closeSync, constants, fstatSync, openSync, readSync, realpathSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+  statSync,
+  type Stats,
+} from "node:fs";
 import { resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -74,14 +83,28 @@ function within(path: string, root: string): boolean {
  * OOM or a silent hang, where every other bad prompt in this function is a named refusal.
  *
  * `O_NONBLOCK` is what keeps the *open* from being the thing that blocks — opening a FIFO
- * for reading waits for a writer otherwise — and the kind is then checked on the descriptor
- * rather than on the path, so nothing swapped in between is what gets read.
+ * for reading waits for a writer otherwise.
+ *
+ * Both checks are made on the descriptor rather than on the path: the kind, and the
+ * identity `admitted` pinned from the path containment already passed. Without the second
+ * one this reads *a* file at a path that was checked, rather than *the* file that was
+ * checked, and a swap in the window between them would put bytes nothing admitted in front
+ * of the brain as trusted words.
+ *
+ * It does not make the bundle safe against something that can write inside it while the
+ * gateway starts. Nothing here could: Node exposes no per-component no-follow traversal,
+ * and anything able to swap a path in the bundle can write that path's contents instead.
+ * What it does is make the containment check mean what it says.
  */
-function readBounded(path: string): Buffer {
+function readBounded(path: string, admitted: Stats): Buffer {
   const fd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK);
   try {
-    if (!fstatSync(fd).isFile()) {
+    const opened = fstatSync(fd);
+    if (!opened.isFile()) {
       throw new Error("not a regular file — a prompt is a file in the bundle");
+    }
+    if (opened.dev !== admitted.dev || opened.ino !== admitted.ino) {
+      throw new Error("changed between the check that admitted it and the read");
     }
     // One past the limit: enough for the caller to refuse, and never the whole of something
     // that should have been refused.
@@ -148,7 +171,9 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
 
   let raw: Buffer;
   try {
-    raw = readBounded(real);
+    // The identity of what containment admitted, pinned here and compared against the
+    // descriptor that gets read — see {@link readBounded}.
+    raw = readBounded(real, statSync(real));
   } catch (error) {
     throw new Error(`${named}: ${errorText(error)}`);
   }

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -781,6 +781,10 @@ function named(
   // and a `prompt` job carrying one expression have to refuse it the same way.
   const byName = written.length === 3 ? names?.indexOf(written.toLowerCase()) : -1;
   if (byName !== undefined && byName >= 0) return byName + min;
+  // Digits only. `Number` also reads `0x10` as 16, `+5` as 5 and `1e1` as 10, and every one
+  // of those is a field the Kubernetes parser refuses for a `run` job — the same invariant
+  // the three-letter rule above keeps: one expression means one thing to both bodies.
+  if (!/^\d+$/.test(written)) return undefined;
   const value = Number(written);
-  return Number.isInteger(value) && value >= min && value <= max ? value : undefined;
+  return value >= min && value <= max ? value : undefined;
 }

--- a/packages/core/src/scheduled-turn.ts
+++ b/packages/core/src/scheduled-turn.ts
@@ -152,6 +152,10 @@ export function readJobPrompt(job: PromptJob, agentDir: string): JobPrompt {
     throw new Error(`${named} is outside the agent directory — ${steering}`);
   }
 
+  // Neither check can see a *mount* inside the bundle — a mount point is an ordinary
+  // directory to `realpath` — so a target that can place one owes that refusal itself. The
+  // chart refuses a `sharedVolumes` claim under `/agents/<name>` for this reason.
+  //
   // And what the filesystem says it really is. A symlink committed into the bundle is the
   // case the first check cannot see, and it is the worse one: the diff shows a path and
   // never the content, the content can change after the review that approved it, and what

--- a/packages/core/src/surface-egress.ts
+++ b/packages/core/src/surface-egress.ts
@@ -285,7 +285,8 @@ export class SurfaceEgress {
     // checks would both wake someone — and kept whatever the send does: a rejection from a
     // surface can come after the message is out, and a second wake is worse than a lost
     // retry.
-    const target = this.admit(surface, channelId, msg);
+    const { target, verdict } = this.admit(surface, channelId, msg);
+    if (!verdict.ok) throw new Error(`post refused by ${verdict.rule}: ${verdict.reason}`);
     turn.addressed = true;
     const ref = await this.publish(target, msg, undefined, [principal.id]);
     // The resolved id, on its own line: the tool audit records what the brain asked for,
@@ -453,14 +454,39 @@ export class SurfaceEgress {
     threadRoot?: EventRef,
     mentions?: readonly string[],
   ): Promise<EventRef | undefined> {
-    return this.publish(this.admit(surface, channelId, msg), msg, threadRoot, mentions);
+    const { target, verdict } = this.admit(surface, channelId, msg);
+    if (!verdict.ok) throw new Error(`post refused by ${verdict.rule}: ${verdict.reason}`);
+    return this.publish(target, msg, threadRoot, mentions);
+  }
+
+  /**
+   * {@link post}, answering the guard's refusal instead of throwing it.
+   *
+   * The one caller is a turn whose answer is a top-level post rather than a reply — a
+   * scheduled turn — and the turn loop hands a refusal back to the brain as the result of
+   * its own yield so it can rephrase without the turn ending. A thrown string cannot carry
+   * the rule and the reason as separate fields, and a loop that had to parse one back out
+   * would be reading its own error message.
+   *
+   * Only the guard answers this way. A surface that cannot post at all and a channel that
+   * is not a configured target still throw, because no rewording fixes either.
+   */
+  async postReply(surface: string, channelId: string, msg: GuardedMessage): Promise<GuardVerdict> {
+    const { target, verdict } = this.admit(surface, channelId, msg);
+    if (verdict.ok) await this.publish(target, msg);
+    return verdict;
   }
 
   /**
    * Everything a post decides before anything is sent: the adapter, the configured channel
-   * the request resolves to, and the guard's verdict on it. Throws with nothing on the wire.
+   * the request resolves to, and the guard's verdict on it. Nothing reaches the wire here,
+   * whichever way the verdict goes.
    */
-  private admit(surface: string, channelId: string, msg: GuardedMessage): PostTarget {
+  private admit(
+    surface: string,
+    channelId: string,
+    msg: GuardedMessage,
+  ): { target: PostTarget; verdict: GuardVerdict } {
     const adapter = this.byKind.get(surface);
     if (!adapter?.post || !adapter.postTargets) {
       throw new Error("the target surface does not support top-level posts");
@@ -486,9 +512,8 @@ export class SurfaceEgress {
         `post_message surface=${surface} channel=${channel.id} result=refused ` +
           `rule=${verdict.rule} reason="${verdict.reason}"`,
       );
-      throw new Error(`post refused by ${verdict.rule}: ${verdict.reason}`);
     }
-    return { adapter, channel };
+    return { target: { adapter, channel }, verdict };
   }
 
   /**
@@ -643,7 +668,7 @@ export function resolveTarget(
   return named.length === 1 ? named[0] : undefined;
 }
 
-/** What {@link SurfaceEgress.admit} hands to the send: the adapter and its own channel ref. */
+/** What {@link SurfaceEgress.admit} resolves for the send: the adapter and its own channel ref. */
 interface PostTarget {
   adapter: SurfaceAdapter;
   channel: ChannelRef;

--- a/packages/core/src/turn.ts
+++ b/packages/core/src/turn.ts
@@ -201,11 +201,26 @@ export function assembleTurnPrompt(
           "",
         ];
 
+  const header =
+    `[${ctx.scheduled ? "scheduled turn · " : ""}${event.surface} · channel ${event.channel.id}` +
+    `${event.channel.isPublic ? " · PUBLIC" : ""} · from ${event.author.id}` +
+    `${event.author.isAgent ? " · another agent" : ""}]`;
+
+  // A scheduled turn's text is the bundle's own prompt, read off disk by this process from
+  // the same reviewed directory the persona above came out of. So it goes in as steering,
+  // unfenced and unaltered: fencing it would brief the agent never to obey the one thing
+  // it was woken to do, and defanging it would silently edit an operator's words. Nothing
+  // in a channel sets `scheduled` — `Gateway.tick` does, and only the ticker calls it.
+  if (ctx.scheduled) {
+    return [...steering, ...capabilitySteering(ctx.capabilities ?? []), header, event.text].join(
+      "\n",
+    );
+  }
+
   return [
     ...steering,
     ...capabilitySteering(ctx.capabilities ?? []),
-    `[${event.surface} · channel ${event.channel.id}${event.channel.isPublic ? " · PUBLIC" : ""}` +
-      ` · from ${event.author.id}${event.author.isAgent ? " · another agent" : ""}]`,
+    header,
     UNTRUSTED_OPEN,
     body,
     UNTRUSTED_CLOSE,

--- a/packages/core/test/gateway.test.ts
+++ b/packages/core/test/gateway.test.ts
@@ -1046,35 +1046,47 @@ describe("Gateway.tick", () => {
 
   it("waits behind a live turn in the same channel rather than interleaving with it", async () => {
     const f = postingAdapter([HIVE]);
-    const order: string[] = [];
+    const entered: string[] = [];
     let release!: () => void;
+    let chatStarted!: () => void;
     const held = new Promise<void>((resolve) => {
       release = resolve;
     });
+    // Signalled from inside the brain rather than waited out on a clock: a sleep long
+    // enough on this machine is a sleep that, on a loaded runner, asserts an empty list
+    // because nothing had started yet — and then the test passes without proving anything.
+    const started = new Promise<void>((resolve) => {
+      chatStarted = resolve;
+    });
     const brain: Brain = {
       async *runTurn(event: InboundEvent): AsyncGenerator<BrainStep, void, GuardFeedback | undefined> {
-        if (event.author.id === "u1") await held;
-        order.push(event.author.id);
+        entered.push(event.author.id);
+        if (event.author.id === "u1") {
+          chatStarted();
+          await held;
+        }
         yield { type: "reply", msg: { text: `done ${event.author.id}` } };
       },
     };
-    const gw = new Gateway({
-      manifest: ticking("", "anyone"),
-      adapters: [f.adapter],
-      brain,
-    });
+    const gw = new Gateway({ manifest: ticking("", "anyone"), adapters: [f.adapter], brain });
     await gw.start();
 
     f.inject({ ...tickEv("a message"), author: { surface: "slack", id: "u1", isSelf: false, isAgent: false } });
-    await new Promise((r) => setTimeout(r, 5));
+    await started; // the chat turn is inside the brain and holding the channel
+
     const ticked = gw.tick(tickEv("the digest"), { surface: "slack", channel: "C01" });
-    await new Promise((r) => setTimeout(r, 5));
-    // The chat turn is still holding the channel, so nothing of the tick has happened.
-    expect(order).toEqual([]);
+    // Drained rather than slept on: every microtask the tick could have run on has run, and
+    // it still has not entered the brain.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(entered).toEqual(["u1"]);
 
     release();
     await ticked;
-    expect(order).toEqual(["u1", "schedule:digest"]);
+    expect(entered).toEqual(["u1", "schedule:digest"]);
+    // Only the tick's answer is here: the chat turn replies through `send`, which this
+    // adapter refuses on purpose — see `postingAdapter`.
+    expect(f.posts.map((post) => post.msg.text)).toEqual(["done schedule:digest"]);
   });
 
   it("counts what the guard refused, and posts none of it", async () => {
@@ -1088,6 +1100,41 @@ describe("Gateway.tick", () => {
       asked: 1,
       sent: 0,
     });
+    expect(f.posts).toHaveLength(0);
+  });
+
+  it("refuses a step that arrives after the tick was already recorded", async () => {
+    const f = postingAdapter([HIVE]);
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let resumed = false;
+    // Suspended inside an `await` when the timeout wins, then coming back with a reply.
+    // `withTimeout` releases the queue slot and cannot cancel this — so the send has to.
+    const brain: Brain = {
+      async *runTurn(): AsyncGenerator<BrainStep, void, GuardFeedback | undefined> {
+        await held;
+        resumed = true;
+        yield { type: "reply", msg: { text: "late" } };
+      },
+    };
+    const gw = new Gateway({
+      manifest: ticking("limits: {turnTimeoutMs: 20}\n"),
+      adapters: [f.adapter],
+      brain,
+    });
+    await gw.start();
+
+    const outcome = await gw.tick(tickEv("summarize"), { surface: "slack", channel: "C01" });
+    expect((outcome.error as Error).message).toMatch(/turn timed out/);
+
+    release();
+    await new Promise((r) => setTimeout(r, 20));
+    // The brain came back and asked to post, and nothing reached the channel: the host has
+    // already said this tick proved nothing, and a second, contradicting post at top level
+    // is what this closes.
+    expect(resumed).toBe(true);
     expect(f.posts).toHaveLength(0);
   });
 

--- a/packages/core/test/gateway.test.ts
+++ b/packages/core/test/gateway.test.ts
@@ -952,3 +952,162 @@ describe("answers come home", () => {
     expect(slack.sent.at(-1)?.msg.text).toBe("ida (buzz · hive): and again"); // "one more" never came
   });
 });
+
+/**
+ * A surface that can create a top-level post, which is what a scheduled turn answers with.
+ *
+ * `send` throws here on purpose. It is the reply path, and every real adapter needs an
+ * inbound event to thread onto — a synthetic tick has none, so a tick that reached `send`
+ * would be publishing under an id no surface ever issued.
+ */
+function postingAdapter(channels: ChannelRef[]) {
+  let emit!: (e: InboundEvent) => void;
+  const posts: { channel: ChannelRef; msg: GuardedMessage }[] = [];
+  const adapter: SurfaceAdapter = {
+    kind: "slack",
+    start: async (onEvent) => {
+      if (onEvent) emit = onEvent;
+    },
+    send: async () => {
+      throw new Error("a scheduled turn must not reply through the inbound path");
+    },
+    postTargets: () => channels,
+    post: async (channel, msg) => {
+      posts.push({ channel, msg });
+      return { surface: "slack", nativeId: `p${posts.length}` };
+    },
+    stop: async () => {},
+  };
+  return { adapter, posts, inject: (e: InboundEvent) => emit(e) };
+}
+
+const HIVE: ChannelRef = { surface: "slack", id: "C01", isPublic: false, name: "hive" };
+
+/** A clock tick as `ScheduledTurns` builds one: no author a surface could resolve. */
+const tickEv = (text: string): InboundEvent => ({
+  id: { surface: "slack", nativeId: "schedule:digest:run1" },
+  surface: "slack",
+  channel: HIVE,
+  author: { surface: "slack", id: "schedule:digest", isSelf: false, isAgent: false },
+  text,
+  mentionsMe: true,
+  ts: "2026-09-10T18:00:00Z",
+  raw: null,
+});
+
+describe("Gateway.tick", () => {
+  const ticking = (extra = "", respondTo = "owner-only\nowner: [U08NOBODY]") =>
+    loadManifest(
+      `name: t\nbrain: {provider: mock}\nrespondTo: ${respondTo}\n` +
+        "surfaces: [{kind: slack, channels: [{id: C01, name: hive, reply: private}]}]\n" +
+        extra,
+    );
+
+  it("skips the author gate and answers with a top-level post", async () => {
+    const f = postingAdapter([HIVE]);
+    // `owner-only`, and the clock is not the owner: every other inbound event here would
+    // be refused, and the tick is admitted because there is no channel author to weigh.
+    const gw = new Gateway({ manifest: ticking(), adapters: [f.adapter], brain: new MockBrain() });
+    await gw.start();
+
+    const outcome = await gw.tick(tickEv("summarize the day"), { surface: "slack", channel: "C01" });
+
+    expect(outcome).toEqual({ asked: 1, sent: 1 });
+    expect(f.posts).toHaveLength(1);
+    expect(f.posts[0].msg.text).toBe("echo: summarize the day");
+    expect(f.posts[0].channel.id).toBe("C01");
+  });
+
+  it("stops at the kill switch and at the rate cap, and never starts a turn", async () => {
+    const f = postingAdapter([HIVE]);
+    const gw = new Gateway({
+      manifest: ticking("limits: {perChannelPerMinute: 1}\n"),
+      adapters: [f.adapter],
+      brain: new MockBrain(),
+    });
+    await gw.start();
+
+    gw.stopServing("operator halted the agent");
+    expect(await gw.tick(tickEv("one"), { surface: "slack", channel: "C01" })).toEqual({
+      asked: 0,
+      sent: 0,
+      skipped: "kill_switch",
+    });
+    gw.resumeServing();
+
+    expect(await gw.tick(tickEv("two"), { surface: "slack", channel: "C01" })).toMatchObject({ sent: 1 });
+    expect(await gw.tick(tickEv("three"), { surface: "slack", channel: "C01" })).toEqual({
+      asked: 0,
+      sent: 0,
+      skipped: "limit:perChannelPerMinute",
+    });
+    expect(f.posts).toHaveLength(1);
+  });
+
+  it("waits behind a live turn in the same channel rather than interleaving with it", async () => {
+    const f = postingAdapter([HIVE]);
+    const order: string[] = [];
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const brain: Brain = {
+      async *runTurn(event: InboundEvent): AsyncGenerator<BrainStep, void, GuardFeedback | undefined> {
+        if (event.author.id === "u1") await held;
+        order.push(event.author.id);
+        yield { type: "reply", msg: { text: `done ${event.author.id}` } };
+      },
+    };
+    const gw = new Gateway({
+      manifest: ticking("", "anyone"),
+      adapters: [f.adapter],
+      brain,
+    });
+    await gw.start();
+
+    f.inject({ ...tickEv("a message"), author: { surface: "slack", id: "u1", isSelf: false, isAgent: false } });
+    await new Promise((r) => setTimeout(r, 5));
+    const ticked = gw.tick(tickEv("the digest"), { surface: "slack", channel: "C01" });
+    await new Promise((r) => setTimeout(r, 5));
+    // The chat turn is still holding the channel, so nothing of the tick has happened.
+    expect(order).toEqual([]);
+
+    release();
+    await ticked;
+    expect(order).toEqual(["u1", "schedule:digest"]);
+  });
+
+  it("counts what the guard refused, and posts none of it", async () => {
+    const f = postingAdapter([{ ...HIVE, isPublic: true }]);
+    // A public channel the manifest never consented to: `reply: private` above, so the
+    // guard refuses every post into it and the brain's one ask reaches nobody.
+    const gw = new Gateway({ manifest: ticking(), adapters: [f.adapter], brain: new MockBrain() });
+    await gw.start();
+
+    expect(await gw.tick(tickEv("summarize"), { surface: "slack", channel: "C01" })).toEqual({
+      asked: 1,
+      sent: 0,
+    });
+    expect(f.posts).toHaveLength(0);
+  });
+
+  it("answers a turn that never finished with the tally and the failure", async () => {
+    const f = postingAdapter([HIVE]);
+    const brain: Brain = {
+      // eslint-disable-next-line require-yield
+      async *runTurn(): AsyncGenerator<BrainStep, void, GuardFeedback | undefined> {
+        await new Promise(() => {}); // hangs until the turn's own clock gives up
+      },
+    };
+    const gw = new Gateway({
+      manifest: ticking("limits: {turnTimeoutMs: 20}\n"),
+      adapters: [f.adapter],
+      brain,
+    });
+    await gw.start();
+
+    const outcome = await gw.tick(tickEv("summarize"), { surface: "slack", channel: "C01" });
+    expect(outcome.sent).toBe(0);
+    expect((outcome.error as Error).message).toMatch(/turn timed out/);
+  });
+});

--- a/packages/core/test/gateway.test.ts
+++ b/packages/core/test/gateway.test.ts
@@ -1075,10 +1075,9 @@ describe("Gateway.tick", () => {
     await started; // the chat turn is inside the brain and holding the channel
 
     const ticked = gw.tick(tickEv("the digest"), { surface: "slack", channel: "C01" });
-    // Drained rather than slept on: every microtask the tick could have run on has run, and
-    // it still has not entered the brain.
-    await Promise.resolve();
-    await Promise.resolve();
+    // Asserted with nothing awaited in between, and that is the point: `ChannelQueue.submit`
+    // pumps synchronously, so if the tick could overtake a running turn in its channel it
+    // would already have entered the brain by this line.
     expect(entered).toEqual(["u1"]);
 
     release();
@@ -1110,13 +1109,24 @@ describe("Gateway.tick", () => {
       release = resolve;
     });
     let resumed = false;
+    let stepTaken!: () => void;
+    // The completion point, and it is a real one rather than a guess: this `finally` runs
+    // when the abandoned generator is returned, which cannot happen before `drive` has
+    // taken the late step off the `yield` and offered it to the send.
+    const taken = new Promise<void>((resolve) => {
+      stepTaken = resolve;
+    });
     // Suspended inside an `await` when the timeout wins, then coming back with a reply.
     // `withTimeout` releases the queue slot and cannot cancel this — so the send has to.
     const brain: Brain = {
       async *runTurn(): AsyncGenerator<BrainStep, void, GuardFeedback | undefined> {
-        await held;
-        resumed = true;
-        yield { type: "reply", msg: { text: "late" } };
+        try {
+          await held;
+          resumed = true;
+          yield { type: "reply", msg: { text: "late" } };
+        } finally {
+          stepTaken();
+        }
       },
     };
     const gw = new Gateway({
@@ -1130,7 +1140,7 @@ describe("Gateway.tick", () => {
     expect((outcome.error as Error).message).toMatch(/turn timed out/);
 
     release();
-    await new Promise((r) => setTimeout(r, 20));
+    await taken;
     // The brain came back and asked to post, and nothing reached the channel: the host has
     // already said this tick proved nothing, and a second, contradicting post at top level
     // is what this closes.

--- a/packages/core/test/job-channel.test.ts
+++ b/packages/core/test/job-channel.test.ts
@@ -321,10 +321,10 @@ describe("a job body that probes", () => {
   const body = (declared: JobConfig, script: string): JobConfig => ({
     ...declared,
     run: {
-      ...declared.run,
+      ...declared.run!,
       command: process.execPath,
       args: ["-e", `const fs=require("fs");${script}`],
-      passthrough: [...declared.run.passthrough, "MARKER"],
+      passthrough: [...declared.run!.passthrough, "MARKER"],
     },
   });
 

--- a/packages/core/test/job-dispatcher.test.ts
+++ b/packages/core/test/job-dispatcher.test.ts
@@ -635,7 +635,7 @@ it.each([false, true])("uses the same host contract for Python and a compiled ex
     execFileSync("cc", [join(dir, "task.c"), "-o", join(dir, "task")]);
     for (const [command, args] of [["python3", [join(dir, "task.py")]], [join(dir, "task"), []]] as const) {
       const original = manifest(enabled ? "output: {format: json}" : "").jobs[0]!;
-      const job = { ...original, run: { ...original.run, command, args: [...args] } };
+      const job = { ...original, run: { ...original.run!, command, args: [...args] } };
       const output = vi.fn();
       const host = new JobHost({ workDir: dir, secretOpts: { dir, env: { TASK_TOKEN: "worker-secret" } }, onOutput: output });
       const run = await host.executeWorker(JobSchema.parse(job), request(job));
@@ -677,7 +677,7 @@ it.each(["buzz", "slack"])("automatically explains an uncaught script error in t
   const dir = await mkdtemp(join(tmpdir(), "worker-failure-"));
   const original = manifest().jobs[0]!;
   const job: JobConfig = { ...original,
-    run: { ...original.run, command: process.execPath, args: ["-e", 'console.log("step: connecting"); throw new Error("synthetic worker exception: " + process.env.API_TOKEN)'] },
+    run: { ...original.run!, command: process.execPath, args: ["-e", 'console.log("step: connecting"); throw new Error("synthetic worker exception: " + process.env.API_TOKEN)'] },
     report: { surface, channel: "operations", announce: "unproven", proven: "labelled", probe: false, history: false },
   };
   const api = new Cluster(), dispatch = dispatcher(api, [job]);

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../src/job-host.ts";
 import type { EventRef } from "../src/events.ts";
 import { interpretSwitchValue, type SwitchLookup, type SwitchSource } from "../src/kill-switch.ts";
-import { loadManifest, type JobAnnounce, type JobConfig } from "../src/manifest.ts";
+import { isProcessJob, loadManifest, type JobAnnounce, type JobConfig, type ProcessJob } from "../src/manifest.ts";
 import { combineVerdicts, describeVerdict, type ProvenVoice } from "../src/verdict.ts";
 import { collectJobOutput, JOB_OUTPUT_LIMIT_BYTES, type FinalJobOutput } from "../src/job-output.ts";
 
@@ -33,19 +33,24 @@ const declared = {
 };
 
 /** One declared job, through the real schema so the bounds and the switch key are derived. */
-const job = (over: Record<string, string | undefined> = {}): JobConfig =>
-  loadManifest(
+const job = (over: Record<string, string | undefined> = {}): ProcessJob => {
+  const [parsed] = loadManifest(
     `${base}jobs: [{${Object.entries({ ...declared, ...over })
       .filter(([, value]) => value !== undefined)
       .map(([key, value]) => `${key}: ${value}`)
       .join(", ")}}]\n`,
-  ).jobs[0];
+  ).jobs;
+  // Narrowed rather than cast: an `over` that dropped `run` would otherwise reach the host
+  // as a job with no body and fail somewhere further down than the line that caused it.
+  if (!parsed || !isProcessJob(parsed)) throw new Error("this fixture declares no run body");
+  return parsed;
+};
 
 /**
  * A real job body: a node process this host knows nothing about beyond its argv, its exit
  * code, and the file it writes. Every test below drives the envelope through one.
  */
-const body = (script: string, over: Record<string, string | undefined> = {}): JobConfig => {
+const body = (script: string, over: Record<string, string | undefined> = {}): ProcessJob => {
   const declared = job(over);
   return {
     ...declared,

--- a/packages/core/test/job-host.test.ts
+++ b/packages/core/test/job-host.test.ts
@@ -723,7 +723,7 @@ describe("the status post", () => {
   const feed = (
     id: (n: number) => EventRef | undefined = named,
     announce: JobAnnounce = "unproven",
-    proven: ProvenVoice = "labelled",
+    proven?: ProvenVoice,
   ) => {
     const posts: Array<{ text: string; threadRoot?: EventRef; mentions?: readonly string[] }> = [];
     const post: JobPoster = async (report, text, threadRoot, mentions) => {
@@ -738,7 +738,9 @@ describe("the status post", () => {
         surface: "console",
         channel: "hive",
         announce,
-        proven,
+        // Absent unless the job asked for one: `proven` carries no schema default, so that
+        // the difference between omitting it and choosing `labelled` survives to the load.
+        ...(proven ? { proven } : {}),
         probe: false,
         history: false,
       });

--- a/packages/core/test/job-server.test.ts
+++ b/packages/core/test/job-server.test.ts
@@ -63,11 +63,11 @@ const TRIAGE =
 const withBody = (job: JobConfig, script: string): JobConfig => ({
   ...job,
   run: {
-    ...job.run,
+    ...job.run!,
     command: process.execPath,
     args: ["-e", `const fs=require("fs");${script}`, "--", "--declared"],
     // `MARKER` is ambient on the host's base env, so the body has to name it to see it.
-    passthrough: [...job.run.passthrough, "MARKER"],
+    passthrough: [...job.run!.passthrough, "MARKER"],
   },
 });
 

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -1060,14 +1060,27 @@ describe("a job whose body is a prompt", () => {
       .map(([key, value]) => `${key}: ${value}`)
       .join(", ")}}]\n`;
 
-  it("takes a one-liner inline and a page as a file, and never both", () => {
+  it("takes a one-liner inline and a page as a named skill, and never both", () => {
     expect(loadManifest(withJob()).jobs[0]!.prompt).toBe("Summarize the day.");
-    expect(loadManifest(withJob({ prompt: "{file: ./jobs/digest.md}" })).jobs[0]!.prompt).toEqual({
-      file: "./jobs/digest.md",
+    expect(loadManifest(withJob({ prompt: "{skill: daily-digest}" })).jobs[0]!.prompt).toEqual({
+      skill: "daily-digest",
     });
     expect(() =>
-      loadManifest(withJob({ prompt: "{file: ./digest.md, text: inline}" })),
+      loadManifest(withJob({ prompt: "{skill: daily-digest, text: inline}" })),
     ).toThrow(/unrecognized/i);
+  });
+
+  it("takes a name rather than a path, so there is nothing to traverse with", () => {
+    // The narrowing that removes a category rather than closing a door: a slug cannot be
+    // absolute, cannot climb out, and cannot name the runtime's own `workspace/`.
+    for (const bad of ["./jobs/digest.md", "../secrets/token", "/etc/motd", "Daily-Digest", "1st"]) {
+      expect(() => loadManifest(withJob({ prompt: `{skill: '${bad}'}` })), bad).toThrow(
+        /a skill name is lower-case letters/,
+      );
+    }
+    expect(() => loadManifest(withJob({ prompt: "{file: ./jobs/digest.md}" }))).toThrow(
+      /unrecognized/i,
+    );
   });
 
   it("needs exactly one body, because two bodies is two jobs", () => {

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -963,7 +963,6 @@ describe("jobs", () => {
       surface: "console",
       channel: "hive",
       announce: "unproven",
-      proven: "labelled",
       probe: false,
       history: false,
     });
@@ -1009,7 +1008,10 @@ describe("jobs", () => {
     // The default is the rendering every job had before the field existed. Presentation
     // only, and over PASS alone — `verdict.test.ts` holds the half that matters.
     const declared = (report: string) => loadManifest(withJob({ report })).jobs[0].report?.proven;
-    expect(declared("{surface: console, channel: hive}")).toBe("labelled");
+    // Absent rather than defaulted here: the rendering default lives in `jobStatus`, which
+    // is the one place that has to know it, and leaving it absent is what lets a prompt
+    // job tell "omitted" from "asked for `labelled`".
+    expect(declared("{surface: console, channel: hive}")).toBeUndefined();
     expect(declared("{surface: console, channel: hive, proven: verbatim}")).toBe("verbatim");
 
     // A word nobody implements is refused rather than read as `verbatim`: a job asking for
@@ -1121,6 +1123,10 @@ describe("a job whose body is a prompt", () => {
       ["output", { output: "{format: json}" }],
       ["report.probe", { report: "{surface: slack, channel: C01, probe: true}" }],
       ["report.history", { report: "{surface: slack, channel: C01, probe: true, history: true}" }],
+      // Detectable only because `proven` is no longer defaulted in the schema: omitting it
+      // and asking for `labelled` would otherwise be the same value here.
+      ["report.proven", { report: "{surface: slack, channel: C01, proven: labelled}" }],
+      ["report.proven", { report: "{surface: slack, channel: C01, proven: verbatim}" }],
     ] as const) {
       expect(() => loadManifest(withJob(over)), field).toThrow(
         new RegExp(`declares a .prompt. body, so it declares no .${field.replace(".", "\\.")}.`),
@@ -1142,6 +1148,10 @@ describe("a job whose body is a prompt", () => {
 
   it("needs somewhere to be addressed and to answer", () => {
     expect(() => loadManifest(withJob({ report: undefined }))).toThrow(/no `report`/);
+  });
+
+  it("takes a report that omits `proven`, which is every prompt job", () => {
+    expect(loadManifest(withJob()).jobs[0]!.report?.proven).toBeUndefined();
   });
 
   it("refuses the announce mode that keys on something a turn never writes", () => {

--- a/packages/core/test/manifest.test.ts
+++ b/packages/core/test/manifest.test.ts
@@ -593,7 +593,7 @@ describe("jobs", () => {
     // the convention — and `mcpServers[].env` had always accepted these.
     const run =
       "{command: node, env: {'MY-CONFIG': on, 'my.config': on, 'MY CONFIG': on}, passthrough: ['MY-CONFIG']}";
-    expect(Object.keys(loadManifest(withJob({ run })).jobs[0].run.env)).toEqual([
+    expect(Object.keys(loadManifest(withJob({ run })).jobs[0]!.run!.env)).toEqual([
       "MY-CONFIG",
       "my.config",
       "MY CONFIG",
@@ -607,13 +607,13 @@ describe("jobs", () => {
       loadManifest(withJob({ run: "{command: node, secrets: {GH_TOKEN: '../TOKEN'}}" })),
     ).toThrow(/secretRef/);
     expect(
-      loadManifest(withJob({ run: "{command: node, secrets: {GH_TOKEN: GH_TOKEN}}" })).jobs[0].run
+      loadManifest(withJob({ run: "{command: node, secrets: {GH_TOKEN: GH_TOKEN}}" })).jobs[0]!.run!
         .secrets,
     ).toEqual({ GH_TOKEN: "GH_TOKEN" });
   });
 
   it("defaults the four environment fields to empty, so a job declares its way out of nothing", () => {
-    expect(loadManifest(withJob()).jobs[0].run).toEqual({
+    expect(loadManifest(withJob()).jobs[0]!.run).toEqual({
       command: "node",
       args: ["runner/src/sweep.ts"],
       env: {},
@@ -635,7 +635,7 @@ describe("jobs", () => {
     // Every trigger but `onRequest` enters through `job run`, which takes the directory.
     expect(
       loadManifest(withJob({ run: "{command: node, jobSecrets: {GH_APP_PEM: GH_APP_PEM}}" }))
-        .jobs[0].run.jobSecrets,
+        .jobs[0]!.run!.jobSecrets,
     ).toEqual({ GH_APP_PEM: "GH_APP_PEM" });
     expect(() =>
       loadManifest(
@@ -690,10 +690,10 @@ describe("jobs", () => {
       run: { command: "node", args: ["runner/src/sweep.ts"] },
     });
     // Nothing implies a spend cap, a model tier, or a place to report.
-    expect(job.budget.maxSpendUsd).toBeUndefined();
+    expect(job!.budget!.maxSpendUsd).toBeUndefined();
     expect(job.model).toBeUndefined();
     expect(job.report).toBeUndefined();
-    expect(loadManifest(withJob({ run: "{command: node}" })).jobs[0].run.args).toEqual([]);
+    expect(loadManifest(withJob({ run: "{command: node}" })).jobs[0]!.run!.args).toEqual([]);
   });
 
   it("derives the switch key from the slug, so the two cannot name different jobs", () => {
@@ -1036,5 +1036,114 @@ describe("jobs", () => {
     expect(() =>
       loadManifest(withJob({ budget: "{wallClockMs: 3600000, maxOpenPrs: 2}" })),
     ).toThrow(/unrecognized/i);
+  });
+});
+describe("a job whose body is a prompt", () => {
+  const base =
+    "name: x\nbrain: {provider: mock}\nrespondTo: anyone\nbrains: [{preset: local}]\n" +
+    "killSwitchParkBy: []\n" +
+    "surfaces: [{kind: slack, channels: [{id: C01, name: hive, reply: private}]}]\n";
+
+  const declared: Record<string, string> = {
+    slug: "daily-digest",
+    archetype: "watch",
+    description: "'One short post per day.'",
+    trigger: '{schedules: ["0 18 * * *"], timezone: America/Los_Angeles}',
+    killSwitch: "{failDirection: closed}",
+    prompt: "'Summarize the day.'",
+    report: "{surface: slack, channel: C01}",
+  };
+
+  const withJob = (over: Record<string, string | undefined> = {}) =>
+    `${base}jobs: [{${Object.entries({ ...declared, ...over })
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(", ")}}]\n`;
+
+  it("takes a one-liner inline and a page as a file, and never both", () => {
+    expect(loadManifest(withJob()).jobs[0]!.prompt).toBe("Summarize the day.");
+    expect(loadManifest(withJob({ prompt: "{file: ./jobs/digest.md}" })).jobs[0]!.prompt).toEqual({
+      file: "./jobs/digest.md",
+    });
+    expect(() =>
+      loadManifest(withJob({ prompt: "{file: ./digest.md, text: inline}" })),
+    ).toThrow(/unrecognized/i);
+  });
+
+  it("needs exactly one body, because two bodies is two jobs", () => {
+    expect(() =>
+      loadManifest(withJob({ run: "{command: node}", budget: "{wallClockMs: 1000}" })),
+    ).toThrow(/both `run` and `prompt`/);
+    expect(() => loadManifest(withJob({ prompt: undefined }))).toThrow(/neither `run` nor `prompt`/);
+  });
+
+  it("says nothing about the body when the body's own value is what failed", () => {
+    // `prompt: "   "` trims to nothing and is refused for that. It is then absent from the
+    // object the body rule reads, and "declares neither" would be a false claim about a
+    // manifest that plainly declares one.
+    let message = "";
+    try {
+      loadManifest(withJob({ prompt: "'   '" }));
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toMatch(/prompt/);
+    expect(message).not.toMatch(/neither `run` nor `prompt`/);
+  });
+
+  it("needs no budget, while a process body still does", () => {
+    expect(loadManifest(withJob()).jobs[0]!.budget).toBeUndefined();
+    expect(() =>
+      loadManifest(
+        withJob({ prompt: undefined, run: "{command: node}", report: undefined, budget: undefined }),
+      ),
+    ).toThrow(/`run` body but no `budget`/);
+  });
+
+  it("refuses every field that belongs to a process body, by name", () => {
+    for (const [field, over] of [
+      ["worker", { worker: `{image: "example/w@sha256:${"a".repeat(64)}", directory: /app}` }],
+      ["parameters", { parameters: "{issue: {type: integer, description: 'Which issue.'}}" }],
+      ["model", { model: "claude-sonnet-5" }],
+      ["output", { output: "{format: json}" }],
+      ["report.probe", { report: "{surface: slack, channel: C01, probe: true}" }],
+      ["report.history", { report: "{surface: slack, channel: C01, probe: true, history: true}" }],
+    ] as const) {
+      expect(() => loadManifest(withJob(over)), field).toThrow(
+        new RegExp(`declares a .prompt. body, so it declares no .${field.replace(".", "\\.")}.`),
+      );
+    }
+  });
+
+  it("takes the clock and no other door, since nothing serves one yet", () => {
+    for (const trigger of [
+      '{schedules: ["0 18 * * *"], onRequest: true}',
+      '{schedules: ["0 18 * * *"], webhook: true}',
+    ]) {
+      expect(() => loadManifest(withJob({ trigger })), trigger).toThrow(/declares no `trigger\./);
+    }
+    // And the clock still has to be stoppable without a deploy, which is the rule every
+    // unattended job already has.
+    expect(() => loadManifest(withJob({ killSwitch: undefined }))).toThrow(/must declare a killSwitch/);
+  });
+
+  it("needs somewhere to be addressed and to answer", () => {
+    expect(() => loadManifest(withJob({ report: undefined }))).toThrow(/no `report`/);
+  });
+
+  it("refuses the announce mode that keys on something a turn never writes", () => {
+    expect(() =>
+      loadManifest(withJob({ report: "{surface: slack, channel: C01, announce: reported}" })),
+    ).toThrow(/report\.announce: reported/);
+    expect(() =>
+      loadManifest(withJob({ report: "{surface: slack, channel: C01, announce: always}" })),
+    ).not.toThrow();
+  });
+
+  it("refuses an interval descriptor, which names no time in the declared zone", () => {
+    expect(() => loadManifest(withJob({ trigger: '{schedules: ["@every 5m"]}' }))).toThrow(
+      /wall-clock time in/,
+    );
+    expect(() => loadManifest(withJob({ trigger: '{schedules: ["@daily"]}' }))).not.toThrow();
   });
 });

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -58,11 +58,13 @@ describe("nextFire", () => {
     expect(wall(nextFire(["0 0 1 * *"], "UTC", from), "UTC")).toBe("2026-10-01 00:00:00");
   });
 
-  it("skips a local time the spring-forward transition deletes", () => {
-    // 2027-03-14 in Los Angeles runs 01:59 → 03:00, so 02:30 is not an instant that day.
-    // A digest scheduled inside the gap is not moved to 03:30; it runs the next day.
+  it("runs at the next real instant when spring-forward deletes the local time", () => {
+    // 2027-03-14 in Los Angeles runs 01:59 → 03:00, so 02:30 is not an instant that day and
+    // the tick lands at 03:30 rather than being dropped. That is the deploy target's answer
+    // too: Go normalizes a non-existent wall-clock time forward, so the CronJob a `run` job
+    // of the same expression renders fires then as well — one expression, one meaning.
     const at = nextFire(["30 2 * * *"], LA, new Date("2027-03-13T12:00:00Z"));
-    expect(wall(at, LA)).toBe("2027-03-15 02:30:00");
+    expect(wall(at, LA)).toBe("2027-03-14 03:30:00");
   });
 
   it("fires once in the hour the fall-back transition repeats", () => {
@@ -91,30 +93,32 @@ describe("nextFire", () => {
     );
   });
 
-  it("refuses an expression it cannot parse, rather than never firing", () => {
-    expect(() => nextFire(["0 3 * *"], "UTC", new Date())).toThrow(/five cron fields/);
-    expect(() => nextFire(["0 3 * * 1-"], "UTC", new Date())).toThrow(/not a value or a range/);
-    expect(() => nextFire(["0 9-5 * * *"], "UTC", new Date())).toThrow(/counts backwards/);
-  });
-
-  it("takes a decimal field and refuses every other way to write a number", () => {
-    // `Number` reads all of these, and the Kubernetes parser refuses all of them — so a
-    // `run` job and a `prompt` job carrying one expression would have disagreed.
+  /**
+   * Every expression that must be refused rather than silently scheduling something else.
+   *
+   * Asserted as "throws" and not on the wording: the message is the parser's now, and a test
+   * that pinned it would be testing the dependency's prose rather than this contract. What
+   * matters is that none of these is accepted — a name truncated to `MON`, a number read as
+   * hex, or a half-written range would each schedule a turn nobody asked for, and a `run`
+   * job carrying the same expression would have its CronJob refused at apply.
+   */
+  it("refuses every expression a deploy target would refuse, rather than firing on it", () => {
     const from = new Date("2026-09-10T13:00:00Z");
-    expect(wall(nextFire(["0 16 * * *"], "UTC", from), "UTC")).toBe("2026-09-10 16:00:00");
-    for (const bad of ["0 0x10 * * *", "0 1e1 * * *", "0 0-0x5 * * *"]) {
-      expect(() => nextFire([bad], "UTC", from), bad).toThrow(/not a value or a range/);
-    }
-  });
-
-  it("takes a three-letter name and refuses anything that merely starts like one", () => {
-    // Truncating to three would read `MONSOON` as Monday and schedule an expression nobody
-    // meant. Kubernetes' own parser takes the abbreviations and nothing longer, so one
-    // expression has to mean the same thing to a `run` job and to a `prompt` job.
-    const from = new Date("2026-09-10T13:00:00Z");
+    // The forms that must still work, so the refusals below are not just a broken parser.
     expect(wall(nextFire(["0 0 * * MON"], "UTC", from), "UTC")).toBe("2026-09-14 00:00:00");
-    for (const bad of ["0 0 * * MONSOON", "0 0 * * MONDAY", "0 0 1 JUNX *", "0 0 * * MO"]) {
-      expect(() => nextFire([bad], "UTC", from), bad).toThrow(/not a value or a range/);
+    expect(wall(nextFire(["0 16 * * *"], "UTC", from), "UTC")).toBe("2026-09-10 16:00:00");
+
+    for (const bad of [
+      "0 3 * *", // four fields
+      "0 3 * * 1-", // half a range
+      "0 9-5 * * *", // counts backwards
+      "0 0 * * MONSOON", // truncates to a valid MON
+      "0 0 * * MONDAY",
+      "0 0 1 JUNX *",
+      "0 0x10 * * *", // `Number` reads this as 16
+      "0 1e1 * * *",
+    ]) {
+      expect(() => nextFire([bad], "UTC", from), bad).toThrow();
     }
   });
 });

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -211,6 +211,28 @@ describe("readJobPrompt", () => {
     expect(readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), inner).body).toBe("inside");
   });
 
+  it("refuses a prompt out of the repository checkouts, which are not the bundle", async () => {
+    // `workspace/` holds clones refreshed from their remotes on every start, so a prompt
+    // read from one is words whoever can merge to that repository chose. The gateway
+    // already refuses to make a checkout the brain's cwd for the same reason.
+    await mkdir(join(dir, "workspace", "repos", "acme"), { recursive: true });
+    await writeFile(
+      join(dir, "workspace", "repos", "acme", "digest.md"),
+      "---\nname: d\ndescription: d\n---\nfrom a clone\n",
+    );
+    expect(() =>
+      readJobPrompt(promptJob({ prompt: "{file: ./workspace/repos/acme/digest.md}" }), dir),
+    ).toThrow(/under workspace\/, which the runtime writes/);
+
+    // And a symlink into it, which the path check alone would admit.
+    await writeFile(join(dir, "ok.md"), "---\nname: d\ndescription: d\n---\nbundled\n");
+    await symlink(join(dir, "workspace", "repos", "acme", "digest.md"), join(dir, "linked.md"));
+    expect(() => readJobPrompt(promptJob({ prompt: "{file: ./linked.md}" }), dir)).toThrow(
+      /under workspace\//,
+    );
+    expect(readJobPrompt(promptJob({ prompt: "{file: ./ok.md}" }), dir).body).toBe("bundled");
+  });
+
   it("refuses a symlink out of the bundle, which a reviewed diff never shows the content of", async () => {
     // The case a path check cannot see. `jobs/digest.md -> /mnt/secrets/TOKEN` reviews as
     // one short line, its content is never in the diff, and the content can change after

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -175,6 +175,40 @@ describe("readJobPrompt", () => {
     }
     await writeFile(join(inner, "digest.md"), "---\nname: d\ndescription: d\n---\ninside\n");
     expect(readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), inner).body).toBe("inside");
+  });
+
+  it("refuses a symlink out of the bundle, which a reviewed diff never shows the content of", async () => {
+    // The case a path check cannot see. `jobs/digest.md -> /mnt/secrets/TOKEN` reviews as
+    // one short line, its content is never in the diff, and the content can change after
+    // the review that approved it — and it would reach the brain as trusted words.
+    const inner = join(dir, "bundle");
+    await mkdir(inner);
+    await writeFile(join(dir, "outside.md"), "---\nname: d\ndescription: d\n---\nelsewhere\n");
+    await symlink(join(dir, "outside.md"), join(inner, "digest.md"));
+
+    expect(() => readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), inner)).toThrow(
+      /is a link to .*outside\.md, which is outside the agent directory/,
+    );
+  });
+
+  it("follows a link that stays inside the bundle, and an agent directory that is itself one", async () => {
+    // The containment is real-path on both sides, so a bundle reached through a symlinked
+    // home — which is how a mount usually arrives — is not mistaken for an escape.
+    const inner = join(dir, "bundle");
+    await mkdir(join(inner, "prompts"), { recursive: true });
+    await writeFile(
+      join(inner, "prompts", "shared.md"),
+      "---\nname: d\ndescription: d\n---\ninside\n",
+    );
+    await symlink(join(inner, "prompts", "shared.md"), join(inner, "digest.md"));
+    const linkedHome = join(dir, "home");
+    await symlink(inner, linkedHome);
+
+    for (const home of [inner, linkedHome]) {
+      expect(readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), home).body, home).toBe(
+        "inside",
+      );
+    }
   });
 
   it("refuses a file that is not shaped like a skill", async () => {

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -78,6 +78,18 @@ describe("nextFire", () => {
     expect(nextFire(["30 2 31 2 *"], "UTC", new Date("2026-09-10T13:00:00Z"))).toBeUndefined();
   });
 
+  it("reaches a leap day, which is the sparsest a real schedule gets", () => {
+    // Two years out, so a one-year horizon would report this as never firing — and the
+    // ticker arms nothing for a schedule that comes back empty.
+    expect(wall(nextFire(["0 0 29 2 *"], "UTC", new Date("2026-03-01T00:00:00Z")), "UTC")).toBe(
+      "2028-02-29 00:00:00",
+    );
+    // And the eight-year gap a non-leap century opens between two of them.
+    expect(wall(nextFire(["0 0 29 2 *"], "UTC", new Date("2096-03-01T00:00:00Z")), "UTC")).toBe(
+      "2104-02-29 00:00:00",
+    );
+  });
+
   it("refuses an expression it cannot parse, rather than never firing", () => {
     expect(() => nextFire(["0 3 * *"], "UTC", new Date())).toThrow(/five cron fields/);
     expect(() => nextFire(["0 3 * * 1-"], "UTC", new Date())).toThrow(/not a value or a range/);
@@ -148,6 +160,21 @@ describe("readJobPrompt", () => {
     // the agent would post a prompt nobody wrote.
     await writeFile(join(dir, "digest.md"), Buffer.concat([Buffer.from(head), Buffer.from([0x80])]));
     expect(() => readJobPrompt(job, dir)).toThrow(/not valid UTF-8/);
+  });
+
+  it("refuses a prompt that is not inside the agent directory", async () => {
+    // The words go in as steering, and the argument for that is that they came out of the
+    // reviewed bundle. A path that leaves it reads a file no diff ever showed.
+    await writeFile(join(dir, "outside.md"), "---\nname: d\ndescription: d\n---\nelsewhere\n");
+    const inner = join(dir, "bundle");
+    await mkdir(inner);
+    for (const file of ["../outside.md", join(dir, "outside.md")]) {
+      expect(() => readJobPrompt(promptJob({ prompt: `{file: '${file}'}` }), inner), file).toThrow(
+        /outside the agent directory/,
+      );
+    }
+    await writeFile(join(inner, "digest.md"), "---\nname: d\ndescription: d\n---\ninside\n");
+    expect(readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), inner).body).toBe("inside");
   });
 
   it("refuses a file that is not shaped like a skill", async () => {
@@ -385,6 +412,70 @@ describe("ScheduledTurns", () => {
       checks: [{ gate: "job:daily-digest", executed: true, exit_code: 0, source: "host" }],
       partial: false,
     });
+  });
+
+  it("refuses a tick that was still being admitted when it was told to stop", async () => {
+    const gw = fakeGateway();
+    const runs: JobRun[] = [];
+    // A switch read that has not answered yet is where a shutdown lands: the timer has
+    // fired, so `stop()` has nothing left to clear, and without the check inside `fire` the
+    // tick would submit a turn into surfaces that are closing.
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const turns = ticker(promptJob(), {
+      gateway: gw.gateway,
+      switchSource: async () => {
+        await held;
+        return { origin: "set", state: "on", value: "arming" };
+      },
+      onRun: (run) => runs.push(run),
+    });
+
+    vi.setSystemTime(new Date("2026-09-10T17:59:30Z"));
+    turns.start();
+    await vi.advanceTimersByTimeAsync(31_000);
+    turns.stop();
+    release();
+    await turns.drained();
+
+    expect(gw.ticks).toHaveLength(0);
+    expect(runs[0]).toMatchObject({ outcome: "abandoned" });
+    expect(runs[0]!.reason).toContain("never started");
+  });
+
+  it("waits out a tick that had already reached the gateway", async () => {
+    const runs: JobRun[] = [];
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const turns = ticker(promptJob(), {
+      gateway: {
+        tick: async () => {
+          await held;
+          return { asked: 1, sent: 1 };
+        },
+      },
+      switchSource: armed,
+      onRun: (run) => runs.push(run),
+    });
+
+    vi.setSystemTime(new Date("2026-09-10T17:59:30Z"));
+    turns.start();
+    await vi.advanceTimersByTimeAsync(31_000);
+    turns.stop();
+
+    let settled = false;
+    const drained = turns.drained().then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(settled).toBe(false); // the turn is still going, so the record is still owed
+    release();
+    await drained;
+    expect(runs[0]).toMatchObject({ outcome: "completed" });
   });
 
   it("arms nothing after it is stopped", async () => {

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -137,6 +137,16 @@ function promptJob(over: Record<string, string> = {}): PromptJob {
 
 describe("readJobPrompt", () => {
   let dir: string;
+  /** Writes `skills/<name>/SKILL.md`, the one layout the manifest can address. */
+  const writeSkill = async (name: string, body: string, frontmatterName = name) => {
+    await mkdir(join(dir, "skills", name), { recursive: true });
+    await writeFile(
+      join(dir, "skills", name, "SKILL.md"),
+      `---\nname: ${frontmatterName}\ndescription: One short post per day.\n---\n${body}\n`,
+    );
+    return join(dir, "skills", name, "SKILL.md");
+  };
+
   beforeEach(async () => {
     dir = await mkdtemp(join(tmpdir(), "prompt-"));
   });
@@ -149,133 +159,114 @@ describe("readJobPrompt", () => {
     expect(prompt).toEqual({ source: "inline", bytes: 18, body: "Summarize the day." });
   });
 
-  it("sends the body of a file and never its frontmatter", async () => {
-    await writeFile(
-      join(dir, "digest.md"),
-      "---\nname: daily-digest\ndescription: One short post per day.\n---\nRead the channel.\n",
-    );
-    const prompt = readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), dir);
+  it("finds a named skill at its standard path and sends only the body", async () => {
+    const path = await writeSkill("daily-digest", "Read the channel.");
+    const prompt = readJobPrompt(promptJob({ prompt: "{skill: daily-digest}" }), dir);
     expect(prompt.body).toBe("Read the channel.");
-    expect(prompt.source).toBe(join(dir, "digest.md"));
+    expect(prompt.source).toBe(path);
     expect(prompt.bytes).toBeGreaterThan(prompt.body.length);
   });
 
-  it("refuses a file that is missing, oversized, or not UTF-8", async () => {
-    const job = promptJob({ prompt: "{file: ./digest.md}" });
+  it("refuses a skill whose frontmatter calls it something else", async () => {
+    // Two spellings of one name is how a skill is found under one and announces itself as
+    // another — and whichever the chat face later reads would be a coin toss.
+    await writeSkill("daily-digest", "Read the channel.", "nightly-digest");
+    expect(() => readJobPrompt(promptJob({ prompt: "{skill: daily-digest}" }), dir)).toThrow(
+      /frontmatter says `name: nightly-digest`/,
+    );
+  });
+
+  it("refuses a skill that is missing, oversized, or not UTF-8", async () => {
+    const job = promptJob({ prompt: "{skill: daily-digest}" });
     expect(() => readJobPrompt(job, dir)).toThrow(/ENOENT|no such file/i);
 
-    const head = "---\nname: d\ndescription: d\n---\n";
-    await writeFile(join(dir, "digest.md"), head + "x".repeat(JOB_ARTIFACT_LIMIT_BYTES));
+    const head = "---\nname: daily-digest\ndescription: d\n---\n";
+    await mkdir(join(dir, "skills", "daily-digest"), { recursive: true });
+    const path = join(dir, "skills", "daily-digest", "SKILL.md");
+    await writeFile(path, head + "x".repeat(JOB_ARTIFACT_LIMIT_BYTES));
     expect(() => readJobPrompt(job, dir)).toThrow(/over the \d+-byte limit/);
 
     // A lone 0x80 continuation byte. `readFileSync(…, "utf8")` would hand back U+FFFD and
     // the agent would post a prompt nobody wrote.
-    await writeFile(join(dir, "digest.md"), Buffer.concat([Buffer.from(head), Buffer.from([0x80])]));
+    await writeFile(path, Buffer.concat([Buffer.from(head), Buffer.from([0x80])]));
     expect(() => readJobPrompt(job, dir)).toThrow(/not valid UTF-8/);
   });
 
   it("refuses a path that is not a regular file, rather than blocking the load on it", async () => {
     // A FIFO would hang `readFileSync` forever, and the load path this runs on is `run`,
     // `doctor` and `validate` — a startup that never returns and never says why.
-    const job = promptJob({ prompt: "{file: ./digest.md}" });
-    execFileSync("mkfifo", [join(dir, "digest.md")]);
+    const job = promptJob({ prompt: "{skill: daily-digest}" });
+    await mkdir(join(dir, "skills", "daily-digest"), { recursive: true });
+    const path = join(dir, "skills", "daily-digest", "SKILL.md");
+    execFileSync("mkfifo", [path]);
     expect(() => readJobPrompt(job, dir)).toThrow(/not a regular file/);
 
-    await rm(join(dir, "digest.md"));
-    await mkdir(join(dir, "digest.md"));
+    await rm(path);
+    await mkdir(path);
     expect(() => readJobPrompt(job, dir)).toThrow(/not a regular file|EISDIR/);
   });
 
-  it("stops reading an oversized file instead of taking the whole of it in", async () => {
-    const job = promptJob({ prompt: "{file: ./digest.md}" });
-    const head = "---\nname: d\ndescription: d\n---\n";
-    // Well past the bound, so a read that allocated the file would be plain in the timing.
-    await writeFile(join(dir, "digest.md"), head + "x".repeat(JOB_ARTIFACT_LIMIT_BYTES * 40));
-    expect(() => readJobPrompt(job, dir)).toThrow(
-      new RegExp(`over the ${JOB_ARTIFACT_LIMIT_BYTES}-byte limit`),
-    );
-  });
+  it("refuses a skill linked out of the bundle, including into the runtime's own subtree", async () => {
+    // A name cannot traverse, so this is the only way left out — and it is the one a
+    // reviewed diff shows as a path and never as the content it will resolve to.
+    const job = promptJob({ prompt: "{skill: daily-digest}" });
+    await mkdir(join(dir, "skills", "daily-digest"), { recursive: true });
 
-  it("refuses a prompt that is not inside the agent directory", async () => {
-    // The words go in as steering, and the argument for that is that they came out of the
-    // reviewed bundle. A path that leaves it reads a file no diff ever showed.
-    await writeFile(join(dir, "outside.md"), "---\nname: d\ndescription: d\n---\nelsewhere\n");
-    const inner = join(dir, "bundle");
-    await mkdir(inner);
-    for (const file of ["../outside.md", join(dir, "outside.md")]) {
-      expect(() => readJobPrompt(promptJob({ prompt: `{file: '${file}'}` }), inner), file).toThrow(
-        /outside the agent directory/,
-      );
-    }
-    await writeFile(join(inner, "digest.md"), "---\nname: d\ndescription: d\n---\ninside\n");
-    expect(readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), inner).body).toBe("inside");
-  });
+    await writeFile(join(dir, "outside.md"), "---\nname: daily-digest\ndescription: d\n---\nelsewhere\n");
+    await symlink(join(dir, "outside.md"), join(dir, "skills", "daily-digest", "SKILL.md"));
+    expect(() => readJobPrompt(job, dir)).toThrow(/outside the bundle's skills\/ tree/);
 
-  it("refuses a prompt out of the repository checkouts, which are not the bundle", async () => {
-    // `workspace/` holds clones refreshed from their remotes on every start, so a prompt
-    // read from one is words whoever can merge to that repository chose. The gateway
-    // already refuses to make a checkout the brain's cwd for the same reason.
+    // `workspace/` holds clones refreshed from their remotes, so a link into one is words
+    // whoever can merge to that repository chose. Out by construction now: it is not under
+    // `skills/`, so no carve-out per subtree is needed to exclude it.
+    await rm(join(dir, "skills", "daily-digest", "SKILL.md"));
     await mkdir(join(dir, "workspace", "repos", "acme"), { recursive: true });
     await writeFile(
-      join(dir, "workspace", "repos", "acme", "digest.md"),
-      "---\nname: d\ndescription: d\n---\nfrom a clone\n",
+      join(dir, "workspace", "repos", "acme", "SKILL.md"),
+      "---\nname: daily-digest\ndescription: d\n---\nfrom a clone\n",
     );
-    expect(() =>
-      readJobPrompt(promptJob({ prompt: "{file: ./workspace/repos/acme/digest.md}" }), dir),
-    ).toThrow(/under workspace\/, which the runtime writes/);
-
-    // And a symlink into it, which the path check alone would admit.
-    await writeFile(join(dir, "ok.md"), "---\nname: d\ndescription: d\n---\nbundled\n");
-    await symlink(join(dir, "workspace", "repos", "acme", "digest.md"), join(dir, "linked.md"));
-    expect(() => readJobPrompt(promptJob({ prompt: "{file: ./linked.md}" }), dir)).toThrow(
-      /under workspace\//,
+    await symlink(
+      join(dir, "workspace", "repos", "acme", "SKILL.md"),
+      join(dir, "skills", "daily-digest", "SKILL.md"),
     );
-    expect(readJobPrompt(promptJob({ prompt: "{file: ./ok.md}" }), dir).body).toBe("bundled");
+    expect(() => readJobPrompt(job, dir)).toThrow(/outside the bundle's skills\/ tree/);
   });
 
-  it("refuses a symlink out of the bundle, which a reviewed diff never shows the content of", async () => {
-    // The case a path check cannot see. `jobs/digest.md -> /mnt/secrets/TOKEN` reviews as
-    // one short line, its content is never in the diff, and the content can change after
-    // the review that approved it — and it would reach the brain as trusted words.
-    const inner = join(dir, "bundle");
-    await mkdir(inner);
-    await writeFile(join(dir, "outside.md"), "---\nname: d\ndescription: d\n---\nelsewhere\n");
-    await symlink(join(dir, "outside.md"), join(inner, "digest.md"));
-
-    expect(() => readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), inner)).toThrow(
-      /is a link to .*outside\.md, which is outside the agent directory/,
+  it("follows a link that stays inside the tree, and an agent directory that is itself one", async () => {
+    // Real-path on both sides, so a bundle reached through a symlinked home — which is how
+    // a mount usually arrives — is not mistaken for an escape.
+    await writeSkill("shared-digest", "inside");
+    await mkdir(join(dir, "skills", "daily-digest"), { recursive: true });
+    await symlink(
+      join(dir, "skills", "shared-digest", "SKILL.md"),
+      join(dir, "skills", "daily-digest", "SKILL.md"),
     );
-  });
-
-  it("follows a link that stays inside the bundle, and an agent directory that is itself one", async () => {
-    // The containment is real-path on both sides, so a bundle reached through a symlinked
-    // home — which is how a mount usually arrives — is not mistaken for an escape.
-    const inner = join(dir, "bundle");
-    await mkdir(join(inner, "prompts"), { recursive: true });
-    await writeFile(
-      join(inner, "prompts", "shared.md"),
-      "---\nname: d\ndescription: d\n---\ninside\n",
-    );
-    await symlink(join(inner, "prompts", "shared.md"), join(inner, "digest.md"));
     const linkedHome = join(dir, "home");
-    await symlink(inner, linkedHome);
+    await symlink(dir, linkedHome);
 
-    for (const home of [inner, linkedHome]) {
-      expect(readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), home).body, home).toBe(
+    for (const home of [dir, linkedHome]) {
+      // The frontmatter still has to agree with the name it was found under.
+      expect(() => readJobPrompt(promptJob({ prompt: "{skill: daily-digest}" }), home), home).toThrow(
+        /frontmatter says `name: shared-digest`/,
+      );
+      expect(readJobPrompt(promptJob({ prompt: "{skill: shared-digest}" }), home).body, home).toBe(
         "inside",
       );
     }
   });
 
   it("refuses a file that is not shaped like a skill", async () => {
-    const job = promptJob({ prompt: "{file: ./digest.md}" });
-    await writeFile(join(dir, "digest.md"), "Read the channel.\n");
+    const job = promptJob({ prompt: "{skill: daily-digest}" });
+    await mkdir(join(dir, "skills", "daily-digest"), { recursive: true });
+    const path = join(dir, "skills", "daily-digest", "SKILL.md");
+
+    await writeFile(path, "Read the channel.\n");
     expect(() => readJobPrompt(job, dir)).toThrow(/no frontmatter/);
 
-    await writeFile(join(dir, "digest.md"), "---\nname: daily-digest\n---\nRead the channel.\n");
+    await writeFile(path, "---\nname: daily-digest\n---\nRead the channel.\n");
     expect(() => readJobPrompt(job, dir)).toThrow(/needs a `name` and a `description`/);
 
-    await writeFile(join(dir, "digest.md"), "---\nname: d\ndescription: d\n---\n");
+    await writeFile(path, "---\nname: daily-digest\ndescription: d\n---\n");
     expect(() => readJobPrompt(job, dir)).toThrow(/there is no prompt/);
   });
 });

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -96,6 +96,17 @@ describe("nextFire", () => {
     expect(() => nextFire(["0 3 * * 1-"], "UTC", new Date())).toThrow(/not a value or a range/);
     expect(() => nextFire(["0 9-5 * * *"], "UTC", new Date())).toThrow(/counts backwards/);
   });
+
+  it("takes a three-letter name and refuses anything that merely starts like one", () => {
+    // Truncating to three would read `MONSOON` as Monday and schedule an expression nobody
+    // meant. Kubernetes' own parser takes the abbreviations and nothing longer, so one
+    // expression has to mean the same thing to a `run` job and to a `prompt` job.
+    const from = new Date("2026-09-10T13:00:00Z");
+    expect(wall(nextFire(["0 0 * * MON"], "UTC", from), "UTC")).toBe("2026-09-14 00:00:00");
+    for (const bad of ["0 0 * * MONSOON", "0 0 * * MONDAY", "0 0 1 JUNX *", "0 0 * * MO"]) {
+      expect(() => nextFire([bad], "UTC", from), bad).toThrow(/not a value or a range/);
+    }
+  });
 });
 
 const base =

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -1,0 +1,466 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ScheduledTurns,
+  nextFire,
+  readJobPrompt,
+  type ScheduledTurn,
+  type ScheduledTurnsOptions,
+} from "../src/scheduled-turn.ts";
+import { Gateway, type TickOutcome } from "../src/gateway.ts";
+import { MockBrain } from "../src/brain.ts";
+import type { SurfaceAdapter } from "../src/adapter.ts";
+import type { ChannelRef, GuardedMessage, InboundEvent } from "../src/events.ts";
+import { isPromptJob, loadManifest, type PromptJob } from "../src/manifest.ts";
+import { JOB_ARTIFACT_LIMIT_BYTES } from "../src/job-output.ts";
+import type { JobPoster, JobRun } from "../src/job-host.ts";
+import type { SwitchLookup, SwitchSource } from "../src/kill-switch.ts";
+import { combineVerdicts } from "../src/verdict.ts";
+import { jobWorkEvents } from "../src/work-events.ts";
+
+const LA = "America/Los_Angeles";
+
+/** Formatted in the zone under test, because an ISO instant proves nothing about one. */
+const wall = (at: Date | undefined, zone: string) =>
+  at?.toLocaleString("sv-SE", { timeZone: zone });
+
+describe("nextFire", () => {
+  it("answers in the declared zone, not the host's", () => {
+    const at = nextFire(["0 18 * * *"], LA, new Date("2026-09-10T13:00:00Z"));
+    expect(wall(at, LA)).toBe("2026-09-10 18:00:00");
+    expect(at?.toISOString()).toBe("2026-09-11T01:00:00.000Z");
+  });
+
+  it("reads the descriptors, the steps, the names, and the ranges", () => {
+    const from = new Date("2026-09-10T13:07:00Z"); // a Thursday
+    expect(wall(nextFire(["@daily"], "UTC", from), "UTC")).toBe("2026-09-11 00:00:00");
+    expect(wall(nextFire(["*/15 * * * *"], "UTC", from), "UTC")).toBe("2026-09-10 13:15:00");
+    expect(wall(nextFire(["0 9 * * MON-FRI"], "UTC", from), "UTC")).toBe("2026-09-11 09:00:00");
+    expect(wall(nextFire(["0 0 1 JAN *"], "UTC", from), "UTC")).toBe("2027-01-01 00:00:00");
+  });
+
+  it("takes the earliest of several schedules", () => {
+    const from = new Date("2026-09-10T13:00:00Z");
+    expect(wall(nextFire(["0 20 * * *", "0 14 * * *"], "UTC", from), "UTC")).toBe(
+      "2026-09-10 14:00:00",
+    );
+  });
+
+  // Vixie's rule, which Kubernetes' own parser also implements: restrict both day fields
+  // and the expression matches when either does. 2026-09-14 is the first Monday after.
+  it("matches either day field when both are restricted", () => {
+    const from = new Date("2026-09-10T13:00:00Z");
+    expect(wall(nextFire(["0 0 1 * 1"], "UTC", from), "UTC")).toBe("2026-09-14 00:00:00");
+    expect(wall(nextFire(["0 0 1 * *"], "UTC", from), "UTC")).toBe("2026-10-01 00:00:00");
+  });
+
+  it("skips a local time the spring-forward transition deletes", () => {
+    // 2027-03-14 in Los Angeles runs 01:59 → 03:00, so 02:30 is not an instant that day.
+    // A digest scheduled inside the gap is not moved to 03:30; it runs the next day.
+    const at = nextFire(["30 2 * * *"], LA, new Date("2027-03-13T12:00:00Z"));
+    expect(wall(at, LA)).toBe("2027-03-15 02:30:00");
+  });
+
+  it("fires once in the hour the fall-back transition repeats", () => {
+    // 2026-11-01 in Los Angeles runs 01:59 PDT → 01:00 PST, so 01:30 is two real instants.
+    // A daily digest must not be posted twice on one evening.
+    const first = nextFire(["30 1 * * *"], LA, new Date("2026-11-01T00:00:00Z"));
+    expect(first?.toISOString()).toBe("2026-11-01T08:30:00.000Z"); // 01:30 PDT
+    const second = nextFire(["30 1 * * *"], LA, first!);
+    expect(wall(second, LA)).toBe("2026-11-02 01:30:00");
+    expect(second?.toISOString()).not.toBe("2026-11-01T09:30:00.000Z"); // 01:30 PST
+  });
+
+  it("answers `never` for an expression that parses and names no day", () => {
+    expect(nextFire(["30 2 31 2 *"], "UTC", new Date("2026-09-10T13:00:00Z"))).toBeUndefined();
+  });
+
+  it("refuses an expression it cannot parse, rather than never firing", () => {
+    expect(() => nextFire(["0 3 * *"], "UTC", new Date())).toThrow(/five cron fields/);
+    expect(() => nextFire(["0 3 * * 1-"], "UTC", new Date())).toThrow(/not a value or a range/);
+    expect(() => nextFire(["0 9-5 * * *"], "UTC", new Date())).toThrow(/counts backwards/);
+  });
+});
+
+const base =
+  "name: x\nbrain: {provider: mock}\nrespondTo: anyone\nbrains: [{preset: local}]\n" +
+  "killSwitchParkBy: []\n" +
+  "surfaces: [{kind: slack, channels: [{id: C01, name: hive, reply: private}]}]\n";
+
+/** One declared prompt job, through the real schema so every default is the real one. */
+function promptJob(over: Record<string, string> = {}): PromptJob {
+  const declared = {
+    slug: "daily-digest",
+    archetype: "watch",
+    description: "'One short post per day.'",
+    trigger: '{schedules: ["0 18 * * *"], timezone: UTC}',
+    killSwitch: "{failDirection: closed}",
+    prompt: "'Summarize the day.'",
+    report: "{surface: slack, channel: C01}",
+    ...over,
+  };
+  const [job] = loadManifest(
+    `${base}jobs: [{${Object.entries(declared)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(", ")}}]\n`,
+  ).jobs;
+  if (!job || !isPromptJob(job)) throw new Error("this fixture declares no prompt body");
+  return job;
+}
+
+describe("readJobPrompt", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "prompt-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("takes a one-liner inline, verbatim", () => {
+    const prompt = readJobPrompt(promptJob(), dir);
+    expect(prompt).toEqual({ source: "inline", bytes: 18, body: "Summarize the day." });
+  });
+
+  it("sends the body of a file and never its frontmatter", async () => {
+    await writeFile(
+      join(dir, "digest.md"),
+      "---\nname: daily-digest\ndescription: One short post per day.\n---\nRead the channel.\n",
+    );
+    const prompt = readJobPrompt(promptJob({ prompt: "{file: ./digest.md}" }), dir);
+    expect(prompt.body).toBe("Read the channel.");
+    expect(prompt.source).toBe(join(dir, "digest.md"));
+    expect(prompt.bytes).toBeGreaterThan(prompt.body.length);
+  });
+
+  it("refuses a file that is missing, oversized, or not UTF-8", async () => {
+    const job = promptJob({ prompt: "{file: ./digest.md}" });
+    expect(() => readJobPrompt(job, dir)).toThrow(/ENOENT|no such file/i);
+
+    const head = "---\nname: d\ndescription: d\n---\n";
+    await writeFile(join(dir, "digest.md"), head + "x".repeat(JOB_ARTIFACT_LIMIT_BYTES));
+    expect(() => readJobPrompt(job, dir)).toThrow(/over the \d+-byte limit/);
+
+    // A lone 0x80 continuation byte. `readFileSync(…, "utf8")` would hand back U+FFFD and
+    // the agent would post a prompt nobody wrote.
+    await writeFile(join(dir, "digest.md"), Buffer.concat([Buffer.from(head), Buffer.from([0x80])]));
+    expect(() => readJobPrompt(job, dir)).toThrow(/not valid UTF-8/);
+  });
+
+  it("refuses a file that is not shaped like a skill", async () => {
+    const job = promptJob({ prompt: "{file: ./digest.md}" });
+    await writeFile(join(dir, "digest.md"), "Read the channel.\n");
+    expect(() => readJobPrompt(job, dir)).toThrow(/no frontmatter/);
+
+    await writeFile(join(dir, "digest.md"), "---\nname: daily-digest\n---\nRead the channel.\n");
+    expect(() => readJobPrompt(job, dir)).toThrow(/needs a `name` and a `description`/);
+
+    await writeFile(join(dir, "digest.md"), "---\nname: d\ndescription: d\n---\n");
+    expect(() => readJobPrompt(job, dir)).toThrow(/there is no prompt/);
+  });
+});
+
+type Clock = Pick<Gateway, "tick">;
+
+/** A gateway stand-in: the ticker's one seam, so no brain or turn clock is in the way. */
+function fakeGateway(outcome: TickOutcome = { asked: 1, sent: 1 }) {
+  const ticks: { event: InboundEvent; to: { surface: string; channel: string }; timeoutMs?: number }[] = [];
+  const gateway: Clock = {
+    tick: async (event, to, timeoutMs) => {
+      ticks.push({ event, to, timeoutMs });
+      return outcome;
+    },
+  };
+  return { ticks, gateway };
+}
+
+function ticker(
+  job: PromptJob,
+  opts: Pick<ScheduledTurnsOptions, "switchSource" | "post" | "onStart" | "onRun"> & {
+    gateway: Clock;
+  },
+): ScheduledTurns {
+  const turn: ScheduledTurn = {
+    job,
+    prompt: readJobPrompt(job, "/nowhere"),
+    channel: { surface: "slack", id: "C01", isPublic: false, name: "hive" },
+  };
+  return new ScheduledTurns({ ...opts, turns: [turn], turnTimeoutMs: 120_000 });
+}
+
+/** Runs the clock to just past one 18:00 UTC tick and lets the tick settle. */
+async function runOneTick(turns: ScheduledTurns): Promise<void> {
+  vi.setSystemTime(new Date("2026-09-10T17:59:30Z"));
+  turns.start();
+  await vi.advanceTimersByTimeAsync(31_000);
+  await vi.advanceTimersByTimeAsync(0);
+  turns.stop();
+}
+
+const armed: SwitchSource = async () => ({ origin: "set", state: "on", value: "arming" });
+
+describe("ScheduledTurns", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends the prompt as a tick addressed by the clock, and records the run", async () => {
+    const gw = fakeGateway({ asked: 1, sent: 1 });
+    const runs: JobRun[] = [];
+    const started: { jobSlug: string }[] = [];
+    const post = vi.fn<JobPoster>(async () => undefined);
+    await runOneTick(
+      ticker(promptJob(), {
+        gateway: gw.gateway,
+        switchSource: armed,
+        post,
+        onStart: (run) => started.push(run),
+        onRun: (run) => runs.push(run),
+      }),
+    );
+
+    expect(gw.ticks).toHaveLength(1);
+    expect(gw.ticks[0]).toMatchObject({
+      to: { surface: "slack", channel: "C01" },
+      timeoutMs: 120_000,
+      event: {
+        text: "Summarize the day.",
+        mentionsMe: true,
+        // The clock, and an id no surface issues: nothing can be addressed to it, nothing
+        // answers as it, and the author gate has nobody to weigh.
+        author: { id: "schedule:daily-digest", isSelf: false, isAgent: false },
+        channel: { surface: "slack", id: "C01" },
+      },
+    });
+    expect(gw.ticks[0]!.event.threadRoot).toBeUndefined();
+    expect(started.map((run) => run.jobSlug)).toEqual(["daily-digest"]);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ jobSlug: "daily-digest", trigger: "schedule", requestedBy: null });
+    expect(runs[0]!.verdict.status).toBe("PASS");
+    // The sum a reader can check: `JobRun.verdict` is exactly `combineVerdicts(gates)`.
+    expect(runs[0]!.verdict).toEqual(combineVerdicts(runs[0]!.gates));
+    // A turn that spoke has already said everything the channel needed.
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("posts nothing when the turn chose to say nothing", async () => {
+    const runs: JobRun[] = [];
+    const post = vi.fn<JobPoster>(async () => undefined);
+    await runOneTick(
+      ticker(promptJob(), {
+        gateway: fakeGateway({ asked: 0, sent: 0 }).gateway,
+        switchSource: armed,
+        post,
+        onRun: (run) => runs.push(run),
+      }),
+    );
+    expect(runs[0]!.verdict.status).toBe("PASS");
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("says so itself when the turn never finished, and stays quiet when it did", async () => {
+    for (const [outcome, said] of [
+      [{ asked: 0, sent: 0, error: new Error("turn timed out after 120000ms") }, true],
+      [{ asked: 2, sent: 0 }, true],
+      [{ asked: 1, sent: 1 }, false],
+    ] as const) {
+      const post = vi.fn<JobPoster>(async () => undefined);
+      const runs: JobRun[] = [];
+      await runOneTick(
+        ticker(promptJob(), {
+          gateway: fakeGateway(outcome).gateway,
+          switchSource: armed,
+          post,
+          onRun: (run) => runs.push(run),
+        }),
+      );
+      expect(post.mock.calls.length, JSON.stringify(outcome)).toBe(said ? 1 : 0);
+      if (said) expect(post.mock.calls[0]![1]).toContain("job daily-digest");
+    }
+  });
+
+  it("announces a tick that went fine when the job asked to be heard either way", async () => {
+    const post = vi.fn<JobPoster>(async () => undefined);
+    await runOneTick(
+      ticker(promptJob({ report: "{surface: slack, channel: C01, announce: always}" }), {
+        gateway: fakeGateway({ asked: 1, sent: 1 }).gateway,
+        switchSource: armed,
+        post,
+      }),
+    );
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["closed", { origin: "unreadable", failure: "unreachable" } as SwitchLookup],
+    ["open", { origin: "set", state: "off", value: "parking" } as SwitchLookup],
+  ])("skips a tick the switch denies (failDirection %s), and posts nothing", async (direction, lookup) => {
+    const gw = fakeGateway();
+    const runs: JobRun[] = [];
+    const post = vi.fn<JobPoster>(async () => undefined);
+    await runOneTick(
+      ticker(promptJob({ killSwitch: `{failDirection: ${direction}}` }), {
+        gateway: gw.gateway,
+        switchSource: async () => lookup,
+        post,
+        onRun: (run) => runs.push(run),
+      }),
+    );
+    expect(gw.ticks).toHaveLength(0);
+    expect(runs[0]!.outcome).toBe("denied-switch");
+    // Refusing to start a parked job is the posture somebody chose, not news.
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("records a tick the gateway would not start, and posts nothing for it", async () => {
+    const runs: JobRun[] = [];
+    const post = vi.fn<JobPoster>(async () => undefined);
+    await runOneTick(
+      ticker(promptJob(), {
+        gateway: { tick: async () => ({ asked: 0, sent: 0, skipped: "limit:perChannelPerMinute" }) },
+        switchSource: armed,
+        post,
+        onRun: (run) => runs.push(run),
+      }),
+    );
+    expect(runs[0]).toMatchObject({ outcome: "skipped-overlap" });
+    expect(runs[0]!.reason).toContain("limit:perChannelPerMinute");
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("does not replay the ticks that fell while it was not running", async () => {
+    const gw = fakeGateway();
+    const turns = ticker(promptJob(), { gateway: gw.gateway, switchSource: armed });
+    // Two days after the last fire, which is what a restart after an outage looks like.
+    vi.setSystemTime(new Date("2026-09-12T19:00:00Z"));
+    turns.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(gw.ticks).toHaveLength(0);
+    // And then the next one lands on time rather than at once.
+    await vi.advanceTimersByTimeAsync(23 * 60 * 60_000);
+    expect(gw.ticks).toHaveLength(1);
+    turns.stop();
+  });
+
+  it("shortens the turn to a declared budget, and never lengthens it", async () => {
+    for (const [budget, timeoutMs] of [
+      ["{wallClockMs: 30000}", 30_000],
+      ["{wallClockMs: 600000}", 120_000],
+    ] as const) {
+      const gw = fakeGateway();
+      await runOneTick(ticker(promptJob({ budget }), { gateway: gw.gateway, switchSource: armed }));
+      expect(gw.ticks[0]!.timeoutMs, budget).toBe(timeoutMs);
+    }
+  });
+
+  it("writes the same work events a process job's tick writes", async () => {
+    const lines: Record<string, unknown>[] = [];
+    const { onStart, onRun } = jobWorkEvents("demo", { AGENT_WORK_EVENTS: "1" }, (line) =>
+      lines.push(JSON.parse(line).sageox_work_event),
+    );
+    await runOneTick(
+      ticker(promptJob(), {
+        gateway: fakeGateway({ asked: 1, sent: 1 }).gateway,
+        switchSource: armed,
+        onStart,
+        onRun,
+      }),
+    );
+
+    expect(lines.map((line) => line.event)).toEqual(["run.started", "run.completed"]);
+    expect(lines[1]).toMatchObject({
+      schema_version: 1,
+      agent: "demo",
+      job: "daily-digest",
+      trigger: "schedule",
+      outcome: "completed",
+      verdict: "PASS",
+      // The turn is the gate, under the name every other job's host gate carries.
+      checks: [{ gate: "job:daily-digest", executed: true, exit_code: 0, source: "host" }],
+      partial: false,
+    });
+  });
+
+  it("arms nothing after it is stopped", async () => {
+    const gw = fakeGateway();
+    const turns = ticker(promptJob(), { gateway: gw.gateway, switchSource: armed });
+    vi.setSystemTime(new Date("2026-09-10T17:59:30Z"));
+    turns.start();
+    turns.stop();
+    await vi.advanceTimersByTimeAsync(48 * 60 * 60_000);
+    expect(gw.ticks).toHaveLength(0);
+  });
+});
+/**
+ * The whole path, with nothing stubbed between the clock and the surface: the ticker fires,
+ * the gateway runs the turn, and the answer leaves as a top-level post through the guard.
+ */
+describe("a scheduled turn end to end", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("posts what the brain wrote into the channel the job reports to", async () => {
+    const posts: { channel: ChannelRef; msg: GuardedMessage }[] = [];
+    const adapter: SurfaceAdapter = {
+      kind: "slack",
+      start: async () => {},
+      // A tick has no inbound event to thread onto, so the reply path is the wrong one.
+      send: async () => {
+        throw new Error("a scheduled turn must not reply through the inbound path");
+      },
+      postTargets: () => [{ surface: "slack", id: "C01", isPublic: false, name: "hive" }],
+      post: async (channel, msg) => {
+        posts.push({ channel, msg });
+        return { surface: "slack", nativeId: "p1" };
+      },
+      stop: async () => {},
+    };
+    const job = promptJob();
+    const manifest = loadManifest(
+      `${base}jobs: [{slug: daily-digest, archetype: watch, description: 'One post.', ` +
+        `trigger: {schedules: ["0 18 * * *"], timezone: UTC}, killSwitch: {failDirection: closed}, ` +
+        `prompt: 'Summarize the day.', report: {surface: slack, channel: hive}}]\n`,
+    );
+    const gateway = new Gateway({ manifest, adapters: [adapter], brain: new MockBrain() });
+    await gateway.start();
+
+    const runs: JobRun[] = [];
+    const turns = new ScheduledTurns({
+      turns: [
+        {
+          job,
+          prompt: readJobPrompt(job, "/nowhere"),
+          // Declared by name in `report` above and resolved to its id here, which is what
+          // the tick is queued on.
+          channel: { surface: "slack", id: "C01", isPublic: false, name: "hive" },
+        },
+      ],
+      gateway,
+      turnTimeoutMs: manifest.limits.turnTimeoutMs,
+      switchSource: armed,
+      onRun: (run) => runs.push(run),
+    });
+
+    vi.setSystemTime(new Date("2026-09-10T17:59:30Z"));
+    turns.start();
+    await vi.advanceTimersByTimeAsync(31_000);
+    await vi.advanceTimersByTimeAsync(0);
+    turns.stop();
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]!.msg.text).toBe("echo: Summarize the day.");
+    expect(posts[0]!.channel.id).toBe("C01");
+    expect(runs[0]).toMatchObject({ outcome: "completed", trigger: "schedule" });
+    expect(runs[0]!.verdict.status).toBe("PASS");
+  });
+});

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -97,6 +97,16 @@ describe("nextFire", () => {
     expect(() => nextFire(["0 9-5 * * *"], "UTC", new Date())).toThrow(/counts backwards/);
   });
 
+  it("takes a decimal field and refuses every other way to write a number", () => {
+    // `Number` reads all of these, and the Kubernetes parser refuses all of them — so a
+    // `run` job and a `prompt` job carrying one expression would have disagreed.
+    const from = new Date("2026-09-10T13:00:00Z");
+    expect(wall(nextFire(["0 16 * * *"], "UTC", from), "UTC")).toBe("2026-09-10 16:00:00");
+    for (const bad of ["0 0x10 * * *", "0 1e1 * * *", "0 0-0x5 * * *"]) {
+      expect(() => nextFire([bad], "UTC", from), bad).toThrow(/not a value or a range/);
+    }
+  });
+
   it("takes a three-letter name and refuses anything that merely starts like one", () => {
     // Truncating to three would read `MONSOON` as Monday and schedule an expression nobody
     // meant. Kubernetes' own parser takes the abbreviations and nothing longer, so one

--- a/packages/core/test/scheduled-turn.test.ts
+++ b/packages/core/test/scheduled-turn.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -160,6 +161,28 @@ describe("readJobPrompt", () => {
     // the agent would post a prompt nobody wrote.
     await writeFile(join(dir, "digest.md"), Buffer.concat([Buffer.from(head), Buffer.from([0x80])]));
     expect(() => readJobPrompt(job, dir)).toThrow(/not valid UTF-8/);
+  });
+
+  it("refuses a path that is not a regular file, rather than blocking the load on it", async () => {
+    // A FIFO would hang `readFileSync` forever, and the load path this runs on is `run`,
+    // `doctor` and `validate` — a startup that never returns and never says why.
+    const job = promptJob({ prompt: "{file: ./digest.md}" });
+    execFileSync("mkfifo", [join(dir, "digest.md")]);
+    expect(() => readJobPrompt(job, dir)).toThrow(/not a regular file/);
+
+    await rm(join(dir, "digest.md"));
+    await mkdir(join(dir, "digest.md"));
+    expect(() => readJobPrompt(job, dir)).toThrow(/not a regular file|EISDIR/);
+  });
+
+  it("stops reading an oversized file instead of taking the whole of it in", async () => {
+    const job = promptJob({ prompt: "{file: ./digest.md}" });
+    const head = "---\nname: d\ndescription: d\n---\n";
+    // Well past the bound, so a read that allocated the file would be plain in the timing.
+    await writeFile(join(dir, "digest.md"), head + "x".repeat(JOB_ARTIFACT_LIMIT_BYTES * 40));
+    expect(() => readJobPrompt(job, dir)).toThrow(
+      new RegExp(`over the ${JOB_ARTIFACT_LIMIT_BYTES}-byte limit`),
+    );
   });
 
   it("refuses a prompt that is not inside the agent directory", async () => {

--- a/packages/core/test/turn.test.ts
+++ b/packages/core/test/turn.test.ts
@@ -237,4 +237,24 @@ describe("capability status", () => {
     );
     expect(p).not.toContain("TRUSTED CAPABILITY STATUS");
   });
+
+  it("hands a scheduled turn's prompt over as steering, not as fenced data", () => {
+    // The words came off disk, out of the same reviewed bundle the persona above them did.
+    // Fencing them would brief the agent never to obey the one thing it was woken to do.
+    const prompt = "Read the last 24 hours of the status channel and post one line per agent.";
+    const p = assembleTurnPrompt(
+      { ...ev(prompt), author: { surface: "buzz", id: "schedule:daily-digest", isSelf: false, isAgent: false } },
+      { agentName: "inkslinger", persona: "You are inkslinger.", scheduled: true },
+    );
+    expect(p).toContain(prompt);
+    expect(p).not.toContain(UNTRUSTED_OPEN);
+    expect(p).toContain("You are inkslinger.");
+    expect(p).toContain("[scheduled turn · buzz · channel hive · from schedule:daily-digest]");
+  });
+
+  it("fences the same text when it arrived as a message", () => {
+    const prompt = "Read the last 24 hours of the status channel.";
+    const p = assembleTurnPrompt(ev(prompt), { agentName: "inkslinger" });
+    expect(fenced(p)).toContain(prompt);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: ^1.3.0
         version: 1.3.0(zod@4.4.3)
+      croner:
+        specifier: ^10.0.1
+        version: 10.0.1
       yaml:
         specifier: ^2.5.0
         version: 2.9.0
@@ -731,6 +734,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  croner@10.0.1:
+    resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
+    engines: {node: '>=18.0'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1517,6 +1524,8 @@ snapshots:
   chai@6.2.2: {}
 
   convert-source-map@2.0.0: {}
+
+  croner@10.0.1: {}
 
   detect-libc@2.1.2: {}
 


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a08e14-70d9-79bc-964d-067c5bf89b3e">Session</a>
<!-- /sageox:pr-header -->

Closes #75.

Work started in exactly two ways: a **turn**, when a message mentioned the agent, and a
**job**, which spawns a process with no brain, no tool broker, and no second surface. So
nothing could read channel A on surface X, summarize it, and post to channel B on surface
Y — and nothing could happen at 18:00 unless somebody posted a mention at 18:00. Every
workaround put the clock outside the agent, where its kill switch, `suspend`, `doctor` and
work events cannot see it.

A `jobs[]` entry now declares exactly **one** body — `run` for a process in a pod of its
own, or the new `prompt` for a brain turn in the gateway process:

```yaml
jobs:
  - slug: daily-digest
    archetype: watch
    description: Summarize the last 24 hours of the status channel and post it on Slack.
    trigger: { schedules: ["0 18 * * *"], timezone: America/Los_Angeles }
    killSwitch: { failDirection: closed }
    prompt: { file: ./jobs/daily-digest.md }   # or an inline string, for a one-liner
    report: { surface: slack, channel: "C0123456789" }
```

One list rather than the `schedules:` block §10.1 sketched, because the trigger, the
switch, `suspend`, `report` and the work events already live on `jobs[]` — a second block
would be all of them again for the sake of one field.

## What a tick does

```mermaid
flowchart LR
  C["clock<br/>next fire in trigger.timezone"] --> K{"kill switch<br/>then suspend"}
  K -->|refused| R["run record<br/>posts nothing"]
  K -->|admitted| G{"gateway turn caps<br/>queued on the channel"}
  G -->|refused| R
  G -->|admitted| T["ordinary guarded turn<br/>author gate skipped"]
  T --> P["top-level post in report.channel<br/>via SurfaceEgress.post"]
```

The author is `schedule:&lt;slug&gt;`, an id no surface issues — so the author gate is
skipped because there is nobody to weigh, and nothing else about the turn changes: same
brain, same tool policy, same guard, same rate caps, same `turnTimeoutMs`. The reply
clears the same chokepoint the brain's own `post_message` does. An empty reply posts
nothing.

**Provenance is unforgeable.** The prompt comes from the reviewed bundle and nowhere else:
no channel text can start one of these turns, edit its prompt, or claim to be one. It is
also the reason the prompt is handed to the brain as steering rather than inside the
untrusted fence — it has the same provenance as the persona beside it, and fencing it
would brief the agent never to obey the thing it was woken to do.

## Notable decisions

- **The prompt file is skill-shaped** (frontmatter `name` and `description`, then the
  body). Nothing reads those two fields yet; fixing the shape now is what lets the same
  file later be offered to the chat face, so "run the digest now" asked by a person is
  this prompt invoked on request with no second declaration.
- **Ticks are not replayed.** A digest of yesterday posted at 06:00 because that is when
  the pod came back is worse than no digest; the next tick's `run.started` is the record
  that one was missed.
- **DST.** A local time a spring-forward deletes does not run that day; the hour a
  fall-back repeats fires once. Both are tested in a non-UTC zone.
- **`JobConfig` gains optional `run`/`budget`**, so `ProcessJob` and `isProcessJob` narrow
  at the doors that spawn, bound, or deploy a body. `arms()` in `JobHost` is now the
  narrowing door — a prompt job arms no trigger there and is recorded as `denied-trigger`.
- **Refused at load on a prompt job**, each by name: `run`, `worker`, `parameters`,
  `model`, `output`, `report.probe`, `report.history`, `trigger.onRequest`,
  `trigger.webhook`, `report.announce: reported`, and an `@every` descriptor (it names no
  wall-clock time for the zone to resolve). `budget` is optional and can only shorten the
  turn.

## Ops

`doctor` and `validate` list each prompt job with its resolved prompt file, that file's
size, and its next fire time in the declared zone. `job run` refuses one; `job park` still
stops it. Chart **0.14.0** mirrors a prompt job as `{slug, suspend, trigger, prompt: true}`
with no `budget`, and renders no `CronJob` for it — the schema refuses a budget on one, and
`jobs.sh` asserts both.

## Tests

`pnpm test` (1515) and `pnpm typecheck` are green, as are the four chart scripts and
`helm lint --strict`. New coverage: `nextFire` across both DST transitions and the
either-day rule; the prompt reader's four refusals; admission under both fail directions; a
tick queued behind a live turn; the author gate skipped and nothing else; an empty reply
posting nothing; a timed-out turn posting the `unproven` host line; no replay after a
simulated restart; the work events a tick writes; and the whole path end to end with a real
`Gateway`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791685480&installation_model_id=433550&pr_number=77&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F77&signature=2bbeb5add37947a5c63379e5dbb5bed44a8aabf4682dcbbdfddabcd13b203bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled prompt-based jobs using inline text or validated UTF-8 files.
  * Supports timezone-aware scheduling, reporting channels, safety checks, suspension, execution limits, and no replay after downtime.
  * Added validation and diagnostics for prompts, schedules, report targets, and next run times.
  * Prompt jobs support parking and clean shutdown/restart handling.
  * Direct execution of prompt jobs is not supported.

* **Deployment**
  * Helm represents prompt jobs without creating Kubernetes CronJobs.
  * Prevented shared volumes from overwriting agent bundles.
  * Updated the Helm chart to version 0.14.0.

* **Documentation**
  * Added configuration guidance, examples, and job contract details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->