### PR TITLE
Translate a brain's Markdown to mrkdwn on Slack egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **A brain's Markdown renders on Slack, because the adapter now writes Slack's dialect.**
+  A reply left the gateway as the brain wrote it — `SlackAdapter.outboundText` escaped `&`,
+  `<` and `>` and nothing else — so `**Agents logged solid work.**` and
+  `[#305](https://github.example/org/repo/pull/305)` arrived with their asterisks and
+  brackets showing, while the same text read correctly on a Markdown surface. Steering a
+  persona per surface is not a fix: a fleet's reply contract is one prompt shared by every
+  agent, so "write `*bold*` on Slack" cannot be said to one of them, and a contract that
+  requires a Markdown link cannot be excepted at all. The dialect is a fact about the
+  transport, so the transport applies it — `adapter-slack` is the only thing that knows the
+  surface is Slack. On egress `**bold**` and `__bold__` become `*bold*`, `*italic*` becomes
+  `_italic_`, `~~struck~~` becomes `~struck~`, `# Heading` becomes bold, `-` and `*` list
+  markers become `•`, and `[text](url)` becomes `<url|text>`; code spans and fenced blocks
+  are copied untouched, and a bare URL is left bare because Slack links one itself. The
+  pass runs **after** the escape, which is what keeps it safe: by then a `<`, `>` or `&`
+  the brain typed is an entity, and a link is built only around an `http(s):` or `mailto:`
+  URL — so `[page everyone](!channel)` is still text and `<!channel>` still notifies
+  nobody.
+
 ## [0.5.1] - 2026-09-11
 
 Everything below shipped after `v0.5.0`.

--- a/docs/guide/chat-surfaces.md
+++ b/docs/guide/chat-surfaces.md
@@ -262,6 +262,21 @@ It is asked rather than inferred: naming a channel says where the agent should l
 which is not the same as saying it may speak there. Without a terminal, pass
 `--allow-public` — otherwise the public channels are dropped and the command says so.
 
+### Markdown — translated to mrkdwn on the way out
+
+A brain writes Markdown wherever it is: its reply contract is one prompt for every surface
+it answers on. Slack renders *mrkdwn*, which spells emphasis and links differently, so the
+adapter translates on the way out. `**bold**` and `__bold__` become `*bold*`, `*italic*`
+becomes `_italic_`, `~~struck~~` becomes `~struck~`, `# Heading` becomes bold, `-` and `*`
+list markers become `•`, and `[text](url)` becomes Slack's `<url|text>`. Code spans and
+fenced blocks are copied untouched, and a bare URL is left bare — Slack links one itself.
+
+There is nothing to configure and nothing to steer per agent, because the dialect is a fact
+about the transport rather than about the agent. The escape still runs first and still
+holds: a `<`, `>` or `&` the agent typed renders as that character, and a link is built
+only around an `http(s):` or `mailto:` URL — so `[page everyone](!channel)` is text, not a
+broadcast.
+
 ### Leak patterns — the second gate on a public destination
 
 A grant says the agent may speak in a channel. It does not say everything the agent knows

