### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-09-11
+
+Everything below shipped after `v0.5.0`.
+
+On publication, `ghcr.io/sageox/agent-base:0.5.1` takes `:latest` and advances `:0.5`. Pin
+the digest recorded on the GitHub Release in production. A patch rather than a minor
+because nothing here asks a running deployment to act: an `agent.yaml` that declares no
+`prompt` job loads and behaves exactly as it did on 0.5.0, so `:0.5` moving forward onto
+this is safe to pick up.
+
+Helm chart 0.14.0 pairs with this release, and only in that direction. A 0.5.0 gateway
+refuses an `agent.yaml` that declares a `prompt` job — `jobs[]` required `run` there and
+rejects unknown keys — so an upgrade that mirrors one in values must take `imageRef` to
+0.5.1 in the same pass.
+
 - **A job's body may be a prompt, so an agent can do light scheduled work only its brain
   can do.** Work started in exactly two ways before this: a turn, when a message mentioned
   the agent, and a job, which spawns a process with no brain, no tool broker, and no second

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -79,11 +79,11 @@ Collect `sageox_work_event` records from those containers' stdout. Child diagnos
 use a separate envelope. External jobs report lifecycle and aggregate results from
 the launching host; their events remain partial because the dispatcher does not
 return individual worker checks or work metadata. See the
