### PR TITLE
Pin the manifest gate to a digest, not a floating tag

### DIFF
--- a/docs/deployment-contract.md
+++ b/docs/deployment-contract.md
@@ -29,9 +29,10 @@ them in CI. The runtime image is the entry point, and its `validate` is the same
 repository's `./bin/sageox-agent validate` runs:
 
 ```bash
-# The same tag the deployment runs: the gate is only worth having if it holds the schema
-# the runtime about to load this file holds.
-docker run --rm -v "$PWD:/w" ghcr.io/sageox/agent-base:0.4 validate /w/agent.yaml
+# The same image the deployment runs: the gate is only worth having if it holds the schema
+# the runtime about to load this file holds. That is the digest the deployment pins, not a
+# floating tag — a patch advances the tag and may add schema the deployment still refuses.
+docker run --rm -v "$PWD:/w" ghcr.io/sageox/agent-base@sha256:<digest> validate /w/agent.yaml
 ```
 
 Two properties make this worth a CI step rather than a later `doctor` run:


### PR DESCRIPTION
<!-- sageox:pr-header v2 -->
> guided&nbsp;by&nbsp;<picture><source media="(prefers-color-scheme: dark)" srcset="https://sageox.ai/sageox-wordmark-dark.png"><img alt="SageOx" height="16" src="https://sageox.ai/sageox-wordmark-light.png"></picture>&nbsp;&middot;&nbsp;<a href="https://sageox.ai/c/ses_01a0944f-1c6f-780a-8f04-ad1e6ab9f1e1">Session</a>
<!-- /sageox:pr-header -->

The `validate` example in the deployment contract told a consumer to gate `agent.yaml` on
`ghcr.io/sageox/agent-base:0.4`, under a comment demanding *"the same tag the deployment
runs: the gate is only worth having if it holds the schema the runtime about to load this
file holds."*

**A floating tag cannot hold that**, and this repository has already proved it: 0.5.1
added the `prompt` body to `jobs[]`, so a gate on `:0.5` passes a manifest a deployment
pinned to 0.5.0 refuses — the failure the comment exists to prevent, arriving one release
after the gate went green. The example contradicted its own comment independently of the
number being wrong.

**The number was wrong too**, by two minors. Both the 0.5.0 and 0.5.1 release preps walked
past it, which is the argument against fixing it by bumping to `:0.5`: a version in prose
that no test reads rots silently, and would rot again at 0.6.0.

A digest is what the rest of the repository already says a deployment runs —
[`release.yml`](.github/workflows/release.yml)'s own header ("THE DIGEST IS THE CONTRACT,
NOT THE TAG"), and the `@sha256:<digest>` placeholder in `docs/aws-eks-deployment.md`,
`docs/external-jobs.md`, `docs/guide/run-it-for-real.md` and `deploy/helm/README.md`. It
leaves no version number in the line or its comment, so there is nothing left to go stale
and nothing new to guard it with.

Says "the digest the deployment pins" rather than `imageRef`: that key exists only under
`deploy/helm/`, and this document is target-agnostic by its opening line, so naming it
would put Kubernetes' spelling into the general contract.

The one other float-tag literal in the docs, `run-it-for-real.md:74`, is left alone — it
demonstrates reading a digest off a release tag, and the next sentence there says a
release tag is immutable.

Docs-only; `pnpm typecheck`, `pnpm test` and `test/naming.test.ts` green.

SageOx-Session: https://sageox.ai/c/ses_01a0944f-1c6f-780a-8f04-ad1e6ab9f1e1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sageox/codesmith/agent-toolkit/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791787670&installation_model_id=433550&pr_number=86&repository=sageox%2Fagent-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fsageox%2Fagent-toolkit%2Fpull%2F86&signature=9cabf49387bb9aa95b567b21d02dad179c5afb0a054a7b491061d1a4ffc2a634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the deployment validation example to pin the runtime image by digest instead of using the floating `0.4` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->