### PR TITLE
Prepare v0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-09-11
+
+Everything below shipped after `v0.5.1`.
+
+On publication, `ghcr.io/sageox/agent-base:0.5.2` takes `:latest` and advances `:0.5`. Pin
+the digest recorded on the GitHub Release in production. A patch rather than a minor
+because nothing about configuration moved: no manifest field, no chart setting, and no
+chart version — `deploy/helm` renders on 0.14.0 exactly as it did.
+
+**Every Slack reply reads differently, and there is nothing to turn on.** Emphasis,
+headings, list markers and links render now rather than arriving with their punctuation
+showing. The one thing to check before upgrading is an agent whose prompt was steered to
+write Slack's dialect itself: `*bold*` is Markdown for italic, so that steering now
+produces `_bold_`. Drop it; the adapter translates for every agent. Only `adapter-slack`
+changed, so Buzz and console egress is byte-identical.
+
 - **A brain's Markdown renders on Slack, because the adapter now writes Slack's dialect.**
   A reply left the gateway as the brain wrote it — `SlackAdapter.outboundText` escaped `&`,
   `<` and `>` and nothing else — so `**Agents logged solid work.**` and

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -79,11 +79,11 @@ Collect `sageox_work_event` records from those containers' stdout. Child diagnos
 use a separate envelope. External jobs report lifecycle and aggregate results from
 the launching host; their events remain partial because the dispatcher does not
 return individual worker checks or work metadata. See the
-[work event contract](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/job-contract.md#structured-work-events-schema-1).
+[work event contract](https://github.com/sageox/agent-toolkit/blob/v0.5.2/docs/job-contract.md#structured-work-events-schema-1).
 
 Structured job answers need no chart setting: declare `output: {format: json}` in
 the bundle's `agent.yaml`, and use workers built from the same toolkit release as
-the gateway and dispatcher. See [structured answers](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/external-jobs.md#structured-answers).
+the gateway and dispatcher. See [structured answers](https://github.com/sageox/agent-toolkit/blob/v0.5.2/docs/external-jobs.md#structured-answers).
 
 ## Where a bundle comes from
 
@@ -410,7 +410,7 @@ agents:
 
 A body then finds `workspace/repos/<owner>--<repo>` under its working directory, where a run
 started from chat already finds it
-([the job body contract](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/job-contract.md#what-a-body-finds-on-disk)).
+([the job body contract](https://github.com/sageox/agent-toolkit/blob/v0.5.2/docs/job-contract.md#what-a-body-finds-on-disk)).
 
 Three things this deliberately does not do.
 
@@ -503,7 +503,7 @@ These gateway/scheduled-Pod mount rules apply to local jobs. An external `worker
 instead maps each `run.secrets` and `run.jobSecrets` ref through
 `agents.<agent>.jobs[].worker.secrets`.
 That worker-only credential path supports both requested and scheduled runs, without
-mounting the credential in the gateway. See [external jobs](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/external-jobs.md).
+mounting the credential in the gateway. See [external jobs](https://github.com/sageox/agent-toolkit/blob/v0.5.2/docs/external-jobs.md).
 
 Two consequences worth knowing before you split a local job credential out:
 
@@ -531,4 +531,4 @@ rule that reads as a control and is not.
 
 ## External job workers
 
-For on-demand jobs with their own runtime image, use [the external jobs guide](https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs/external-jobs.md). It covers the worker image, per-job ServiceAccount and Secret mappings, the shared dispatcher, scheduled triggers, durable results and cancellation. The gateway image does not need the task runtime.
+For on-demand jobs with their own runtime image, use [the external jobs guide](https://github.com/sageox/agent-toolkit/blob/v0.5.2/docs/external-jobs.md). It covers the worker image, per-job ServiceAccount and Secret mappings, the shared dispatcher, scheduled triggers, durable results and cancellation. The gateway image does not need the task runtime.

--- a/deploy/helm/tests/jobs.sh
+++ b/deploy/helm/tests/jobs.sh
@@ -62,7 +62,7 @@ fi
 # linked twice, so a count alone still passes when one of those two is replaced by a copy
 # of another pinned link. Matched at any tag rather than at this release's, so a link left
 # behind on the previous one is reported as the stale link it is.
-release_docs='https://github.com/sageox/agent-toolkit/blob/v0.5.1/docs'
+release_docs='https://github.com/sageox/agent-toolkit/blob/v0.5.2/docs'
 expected=$(printf '%s\n' \
   "$release_docs/external-jobs.md" \
   "$release_docs/external-jobs.md" \


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0944f-1c6f-780a-8f04-ad1e6ab9f1e1">Session</a>
<!-- /sageox:pr-header -->

Step 1 of the release in [`CONTRIBUTING.md`](CONTRIBUTING.md#releasing): cut the
`## [Unreleased]` heading to `## [0.5.2] - 2026-09-11` and open a fresh one. Tagging
`v0.5.2` on `main` follows this merge.

**Patch, not minor.** `:0.5` should float onto this. Nothing about configuration moved —
no manifest field, no chart setting, and no chart version, because nothing under `deploy/`
changed since `v0.5.1`. `Chart.yaml` stays at 0.14.0. The one runtime change is the
Markdown→mrkdwn egress pass in `adapter-slack` (#84).

**The one thing that does ask an operator to act**, said in the changelog header rather
than left to be discovered: an agent whose prompt was steered to write Slack's dialect
itself now gets `_bold_` where it wrote `*bold*`, because `*x*` is Markdown for italic.
That is cosmetic, on one surface, and the steering is exactly what this release makes
unnecessary — not grounds to freeze `:0.5` and ask every operator on it to decide about a
fix they want unconditionally.

**What moves is what the release tag pins:** the five `blob/v0.5.1/docs` links in
`deploy/helm/README.md` and the `release_docs` value `jobs.sh` asserts them against. The
three `0.5.1` mentions left in `deploy/` (`README.md:364`, `values.yaml:39`,
`values.schema.json:127`) are the prompt-job floor rather than the current release, and
stay. This release adds no chart setting, so unlike 0.4.1 and 0.5.1 there is no new
"requires toolkit X or newer" note to write.

Green: `pnpm typecheck`, `pnpm test` (73 files, 1535 tests), and all four
`deploy/helm/tests/*.sh`.

SageOx-Session: https://sageox.ai/c/ses_01a0944f-1c6f-780a-8f04-ad1e6ab9f1e1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791787655&installation_model_id=433550&pr_number=85&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F85&signature=d5af1e76d1eb2c8dcbbc8be43a4d8a3d9aa7564d40d5bbc85fa5d2ad63dadfa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 0.5.2, including image tag updates, configuration and Helm chart compatibility, and Slack Markdown formatting behavior.
  - Updated Helm documentation links and validation references to version 0.5.2.
  - Documented that changes apply only to the Slack adapter; Buzz and console output remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->