--- a/packages/adapter-slack/src/mrkdwn.ts
+++ b/packages/adapter-slack/src/mrkdwn.ts
@@ -20,12 +20,16 @@ export function toMrkdwn(text: string): string {
   return text
     .split("\n")
     .map((line) => {
-      const rail = FENCE.exec(line)?.[1];
-      if (rail) {
-        // A block closes only on its own character and on a run at least as long as the one
-        // that opened it, so a ```` block quoting ``` stays open and its lines stay verbatim.
+      const fenceLine = FENCE.exec(line);
+      if (fenceLine) {
+        const [, rail, info] = fenceLine;
+        // A block closes only on its own character, on a run at least as long as the one
+        // that opened it, and on nothing else: a ```` block quoting ``` stays open, and so
+        // does one whose code says ```bash, because only an opening fence carries a word.
         if (!fence) fence = rail;
-        else if (rail[0] === fence[0] && rail.length >= fence.length) fence = undefined;
+        else if (rail[0] === fence[0] && rail.length >= fence.length && !info.trim()) {
+          fence = undefined;
+        }
         return line;
       }
       if (fence) return line;
@@ -42,8 +46,8 @@ export function toMrkdwn(text: string): string {
     .join("\n");
 }
 
-/** A fence line, and the run that has to be matched to close it. Slack renders the block. */
-const FENCE = /^[ \t]*(`{3,}|~{3,})/;
+/** A fence line: the run a close has to match, and what follows it on the line. */
+const FENCE = /^[ \t]*(`{3,}|~{3,})(.*)$/;
 
 /** mrkdwn has no heading, so bold is the nearest thing a brain that asked for one gets. */
 const HEADING = /^#{1,6}[ \t]+(.+)$/;
@@ -66,9 +70,11 @@ function inline(line: string): string {
 
 /**
  * Emphasized text is translated in turn, or `**[#305](url)**` would consume the link and
- * send its brackets. That terminates: a delimiter pair is dropped on the way in. A link's
- * label is the exception — it is the one place a nested rule would put a second `<…>`
- * inside the one being built.
+ * send its brackets. That terminates: a delimiter pair is dropped on the way in.
+ *
+ * A label is translated too — Slack renders mrkdwn inside one — and cannot smuggle a second
+ * `<…>` into the link being built around it: the link rule needs a `]`, and a label is
+ * matched by a class that excludes one.
  */
 function translate(text: string): string {
   /**
@@ -96,7 +102,7 @@ function translate(text: string): string {
       strike: string,
       italic: string,
     ) => {
-      if (url) return `<${url}|${label}>`;
+      if (url) return `<${url}|${translate(label)}>`;
       if (bold) return `*${translate(bold)}*`;
       if (strike) return `~${translate(strike)}~`;
       return `_${translate(italic)}_`;

--- a/packages/adapter-slack/src/mrkdwn.ts
+++ b/packages/adapter-slack/src/mrkdwn.ts
@@ -1,0 +1,97 @@
+/**
+ * A brain's Markdown, written as Slack's mrkdwn.
+ *
+ * A brain writes Markdown whatever surface it is on — its reply contract is one prompt for
+ * all of them — and Slack renders mrkdwn, so `**bold**` and `[#305](url)` arrive with their
+ * punctuation showing. Steering a persona per surface does not fix that: the dialect is a
+ * fact about the transport, and this adapter is the only thing that knows the surface is
+ * Slack.
+ *
+ * Runs after the escape in `SlackAdapter.outboundText`, which is what makes the link rule
+ * safe. By then the brain's own `<`, `>` and `&` are entities, so the `<url|text>` built
+ * here is the only live markup that reaches the wire — and it is built only around an
+ * `http(s):` or `mailto:` URL, so `[boom](!channel)` stays text and cannot become a
+ * broadcast.
+ *
+ * A bare URL is left alone; Slack links it without help.
+ */
+export function toMrkdwn(text: string): string {
+  let fenced = false;
+  return text
+    .split("\n")
+    .map((line) => {
+      if (FENCE.test(line)) {
+        fenced = !fenced;
+        return line;
+      }
+      if (fenced) return line;
+      const heading = HEADING.exec(line);
+      if (heading) {
+        const title = inline(heading[1]).trimEnd();
+        // `## **Summary**` is bold already; wrapping it again leaves a stray `*` each side.
+        return title.startsWith("*") && title.endsWith("*") ? title : `*${title}*`;
+      }
+      return inline(line.replace(BULLET, "$1• "));
+    })
+    .join("\n");
+}
+
+/** A fence line — the same pattern opens a block and closes it. Slack renders the block. */
+const FENCE = /^[ \t]*```/;
+
+/** Kept whole by the `split` in {@link inline}, so no rule reaches inside a code span either. */
+const CODE_SPAN = /(`[^`]*`)/;
+
+/** mrkdwn has no heading, so bold is the nearest thing a brain that asked for one gets. */
+const HEADING = /^#{1,6}[ \t]+(.+)$/;
+
+/** The space is required: `---` stays a rule and `**bold**` at a line start stays bold. */
+const BULLET = /^([ \t]*)[-*][ \t]+/;
+
+/** The rules, applied to the parts of a line that are not a code span. */
+function inline(line: string): string {
+  return line
+    .split(CODE_SPAN)
+    .map((part, index) => (index % 2 ? part : translate(part)))
+    .join("");
+}
+
+/**
+ * Emphasized text is translated in turn, or `**[#305](url)**` would consume the link and
+ * send its brackets. That terminates: a delimiter pair is dropped on the way in. A link's
+ * label is the exception — it is the one place a nested rule would put a second `<…>`
+ * inside the one being built.
+ */
+function translate(text: string): string {
+  /**
+   * Every inline rule in one alternation, so no rule reads another's output — applied in
+   * sequence, `**a**` becomes `*a*` and the next rule turns that into `_a_`. Declared here
+   * rather than beside the rules above because the replacer re-enters this function, and a
+   * `lastIndex` shared across those calls is a thing nobody should have to reason about.
+   *
+   * Both bold spellings are one alternative closed by a backreference, so `**a__` is not
+   * one. Markdown and mrkdwn spell italic `_text_` alike, so that needs no rule; the
+   * `*text*` spelling does, and its flanks exclude whitespace so `run *.ts` and `2 * 3`
+   * are not read as emphasis.
+   */
+  const inlineRules =
+    /\[([^\]\n]+)\]\(((?:https?:\/\/|mailto:)[^\s<>|()]+)\)|(\*\*|__)(.+?)\3|~~(.+?)~~|\*([^*\s][^*]*[^*\s]|[^*\s])\*/g;
+
+  return text.replace(
+    inlineRules,
+    (
+      _whole: string,
+      label: string,
+      url: string,
+      _delimiter: string,
+      bold: string,
+      strike: string,
+      italic: string,
+    ) => {
+      if (url) return `<${url}|${label}>`;
+      if (bold) return `*${translate(bold)}*`;
+      if (strike) return `~${translate(strike)}~`;
+      return `_${translate(italic)}_`;
+    },
+  );
+}

--- a/packages/adapter-slack/src/mrkdwn.ts
+++ b/packages/adapter-slack/src/mrkdwn.ts
@@ -16,31 +16,34 @@
  * A bare URL is left alone; Slack links it without help.
  */
 export function toMrkdwn(text: string): string {
-  let fenced = false;
+  let fence: string | undefined;
   return text
     .split("\n")
     .map((line) => {
-      if (FENCE.test(line)) {
-        fenced = !fenced;
+      const rail = FENCE.exec(line)?.[1];
+      if (rail) {
+        // A block closes only on its own character and on a run at least as long as the one
+        // that opened it, so a ```` block quoting ``` stays open and its lines stay verbatim.
+        if (!fence) fence = rail;
+        else if (rail[0] === fence[0] && rail.length >= fence.length) fence = undefined;
         return line;
       }
-      if (fenced) return line;
+      if (fence) return line;
       const heading = HEADING.exec(line);
       if (heading) {
         const title = inline(heading[1]).trimEnd();
-        // `## **Summary**` is bold already; wrapping it again leaves a stray `*` each side.
-        return title.startsWith("*") && title.endsWith("*") ? title : `*${title}*`;
+        // mrkdwn has no bold inside bold. A heading already carrying a `*` — its own
+        // emphasis, or one no rule claimed — keeps it rather than being wrapped in a span
+        // that `*` would leave unbalanced.
+        return title.includes("*") ? title : `*${title}*`;
       }
       return inline(line.replace(BULLET, "$1• "));
     })
     .join("\n");
 }
 
-/** A fence line — the same pattern opens a block and closes it. Slack renders the block. */
-const FENCE = /^[ \t]*```/;
-
-/** Kept whole by the `split` in {@link inline}, so no rule reaches inside a code span either. */
-const CODE_SPAN = /(`[^`]*`)/;
+/** A fence line, and the run that has to be matched to close it. Slack renders the block. */
+const FENCE = /^[ \t]*(`{3,}|~{3,})/;
 
 /** mrkdwn has no heading, so bold is the nearest thing a brain that asked for one gets. */
 const HEADING = /^#{1,6}[ \t]+(.+)$/;
@@ -48,12 +51,17 @@ const HEADING = /^#{1,6}[ \t]+(.+)$/;
 /** The space is required: `---` stays a rule and `**bold**` at a line start stays bold. */
 const BULLET = /^([ \t]*)[-*][ \t]+/;
 
+/**
+ * A code span closes on a backtick run as long as the one that opened it, so the doubled
+ * backticks a brain uses to quote a backtick are one span and not two empty ones with
+ * translated text between them. A run that never closes is copied like one that did, and
+ * the text around it is still translated.
+ */
+const SEGMENT = /(`+).*?\1|[^`]+|`+/g;
+
 /** The rules, applied to the parts of a line that are not a code span. */
 function inline(line: string): string {
-  return line
-    .split(CODE_SPAN)
-    .map((part, index) => (index % 2 ? part : translate(part)))
-    .join("");
+  return line.replace(SEGMENT, (part) => (part.startsWith("`") ? part : translate(part)));
 }
 
 /**

--- a/packages/adapter-slack/src/slack.ts
+++ b/packages/adapter-slack/src/slack.ts
@@ -21,6 +21,7 @@ import {
   toSlackInboundEvent,
   type SlackMessage,
 } from "./normalize.ts";
+import { toMrkdwn } from "./mrkdwn.ts";
 
 export interface SlackSocketClient {
   on(event: string, listener: (payload: unknown) => void): unknown;
@@ -1023,7 +1024,9 @@ export class SlackAdapter implements SurfaceAdapter {
    * those characters — `normalizeSlackText` un-escapes the `&lt;!channel&gt;` Slack sent —
    * so quoting either form is an answer and one `egress_escaped` line, not a dead turn.
    *
-   * `&` is replaced first, or it escapes the ampersands the other two introduce.
+   * `&` is replaced first, or it escapes the ampersands the other two introduce, and
+   * {@link toMrkdwn} runs after all three — so the `<url|text>` it builds from a Markdown
+   * link is the only live markup on the wire, and prose cannot reach one.
    */
   private outboundText(msg: GuardedMessage, channel: string): string {
     if (/<!\s*(?:channel|here|everyone)(?:\^[^>]*)?>/i.test(msg.text)) {
@@ -1032,7 +1035,11 @@ export class SlackAdapter implements SurfaceAdapter {
           `reason="the text carried a broadcast, escaped to characters that notify nobody"`,
       );
     }
-    return msg.text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    const escaped = msg.text
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;");
+    return toMrkdwn(escaped);
   }
 
 }

--- a/packages/adapter-slack/test/mrkdwn.test.ts
+++ b/packages/adapter-slack/test/mrkdwn.test.ts
@@ -53,6 +53,9 @@ describe("Markdown to mrkdwn", () => {
     expect(toMrkdwn("```ts\nsee ```bash\n- literal\n```\nthen **bold**")).toBe(
       "```ts\nsee ```bash\n- literal\n```\nthen *bold*",
     );
+    // Code outranks every other rule, including the link one: a span inside a label is
+    // copied, which costs that link its translation and keeps the guarantee one sentence.
+    expect(toMrkdwn("[`--flag`](https://x.test/a)")).toBe("[`--flag`](https://x.test/a)");
   });
 
   it("builds a link only around a URL, so escaped markup cannot become live again", () => {

--- a/packages/adapter-slack/test/mrkdwn.test.ts
+++ b/packages/adapter-slack/test/mrkdwn.test.ts
@@ -16,8 +16,10 @@ describe("Markdown to mrkdwn", () => {
     expect(toMrkdwn("([#305](https://github.test/org/repo/pull/305)) landed")).toBe(
       "(<https://github.test/org/repo/pull/305|#305>) landed",
     );
-    // The link inside is translated, not swallowed by the emphasis around it.
+    // The link inside is translated, not swallowed by the emphasis around it — and Slack
+    // renders mrkdwn inside a label, so emphasis there is translated rather than shown.
     expect(toMrkdwn("**[#305](https://github.test/a)**")).toBe("*<https://github.test/a|#305>*");
+    expect(toMrkdwn("[**#305**](https://github.test/a)")).toBe("<https://github.test/a|*#305*>");
   });
 
   it("leaves alone the punctuation that is not markup", () => {
@@ -46,6 +48,11 @@ describe("Markdown to mrkdwn", () => {
     expect(toMrkdwn("````\n```\n**a**\n```\n````\nthen **bold**")).toBe(
       "````\n```\n**a**\n```\n````\nthen *bold*",
     );
+    // Only an opening fence carries a word after the run, so a block whose code says
+    // ```bash stays open — and closing on it would read the rest of the message inverted.
+    expect(toMrkdwn("```ts\nsee ```bash\n- literal\n```\nthen **bold**")).toBe(
+      "```ts\nsee ```bash\n- literal\n```\nthen *bold*",
+    );
   });
 
   it("builds a link only around a URL, so escaped markup cannot become live again", () => {
@@ -54,7 +61,8 @@ describe("Markdown to mrkdwn", () => {
     // The one rule that emits `<` needs an http(s) or mailto URL, which these are not.
     expect(toMrkdwn("[boom](!channel)")).toBe("[boom](!channel)");
     expect(toMrkdwn("[boom](javascript:alert(1))")).toBe("[boom](javascript:alert(1))");
-    // A label is markup to nobody: it arrives escaped and is copied, never translated.
+    // A label is translated, but the rule that emits `<` needs a `]` and a label may not
+    // contain one — so no label can put a second `<…>` inside the link built around it.
     expect(toMrkdwn("[&lt;!channel&gt;](https://x.test/a)")).toBe(
       "<https://x.test/a|&lt;!channel&gt;>",
     );

--- a/packages/adapter-slack/test/mrkdwn.test.ts
+++ b/packages/adapter-slack/test/mrkdwn.test.ts
@@ -7,8 +7,11 @@ describe("Markdown to mrkdwn", () => {
       "*bold* and *bold* and _italic_ and _italic_ and ~struck~",
     );
     expect(toMrkdwn("# Deploy report")).toBe("*Deploy report*");
-    // A heading is bold, and one written bold is not bold twice.
+    // A heading is bold, and one written bold is not bold twice. mrkdwn has no bold inside
+    // bold, so a heading that emphasizes only part of itself keeps that rather than being
+    // wrapped in a span the inner `*` would leave unbalanced.
     expect(toMrkdwn("### **Summary**")).toBe("*Summary*");
+    expect(toMrkdwn("## **Summary** today")).toBe("*Summary* today");
     expect(toMrkdwn("- one\n* two\n  - nested")).toBe("• one\n• two\n  • nested");
     expect(toMrkdwn("([#305](https://github.test/org/repo/pull/305)) landed")).toBe(
       "(<https://github.test/org/repo/pull/305|#305>) landed",
@@ -32,6 +35,16 @@ describe("Markdown to mrkdwn", () => {
     expect(toMrkdwn("`**kwargs` beside **bold**")).toBe("`**kwargs` beside *bold*");
     expect(toMrkdwn("```ts\nconst x = **a**;\n- not a bullet\n```\nthen **bold**")).toBe(
       "```ts\nconst x = **a**;\n- not a bullet\n```\nthen *bold*",
+    );
+    // A span closes on a run as long as the one that opened it, or the two backticks a
+    // brain used to quote a backtick would read as one empty span and expose what follows.
+    expect(toMrkdwn("``**a**`` beside **bold**")).toBe("``**a**`` beside *bold*");
+    // The same rule for a block: `~~~` fences, and a ```` block quoting ``` stays open.
+    expect(toMrkdwn("~~~\n**a**\n- not a bullet\n~~~\nthen **bold**")).toBe(
+      "~~~\n**a**\n- not a bullet\n~~~\nthen *bold*",
+    );
+    expect(toMrkdwn("````\n```\n**a**\n```\n````\nthen **bold**")).toBe(
+      "````\n```\n**a**\n```\n````\nthen *bold*",
     );
   });
 

--- a/packages/adapter-slack/test/mrkdwn.test.ts
+++ b/packages/adapter-slack/test/mrkdwn.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { toMrkdwn } from "../src/mrkdwn.ts";
+
+describe("Markdown to mrkdwn", () => {
+  it("writes the emphasis, headings, lists and links a brain wrote as Slack spells them", () => {
+    expect(toMrkdwn("**bold** and __bold__ and *italic* and _italic_ and ~~struck~~")).toBe(
+      "*bold* and *bold* and _italic_ and _italic_ and ~struck~",
+    );
+    expect(toMrkdwn("# Deploy report")).toBe("*Deploy report*");
+    // A heading is bold, and one written bold is not bold twice.
+    expect(toMrkdwn("### **Summary**")).toBe("*Summary*");
+    expect(toMrkdwn("- one\n* two\n  - nested")).toBe("• one\n• two\n  • nested");
+    expect(toMrkdwn("([#305](https://github.test/org/repo/pull/305)) landed")).toBe(
+      "(<https://github.test/org/repo/pull/305|#305>) landed",
+    );
+    // The link inside is translated, not swallowed by the emphasis around it.
+    expect(toMrkdwn("**[#305](https://github.test/a)**")).toBe("*<https://github.test/a|#305>*");
+  });
+
+  it("leaves alone the punctuation that is not markup", () => {
+    // Slack links a bare URL itself, so wrapping one would only add markup to remove later.
+    expect(toMrkdwn("see https://x.test/a?b=1 for the run")).toBe("see https://x.test/a?b=1 for the run");
+    // Emphasis flanks a word, so a glob, an arithmetic line and a rule are none of it.
+    expect(toMrkdwn("run *.ts and *.js")).toBe("run *.ts and *.js");
+    expect(toMrkdwn("2 * 3 * 4")).toBe("2 * 3 * 4");
+    expect(toMrkdwn("---")).toBe("---");
+    // A list marker needs the space that follows it, which a dash mid-line does not have.
+    expect(toMrkdwn("`--flag` - what it does")).toBe("`--flag` - what it does");
+  });
+
+  it("translates nothing inside a code span or a fenced block", () => {
+    expect(toMrkdwn("`**kwargs` beside **bold**")).toBe("`**kwargs` beside *bold*");
+    expect(toMrkdwn("```ts\nconst x = **a**;\n- not a bullet\n```\nthen **bold**")).toBe(
+      "```ts\nconst x = **a**;\n- not a bullet\n```\nthen *bold*",
+    );
+  });
+
+  it("builds a link only around a URL, so escaped markup cannot become live again", () => {
+    // The escape runs first, so a broadcast reaches this as characters — and stays them.
+    expect(toMrkdwn("&lt;!channel&gt; deploy now")).toBe("&lt;!channel&gt; deploy now");
+    // The one rule that emits `<` needs an http(s) or mailto URL, which these are not.
+    expect(toMrkdwn("[boom](!channel)")).toBe("[boom](!channel)");
+    expect(toMrkdwn("[boom](javascript:alert(1))")).toBe("[boom](javascript:alert(1))");
+    // A label is markup to nobody: it arrives escaped and is copied, never translated.
+    expect(toMrkdwn("[&lt;!channel&gt;](https://x.test/a)")).toBe(
+      "<https://x.test/a|&lt;!channel&gt;>",
+    );
+    // `|` is what separates the two halves, so a URL carrying one is left as it was written.
+    expect(toMrkdwn("[a](https://x.test/a|https://evil.test)")).toBe(
+      "[a](https://x.test/a|https://evil.test)",
+    );
+  });
+});

--- a/packages/adapter-slack/test/slack.test.ts
+++ b/packages/adapter-slack/test/slack.test.ts
@@ -387,6 +387,30 @@ describe("SlackAdapter", () => {
     expect(api.posts[1].text).toBe("<@U0DRONE> who is &lt;@U0ALICE&gt;?");
   });
 
+  it("writes the brain's Markdown as mrkdwn, after the escape and on both outbound paths", async () => {
+    const { instance, socket, api } = adapter();
+    const got: InboundEvent[] = [];
+    await instance.start((event) => got.push(event));
+    await socket.emit(mention());
+
+    // A brain writes Markdown on every surface — one reply contract, one prompt — and the
+    // adapter is what knows this one renders mrkdwn. The escape still runs first, so the
+    // `<…>` around the link is the only live markup that reached the wire.
+    await instance.send(
+      got[0].channel,
+      { text: "**Done.** See [#305](https://github.test/org/repo/pull/305), thanks <@U0ALICE>" },
+      got[0],
+    );
+    expect(api.posts[0].text).toBe(
+      "*Done.* See <https://github.test/org/repo/pull/305|#305>, thanks &lt;@U0ALICE&gt;",
+    );
+
+    // The recipients `post` builds are not text a brain wrote, and are untouched by both.
+    const channel = { surface: "slack", id: "GENG", isPublic: false } as const;
+    await instance.post(channel, { text: "- **shipped**" }, undefined, ["U0DRONE"]);
+    expect(api.posts[1].text).toBe("<@U0DRONE> • *shipped*");
+  });
+
   it("names the members a message mentions, and asks Slack about each one once", async () => {
     const { instance, socket, api } = adapter();
     const got: InboundEvent[] = [];


### PR DESCRIPTION
Closes #83.

## What was needed

A reply left the gateway exactly as the brain wrote it — `SlackAdapter.outboundText` escaped `&`, `<` and `>` and nothing else. Brains write Markdown and Slack renders mrkdwn, so `**Agents logged solid work.**` and `[#305](https://github.example/org/repo/pull/305)` arrived with their asterisks and brackets showing, while the same text read correctly on a Markdown surface.

Steering a persona per surface is not a fix. A fleet's reply contract is one prompt shared by every agent — held byte-identical by a gate — so "write `*bold*` on Slack" cannot be said to one of them, and a contract that requires a Markdown link cannot be excepted at all. The dialect is a fact about the transport, so the transport applies it: `adapter-slack` is the only thing that knows the surface is Slack.

## What the change ships

`packages/adapter-slack/src/mrkdwn.ts` — one exported `toMrkdwn(text)`, called from `outboundText`, so both outbound paths (`send` and `post`) go through it.

| Markdown | mrkdwn |
|---|---|
| `**bold**`, `__bold__` | `*bold*` |
| `*italic*` | `_italic_` (`_italic_` already matches) |
| `~~struck~~` | `~struck~` |
| `# Heading` | `*Heading*` |
| `- item`, `* item` | `• item` |
| `[text](url)` | `<url\|text>` |

Code spans and fenced blocks are copied untouched, and a bare URL is left bare — Slack links one itself.

Three things about the shape:

- **Line by line**, so a fenced block is copied whole; each remaining line is split on its code spans, so no rule reaches inside one.
- **Every inline rule is one alternation**, not a pass each — run in sequence, `**a**` becomes `*a*` and the next rule turns that into `_a_`.
- **Emphasized text is translated in turn**, or `**[#305](url)**` would consume the link and send its brackets. A link's *label* is the exception: it is the one place a nested rule would put a second `<…>` inside the one being built.

## Why it is safe

It runs **after** the escape. By then a `<`, `>` or `&` the brain typed is an entity, so the `<url|text>` this builds is the only live markup that reaches the wire — and it is built only around an `http(s):` or `mailto:` URL. `[page everyone](!channel)` stays text, `<!channel>` still renders as characters that notify nobody, and the `egress_escaped … rule=slackBroadcast` line is unchanged. A `|` in the URL half would split the two halves, so such a link is left as the brain wrote it rather than mis-rendered.

## How I verified it

- `packages/adapter-slack/test/mrkdwn.test.ts` — the rules; the punctuation that is *not* markup (`run *.ts`, `2 * 3`, `---`, `` `--flag` - what it does ``); code spans and fences; and the safety cases (`&lt;!channel&gt;`, `[boom](!channel)`, `[boom](javascript:alert(1))`, an escaped broadcast as a link label, a `|` in the URL).
- `packages/adapter-slack/test/slack.test.ts` — one test over the real adapter proving both `send` and `post` translate, that the escape composes (`<@U0ALICE>` → `&lt;@U0ALICE&gt;`), and that the `<@U0DRONE>` prefix `post` builds stays live markup. It fails without the `outboundText` change.
- `pnpm typecheck` green. `pnpm test` green except the known `adapter-buzz` full-run flake (`hears a live mention in every channel it serves`), which passes on its own re-run and is untouched here.
- Docs: a new "Markdown — translated to mrkdwn on the way out" section in `docs/guide/chat-surfaces.md`, and a `CHANGELOG.md` entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

SageOx-Session: https://sageox.ai/c/ses_01a09390-5acf-7b71-91d2-9a433d8f360e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791774986&installation_model_id=433550&pr_number=84&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F84&signature=eb41e2e9ae6431aeb36171659decf1e77ded884aba646ac411c749c714757417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slack messages now render supported Markdown formatting, including headings, lists, bold, strikethrough, emphasis, links, and code.
  - HTTP(S) and mailto links are safely converted to Slack link formatting; unsupported targets and bare URLs remain unchanged.
  - Special characters are safely escaped, and broadcast mentions remain escaped rather than triggering notifications.

- **Documentation**
  - Added guidance covering Slack Markdown conversion, code preservation, URL handling, escaping, and link safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->