-[work event contract](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#structured-work-events-schema-1).
+[work event contract](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/job-contract.md#structured-work-events-schema-1).
 
 Structured job answers need no chart setting: declare `output: {format: json}` in
 the bundle's `agent.yaml`, and use workers built from the same toolkit release as
-the gateway and dispatcher. See [structured answers](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md#structured-answers).
+the gateway and dispatcher. See [structured answers](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/external-jobs.md#structured-answers).
 
 ## Where a bundle comes from
 
@@ -361,6 +361,8 @@ Kubernetes 1.27 or newer.
 A job whose `agent.yaml` body is `prompt:` rather than `run:` renders no `CronJob` either,
 and it is the one kind that renders none while declaring a schedule. Its body is a brain
 turn, held on a clock inside the gateway process, so there is no command for a Pod to run.
+It needs toolkit **0.5.1 or newer** — a 0.5.0 gateway refuses an `agent.yaml` that declares
+one, because `jobs[]` required `run` there.
 Mirror it as `{slug, suspend, trigger, prompt: true}` and state no `budget`; the chart
 refuses one, because nothing here would bound it. It also refuses a `sharedVolumes` claim
 mounted inside `/agents/<name>`: a prompt job's words are read from `skills/<name>/SKILL.md`
@@ -408,7 +410,7 @@ agents:
 
 A body then finds `workspace/repos/<owner>--<repo>` under its working directory, where a run
 started from chat already finds it
-([the job body contract](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/job-contract.md#what-a-body-finds-on-disk)).
+([the job body contract](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/job-contract.md#what-a-body-finds-on-disk)).
 
 Three things this deliberately does not do.
 
@@ -501,7 +503,7 @@ These gateway/scheduled-Pod mount rules apply to local jobs. An external `worker
 instead maps each `run.secrets` and `run.jobSecrets` ref through
 `agents.<agent>.jobs[].worker.secrets`.
 That worker-only credential path supports both requested and scheduled runs, without
-mounting the credential in the gateway. See [external jobs](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md).
+mounting the credential in the gateway. See [external jobs](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/external-jobs.md).
 
 Two consequences worth knowing before you split a local job credential out:
 
@@ -529,4 +531,4 @@ rule that reads as a control and is not.
 
 ## External job workers
 
-For on-demand jobs with their own runtime image, use [the external jobs guide](https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs/external-jobs.md). It covers the worker image, per-job ServiceAccount and Secret mappings, the shared dispatcher, scheduled triggers, durable results and cancellation. The gateway image does not need the task runtime.
+For on-demand jobs with their own runtime image, use [the external jobs guide](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/external-jobs.md). It covers the worker image, per-job ServiceAccount and Secret mappings, the shared dispatcher, scheduled triggers, durable results and cancellation. The gateway image does not need the task runtime.

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -62,7 +62,7 @@ fi
 # linked twice, so a count alone still passes when one of those two is replaced by a copy
 # of another pinned link. Matched at any tag rather than at this release's, so a link left
 # behind on the previous one is reported as the stale link it is.
-release_docs='https://github.com/sageox/agent-toolkit/blob/v0.5.0/docs'
+release_docs='https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs'
 expected=$(printf '%s\n' \
   "$release_docs/external-jobs.md" \
   "$release_docs/external-jobs.md" \

--- a/deploy/helm/values.schema.json
+++ b/deploy/helm/values.schema.json
@@ -122,7 +122,10 @@
           }
         },
         "slug": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
-        "prompt": { "const": true },
+        "prompt": {
+          "const": true,
+          "description": "Mirror a job whose agent.yaml body is `prompt:`. Renders no CronJob — its turn runs on a clock inside the gateway — and states no budget. Requires toolkit 0.5.1 or newer."
+        },
         "suspend": { "type": "boolean" },
         "trigger": {
           "type": "object",

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -36,7 +36,7 @@ networkPolicy:
 # out renders no schedule, and nothing here can tell that apart from an agent with no jobs.
 # A job whose agent.yaml body is `prompt:` is mirrored as `{slug, suspend, trigger,
 # prompt: true}` and no `budget`: its turn runs inside the gateway on a clock the gateway
-# holds, so it renders no CronJob.
+# holds, so it renders no CronJob. Needs toolkit 0.5.1 or newer.
 # Optional agents.<name>.dispatcher.tokenSecret enables external worker dispatch.
 # jobs[].worker supplies a separate serviceAccountName, declared Secret mappings and
 # resources. See docs/external-jobs.md; worker images remain in agent.yaml.


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a092b6-6824-7251-b2df-39012dd7bde0">Session</a>
<!-- /sageox:pr-header -->

Step 1 of the release in [`CONTRIBUTING.md`](CONTRIBUTING.md#releasing): cut the
`## [Unreleased]` heading to `## [0.5.1] - 2026-09-11` and open a fresh one. Tagging
`v0.5.1` on `main` follows this merge.

**Patch, not minor.** `:0.5` should float onto this. The only runtime change since 0.5.0
is the `prompt` job body (#77), and an `agent.yaml` that declares none loads and behaves
exactly as it did — the chat turn's prompt header is byte-identical and nothing else on an
existing path moved. The other unreleased entry is the managed-Kubernetes floor fix, which
was chart-only and already shipped as chart 0.13.1. A minor would freeze `:0.5` and ask
every operator on it to decide about a feature they have not opted into.

**The chart is already bumped.** `Chart.yaml` went to 0.14.0 in #77, so this leaves it
alone. What moves is what the release tag pins: the five `blob/v0.5.0/docs` links in
`deploy/helm/README.md` and the `release_docs` value `jobs.sh` asserts them against.

**One thing the release had to decide.** The chart never said which toolkit a prompt job
needs, because the number was not knowable until now. A 0.5.0 gateway refuses an
`agent.yaml` that declares one — `jobs[]` required `run` there and rejects unknown keys —
so the floor goes where `workEvents` put its own in 0.4.1: the README paragraph that
introduces the mirror, the `values.yaml` comment beside it, and the `values.schema.json`
property an editor validates against.

Green: `pnpm test` (1530), `pnpm typecheck`, and all four `deploy/helm/tests/*.sh`.

Co-Authored-By: [SageOx](https://github.com/SageOx)

SageOx-Session: https://sageox.ai/c/ses_01a092b6-6824-7251-b2df-39012dd7bde0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791760183&installation_model_id=433550&pr_number=79&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F79&signature=a47b2fcefc15e05e9763dbb3061d0ff740c2b79b7c49247a0bc8d0e7ca0341d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm documentation links to toolkit release 0.5.1.
  * Clarified that prompt-based jobs require toolkit version 0.5.1 or newer.
  * Documented prompt job rendering behavior and budget restrictions.
  * Updated deployment guidance to explain compatibility with existing deployments and the coordinated upgrade required for manifests using prompt jobs.

* **Release Notes**
  * Added release information for version 0.5.1, including image and Helm chart updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->